### PR TITLE
Refactor URL scans into an automatic report pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,18 @@ GARDEN_DATABASE_URL=sqlite+pysqlite:///./data/garden.db
 
 # Safe-by-default guardrail: keep false for local/demo use only
 GARDEN_ALLOW_NON_LOCAL_TARGETS=false
+# RFC1918/ULA addresses other than loopback require a separate explicit opt-in
+GARDEN_ALLOW_PRIVATE_TARGETS=false
+
+# URL scan networking: environment proxies are ignored unless this is set.
+# Local names in NO_PROXY bypass the configured scan proxy.
+GARDEN_SCAN_PROXY_URL=
+GARDEN_SCAN_NO_PROXY=localhost,127.0.0.1,::1
+GARDEN_SCAN_REQUEST_TIMEOUT_SECONDS=5
+GARDEN_SCAN_OVERALL_TIMEOUT_SECONDS=90
+# Retries after the first request; only transient connect/read errors and 502/503/504 retry.
+GARDEN_SCAN_RETRY_ATTEMPTS=1
+GARDEN_SCAN_MAX_CONCURRENT_TASKS=2
 
 # Demo credential values for local-only walkthroughs and example login configs
 GARDEN_DEMO_ADMIN_PASSWORD=demo-admin-password

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Garden
 
-> **[garden-ctl.com](https://garden-ctl.com/)**  —  登录态安全验证工作流平台
+> **[garden-ctl.com](https://garden-ctl.com/)**  —  一次提交 URL，自动生成资产与证据报告
 
-Garden 是一个 **Python、FastAPI、Typer、SQLAlchemy、Jinja2、HTMX、Playwright ** 的安全工作流工具，面向**授权场景下的登录后应用面验证**。
+Garden 是一个 **Python、FastAPI、Typer、SQLAlchemy、Jinja2、HTMX、Playwright** 的安全资产工作流工具。普通用户只提交一个已授权的入口 URL，系统自动完成网络预检、发现、采集、标准化、被动分析和结构化报告生成。
 
 
 
@@ -34,6 +34,12 @@ Garden 是一个 **Python、FastAPI、Typer、SQLAlchemy、Jinja2、HTMX、Playw
 
 
 
+面向普通用户的核心链路：
+
+`URL -> validate/preflight -> discover -> collect -> normalize -> analyze -> report`
+
+原有登录后精细工作流继续保留，供需要凭据和人工复测的高级场景使用：
+
 `target -> credential profile -> login -> authenticated session -> inventory -> checks -> findings -> evidence -> triage -> retest -> export`
 
 具体链路收获：
@@ -61,37 +67,35 @@ Garden 的主命令是：
 gardenctl
 ```
 
-一键终端工作流（不需要配置文件）：
+自动终端工作流（只需一个 URL，不需要配置文件、凭据或后续命令）：
 
 ```bash
-gardenctl scan --url http://127.0.0.1:8888/ --username test@123.com
+gardenctl scan --url http://127.0.0.1:8888/
 ```
 
-如果没有传 `--password`，命令会在终端里隐藏输入密码。它会自动完成：
+它调用与 Web、HTTP API 完全相同的核心服务并自动完成：
 
-`login -> authenticated inventory -> checks -> findings -> markdown report`
+`网络预检 -> 同源发现与采集 -> 标准化资产/证据 -> 被动分析 -> Markdown 报告`
 
-常见登录页会自动识别用户名、密码和提交按钮；特殊 SPA 页面可以用 selector 和成功条件兜底。下面是 crAPI 本地靶场的完整实测命令：
+可选边界参数：
 
 ```bash
 gardenctl scan \
   --url http://127.0.0.1:8888/ \
-  --username 'test@123.com' \
-  --password 'Test12345678!' \
-  --username-selector '#basic_email' \
-  --password-selector '#basic_password' \
-  --submit-selector 'button:has-text("Login") >> nth=1' \
-  --success-text 'Dashboard' \
   --max-pages 10 \
   --max-depth 1 \
-  --max-requests 50
+  --request-timeout 5 \
+  --overall-timeout 90 \
+  --retries 1
 ```
 
 默认仍保留安全 guardrail：只允许本地/demo 目标。授权环境下扫描非本地目标时，需要显式设置：
 
 ```bash
-GARDEN_ALLOW_NON_LOCAL_TARGETS=true gardenctl scan --url https://example.test/login --username user
+GARDEN_ALLOW_NON_LOCAL_TARGETS=true gardenctl scan --url https://example.test/
 ```
+
+RFC1918/ULA 内网地址需要额外、明确设置 `GARDEN_ALLOW_PRIVATE_TARGETS=true`。链路本地地址、组播、未指定地址和云元数据常用的 link-local 地址始终拒绝。
 
 最常用的全局命令：**见[garden-ctl.com](https://garden-ctl.com/)**
 
@@ -103,6 +107,9 @@ GARDEN_ALLOW_NON_LOCAL_TARGETS=true gardenctl scan --url https://example.test/lo
 
 Garden 产出结构化工作流产物：
 
+- URL scan parent run、阶段、真实进度、重试与失败诊断
+- 统一的 URL scan 资产、脱敏证据、被动 findings 与覆盖缺口
+- 从结构化数据生成的完整 Markdown 资产报告
 - target 清单
 - credential profile 清单
 - authenticated session 记录
@@ -116,7 +123,7 @@ Garden 产出结构化工作流产物：
 - findings Markdown / JSON / CSV 导出
 - job Markdown report
 
-也就是说，Garden 的价值不只是“做了扫描”，而是把登录后验证工作真正串成了一条可 review、可复测、可导出的流程。
+也就是说，普通用户不需要理解或手动传递内部 ID；高级用户仍可继续使用登录后验证、review、复测和导出流程。
 
 ## DVWA 实战展示
 
@@ -177,8 +184,8 @@ Garden 的定位是补位，而不是全替代。
 
 Garden 刻意保持这些约束：
 
-- CLI-first
-- minimal server-rendered Web UI
+- application-service-first；CLI、Web、HTTP API 都是薄适配层
+- server-rendered Web URL 提交、真实进度、报告阅读与下载
 - 默认只允许本地 / demo 目标
 - 非本地目标必须显式放开
 - 不做 destructive testing

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -10,11 +10,13 @@ from app.api.routes.health import router as health_router
 from app.api.routes.inventory import router as inventory_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.pages import router as pages_router
+from app.api.routes.scans import router as scans_router
 from app.api.routes.sessions import router as sessions_router
 from app.api.routes.targets import router as targets_router
 
 api_router = APIRouter()
 api_router.include_router(pages_router)
+api_router.include_router(scans_router)
 api_router.include_router(targets_router)
 api_router.include_router(credentials_router)
 api_router.include_router(jobs_router)

--- a/app/api/routes/scans.py
+++ b/app/api/routes/scans.py
@@ -1,0 +1,81 @@
+"""Thin HTTP and server-rendered adapters for the core URL scan service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Form, Query, Request, status
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from app.schemas.scan import ScanOptions, ScanRunView, ScanStartRequest
+
+templates = Jinja2Templates(directory=str(Path(__file__).resolve().parents[2] / "templates"))
+router = APIRouter(tags=["scans"])
+
+
+@router.post("/api/scans", response_model=ScanRunView, status_code=status.HTTP_202_ACCEPTED)
+def start_scan_api(request: Request, payload: ScanStartRequest) -> ScanRunView:
+    return request.app.state.scan_service.start_scan(payload.url, payload.options)
+
+
+@router.get("/api/scans/{scan_run_id}", response_model=ScanRunView)
+def scan_status_api(request: Request, scan_run_id: int) -> ScanRunView:
+    return request.app.state.scan_service.get_scan(scan_run_id)
+
+
+@router.get("/api/scans/{scan_run_id}/report")
+def scan_report_api(
+    request: Request,
+    scan_run_id: int,
+    download: bool = Query(default=False),
+):
+    view = request.app.state.scan_service.get_scan(scan_run_id)
+    if download:
+        request.app.state.scan_service.read_report(scan_run_id)
+        return FileResponse(
+            view.report_path,
+            media_type="text/markdown; charset=utf-8",
+            filename=f"garden-scan-{scan_run_id}.md",
+        )
+    return PlainTextResponse(
+        request.app.state.scan_service.read_report(scan_run_id),
+        media_type="text/markdown; charset=utf-8",
+    )
+
+
+@router.get("/scans", response_class=HTMLResponse, include_in_schema=False)
+def scans_page(request: Request) -> HTMLResponse:
+    scans = request.app.state.scan_service.list_scans()
+    return templates.TemplateResponse(
+        request=request,
+        name="scans_list.html",
+        context={"scans": scans, "page_title": "URL Scans"},
+    )
+
+
+@router.post("/scans", include_in_schema=False)
+def start_scan_page(
+    request: Request,
+    url: str = Form(...),
+    max_pages: int = Form(default=10, ge=1, le=100),
+    max_depth: int = Form(default=2, ge=0, le=5),
+) -> RedirectResponse:
+    scan = request.app.state.scan_service.start_scan(
+        url,
+        ScanOptions(max_pages=max_pages, max_depth=max_depth),
+    )
+    return RedirectResponse(url=f"/scans/{scan.id}", status_code=303)
+
+
+@router.get("/scans/{scan_run_id}", response_class=HTMLResponse, include_in_schema=False)
+def scan_detail_page(request: Request, scan_run_id: int) -> HTMLResponse:
+    scan = request.app.state.scan_service.get_scan(scan_run_id)
+    report = None
+    if scan.report_path:
+        report = request.app.state.scan_service.read_report(scan_run_id)
+    return templates.TemplateResponse(
+        request=request,
+        name="scan_detail.html",
+        context={"scan": scan, "report": report, "page_title": f"Scan {scan.id}"},
+    )

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -24,8 +24,8 @@ from app.services.health import build_health_response
 app = typer.Typer(
     name="gardenctl",
     help=(
-        "CLI for Garden authenticated verification workflows: target, login, "
-        "session, inventory, checks, findings, evidence, retest, and report."
+        "CLI for Garden's one-URL automatic asset reports and advanced authenticated "
+        "verification workflows."
     ),
     no_args_is_help=True,
 )

--- a/app/cli/scan.py
+++ b/app/cli/scan.py
@@ -1,290 +1,60 @@
-"""One-command terminal workflow for authenticated findings and reports."""
+"""Thin one-URL CLI adapter over the core scan application service."""
 
 from __future__ import annotations
 
-import os
-import re
-from datetime import datetime, timezone
 from typing import Annotated
-from urllib.parse import urlparse, urlunparse
 
 import typer
 
-from app.cli.utils import (
-    console,
-    handle_cli_error,
-    print_check_run_summary,
-    print_inventory_summary,
-    progress_spinner,
-    render_key_value,
-    render_table,
-    styled_confidence,
-    styled_severity,
-    styled_status,
-)
+from app.cli.utils import console, handle_cli_error, render_key_value
 from app.core.errors import GardenError, InputValidationError
-from app.db.bootstrap import session_scope
-from app.models.enums import AuthType, TargetStatus, TargetType
-from app.schemas.credential import CredentialProfileCreate
-from app.schemas.inventory import InventoryBuildControls
-from app.schemas.target import TargetCreate, normalize_base_url
-from app.services.credentials import CredentialProfileService
-from app.services.findings import CheckRunService, FindingService
-from app.services.inventory import InventoryBuildService
-from app.services.login_configs import encode_inline_login_config
-from app.services.reporting import ReportService
-from app.services.targets import TargetService
-
-PASSWORD_ENV_NAME = "GARDEN_QUICKSCAN_PASSWORD"
-
-target_service = TargetService()
-credential_service = CredentialProfileService()
-inventory_service = InventoryBuildService()
-check_service = CheckRunService()
-finding_service = FindingService()
-report_service = ReportService()
+from app.schemas.scan import ScanOptions
+from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
 
 
 def scan(
-    url: Annotated[str | None, typer.Option("--url", help="Login page or app URL.")] = None,
-    username: Annotated[str | None, typer.Option("--username", "-u")] = None,
-    password: Annotated[
-        str | None,
-        typer.Option("--password", "-p", envvar=PASSWORD_ENV_NAME),
-    ] = None,
-    target_name: Annotated[str | None, typer.Option("--target-name")] = None,
-    profile_name: Annotated[str | None, typer.Option("--profile-name")] = None,
-    owner: Annotated[str, typer.Option("--owner")] = "quickscan",
-    role: Annotated[str, typer.Option("--role")] = "quickscan",
-    validate_path: Annotated[str, typer.Option("--validate-path")] = "/",
-    username_selector: Annotated[str | None, typer.Option("--username-selector")] = None,
-    password_selector: Annotated[str | None, typer.Option("--password-selector")] = None,
-    submit_selector: Annotated[str | None, typer.Option("--submit-selector")] = None,
-    success_selector: Annotated[str | None, typer.Option("--success-selector")] = None,
-    success_text: Annotated[str | None, typer.Option("--success-text")] = None,
-    success_url_contains: Annotated[str | None, typer.Option("--success-url-contains")] = None,
-    max_pages: Annotated[int, typer.Option("--max-pages")] = 25,
+    url: Annotated[str | None, typer.Option("--url", help="Authorized HTTP(S) entry URL.")] = None,
+    max_pages: Annotated[int, typer.Option("--max-pages")] = 10,
     max_depth: Annotated[int, typer.Option("--max-depth")] = 2,
-    max_requests: Annotated[int, typer.Option("--max-requests")] = 100,
-    delay_ms: Annotated[int, typer.Option("--delay-ms")] = 250,
-    report_format: Annotated[str, typer.Option("--report-format")] = "md",
+    request_timeout_seconds: Annotated[float | None, typer.Option("--request-timeout")] = None,
+    overall_timeout_seconds: Annotated[float | None, typer.Option("--overall-timeout")] = None,
+    retry_attempts: Annotated[int | None, typer.Option("--retries")] = None,
 ) -> None:
-    """Run login, inventory, checks, findings, and report from terminal inputs only."""
+    """Submit one URL and automatically produce the final structured report."""
     try:
-        url = _prompt_if_missing(url, "URL")
-        username = _prompt_if_missing(username, "Username")
-        if password is None:
-            password = typer.prompt("Password", hide_input=True)
-        if not password:
-            raise InputValidationError("Password cannot be blank.")
-        if report_format != "md":
-            raise InputValidationError("Quick scan reports currently support only markdown.")
-
-        target_base_url, login_path = _split_target_and_login_url(url)
-        target_name = target_name or _default_target_name(target_base_url)
-        profile_name = profile_name or _default_profile_name(username)
-        login_config_ref = _build_inline_playwright_config(
-            login_path=login_path,
-            validate_path=validate_path,
-            username_selector=username_selector,
-            password_selector=password_selector,
-            submit_selector=submit_selector,
-            success_selector=success_selector,
-            success_text=success_text,
-            success_url_contains=success_url_contains,
+        if url is None:
+            url = typer.prompt("Authorized entry URL")
+        if not url.strip():
+            raise InputValidationError("URL cannot be blank.")
+        service = ScanApplicationService(dispatcher=InlineScanDispatcher())
+        result = service.start_scan(
+            url,
+            ScanOptions(
+                max_pages=max_pages,
+                max_depth=max_depth,
+                request_timeout_seconds=request_timeout_seconds,
+                overall_timeout_seconds=overall_timeout_seconds,
+                retry_attempts=retry_attempts,
+            ),
         )
-        os.environ[PASSWORD_ENV_NAME] = password
-
-        controls = InventoryBuildControls(
-            max_pages=max_pages,
-            max_depth=max_depth,
-            max_requests=max_requests,
-            delay_ms=delay_ms,
-            include=[],
-            exclude=[],
-        )
-
-        with session_scope() as session:
-            target = _get_or_create_target(
-                session,
-                name=target_name,
-                base_url=target_base_url,
-                owner=owner,
-            )
-            credential = credential_service.create(
-                session,
-                CredentialProfileCreate(
-                    target_id=target.id,
-                    name=_unique_profile_name(session, target.id, profile_name),
-                    role=role,
-                    auth_type=AuthType.PASSWORD,
-                    username=username,
-                    secret_ref=f"env://{PASSWORD_ENV_NAME}",
-                    login_config_path=login_config_ref,
-                ),
-            )
-            render_key_value(
-                [
-                    ("Target", f"{target.name} ({target.base_url})"),
-                    ("Profile", credential.name),
-                    ("Login Path", login_path),
-                    ("Validate Path", validate_path),
-                ],
-                title="Quick Scan Inputs",
-            )
-
-            with progress_spinner("Running login and building authenticated inventory ..."):
-                inventory_summary = inventory_service.build_from_target_profile(
-                    session,
-                    target.name,
-                    credential.name,
-                    controls,
-                )
-            print_inventory_summary(inventory_summary)
-
-            with progress_spinner("Running checks and capturing redacted evidence ..."):
-                check_summary = check_service.run_inventory_checks(
-                    session,
-                    inventory_summary.inventory_run_id,
-                )
-            print_check_run_summary(check_summary)
-
-            with progress_spinner("Generating markdown report ..."):
-                report = report_service.generate(
-                    session,
-                    job_id=check_summary.scan_job_id,
-                    export_format=report_format,
-                )
-            findings = finding_service.list(session, job_id=check_summary.scan_job_id)
-
-        _print_findings(findings)
         render_key_value(
             [
-                ("Inventory Run", str(inventory_summary.inventory_run_id)),
-                ("Inventory Job", str(inventory_summary.scan_job_id)),
-                ("Checks Job", str(check_summary.scan_job_id)),
-                ("Report", report.output_path),
+                ("Scan", str(result.id)),
+                ("Status", result.status),
+                ("Progress", f"{result.progress}%"),
+                ("Stage", result.current_stage),
+                ("Assets", str(result.asset_count)),
+                ("Evidence", str(result.evidence_count)),
+                ("Findings", str(result.finding_count)),
+                ("Retries", str(result.retry_count)),
+                ("Report", result.report_path or "not generated"),
             ],
-            title="Quick Scan Result",
+            title="Automatic URL Scan Result",
         )
+        if result.failures:
+            for failure in result.failures:
+                console.print(f"[yellow]{failure.stage}/{failure.code}:[/yellow] {failure.message}")
+        if result.status == "failed":
+            raise typer.Exit(code=1)
     except GardenError as error:
         handle_cli_error(error)
-
-
-def _prompt_if_missing(value: str | None, label: str) -> str:
-    if value is None:
-        value = typer.prompt(label)
-    cleaned = value.strip()
-    if not cleaned:
-        raise InputValidationError(f"{label} cannot be blank.")
-    return cleaned
-
-
-def _split_target_and_login_url(raw_url: str) -> tuple[str, str]:
-    parsed = urlparse(raw_url.strip())
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise InputValidationError("URL must be a valid http or https URL.")
-    target_base_url = normalize_base_url(urlunparse((parsed.scheme, parsed.netloc, "", "", "", "")))
-    path = parsed.path or "/"
-    if parsed.query:
-        path = f"{path}?{parsed.query}"
-    return target_base_url, path
-
-
-def _default_target_name(base_url: str) -> str:
-    parsed = urlparse(base_url)
-    host = re.sub(r"[^a-zA-Z0-9]+", "-", parsed.netloc).strip("-").lower()
-    return f"quick-{host or 'target'}"
-
-
-def _default_profile_name(username: str) -> str:
-    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", username).strip("-").lower()
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    return f"quick-{cleaned or 'user'}-{stamp}"
-
-
-def _build_inline_playwright_config(
-    *,
-    login_path: str,
-    validate_path: str,
-    username_selector: str | None,
-    password_selector: str | None,
-    submit_selector: str | None,
-    success_selector: str | None,
-    success_text: str | None,
-    success_url_contains: str | None,
-) -> str:
-    config = {
-        "adapter": "playwright",
-        "request_timeout_seconds": 15,
-        "retry_attempts": 1,
-        "login_url": login_path,
-        "validate_url": validate_path,
-        "username_selector": username_selector or "auto",
-        "password_selector": password_selector or "auto",
-        "submit_selector": submit_selector or "auto",
-        "success_selector": success_selector,
-        "success_text": success_text,
-        "success_url_contains": success_url_contains,
-        "refresh_via_relogin": True,
-        "auto_detect_selectors": not (
-            username_selector and password_selector and submit_selector
-        ),
-    }
-    return encode_inline_login_config({key: value for key, value in config.items() if value})
-
-
-def _get_or_create_target(session, *, name: str, base_url: str, owner: str):
-    for target in target_service.list(session):
-        if target.base_url == base_url or target.name == name:
-            return target
-    return target_service.create(
-        session,
-        TargetCreate(
-            name=name,
-            base_url=base_url,
-            type=TargetType.WEB,
-            owner=owner,
-            tags=["quickscan"],
-            status=TargetStatus.ACTIVE,
-        ),
-    )
-
-
-def _unique_profile_name(session, target_id: int, preferred: str) -> str:
-    existing = {
-        credential.name
-        for credential in credential_service.list(session)
-        if credential.target_id == target_id
-    }
-    if preferred not in existing:
-        return preferred
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    candidate = f"{preferred}-{stamp}"
-    index = 2
-    while candidate in existing:
-        candidate = f"{preferred}-{stamp}-{index}"
-        index += 1
-    return candidate
-
-
-def _print_findings(findings) -> None:
-    if not findings:
-        console.print("[dim]No findings were produced by the enabled checks.[/dim]")
-        return
-    rows = [
-        [
-            str(finding.id),
-            styled_severity(finding.severity),
-            styled_confidence(finding.confidence),
-            styled_status(finding.status),
-            finding.category[:30],
-            finding.title,
-        ]
-        for finding in findings
-    ]
-    render_table(
-        ["ID", "Severity", "Confidence", "Status", "Category", "Title"],
-        rows,
-        title="Findings",
-    )

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -29,6 +29,39 @@ class Settings(BaseSettings):
         default=False,
         alias="GARDEN_ALLOW_NON_LOCAL_TARGETS",
     )
+    allow_private_targets: bool = Field(
+        default=False,
+        alias="GARDEN_ALLOW_PRIVATE_TARGETS",
+    )
+    scan_proxy_url: str | None = Field(default=None, alias="GARDEN_SCAN_PROXY_URL")
+    scan_no_proxy: str = Field(
+        default="localhost,127.0.0.1,::1",
+        alias="GARDEN_SCAN_NO_PROXY",
+    )
+    scan_request_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        le=60,
+        alias="GARDEN_SCAN_REQUEST_TIMEOUT_SECONDS",
+    )
+    scan_overall_timeout_seconds: float = Field(
+        default=90.0,
+        gt=0,
+        le=1800,
+        alias="GARDEN_SCAN_OVERALL_TIMEOUT_SECONDS",
+    )
+    scan_retry_attempts: int = Field(
+        default=1,
+        ge=0,
+        le=2,
+        alias="GARDEN_SCAN_RETRY_ATTEMPTS",
+    )
+    scan_max_concurrent_tasks: int = Field(
+        default=2,
+        ge=1,
+        le=8,
+        alias="GARDEN_SCAN_MAX_CONCURRENT_TASKS",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/integrations/auth/playwright_adapter.py
+++ b/app/integrations/auth/playwright_adapter.py
@@ -277,9 +277,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         )
         if not isinstance(result, dict) or not result.get("ok"):
             reason = (
-                result.get("reason")
-                if isinstance(result, dict)
-                else "Unknown detection error."
+                result.get("reason") if isinstance(result, dict) else "Unknown detection error."
             )
             raise TimeoutError(str(reason))
         page.fill("[data-garden-autologin='username']", username)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.core.errors import register_exception_handlers
 from app.core.logging import configure_logging, get_logger
 from app.core.settings import get_settings
 from app.db.bootstrap import init_database
+from app.services.scan_application import ScanApplicationService
 
 
 @asynccontextmanager
@@ -20,8 +21,12 @@ async def lifespan(app: FastAPI):
     logger = get_logger(__name__)
     logger.info("Starting Garden application", extra={"environment": settings.environment})
     init_database(settings.database_url)
-    yield
-    logger.info("Shutting down Garden application")
+    app.state.scan_service = ScanApplicationService(settings=settings)
+    try:
+        yield
+    finally:
+        app.state.scan_service.shutdown()
+        logger.info("Shutting down Garden application")
 
 
 def create_app() -> FastAPI:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,6 +12,14 @@ from app.models.inventory_page import InventoryPage
 from app.models.inventory_parameter import InventoryParameter
 from app.models.inventory_run import InventoryRun
 from app.models.scan_job import ScanJob
+from app.models.scan_run import (
+    ScanAsset,
+    ScanEvidence,
+    ScanFailure,
+    ScanFinding,
+    ScanRun,
+    ScanRunStage,
+)
 from app.models.target import Target
 
 __all__ = [
@@ -27,5 +35,11 @@ __all__ = [
     "InventoryParameter",
     "InventoryRun",
     "ScanJob",
+    "ScanRun",
+    "ScanRunStage",
+    "ScanAsset",
+    "ScanEvidence",
+    "ScanFinding",
+    "ScanFailure",
     "Target",
 ]

--- a/app/models/scan_run.py
+++ b/app/models/scan_run.py
@@ -1,0 +1,132 @@
+"""Persistent parent run and normalized URL-scan records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin
+
+
+class ScanRun(TimestampMixin, Base):
+    __tablename__ = "scan_runs"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    input_url: Mapped[str] = mapped_column(String(1000))
+    normalized_url: Mapped[str] = mapped_column(String(1000), index=True)
+    active_key: Mapped[str | None] = mapped_column(String(64), unique=True, nullable=True)
+    status: Mapped[str] = mapped_column(String(40), index=True, default="queued")
+    current_stage: Mapped[str] = mapped_column(String(40), index=True, default="queued")
+    progress: Mapped[int] = mapped_column(Integer, default=0)
+    options: Mapped[dict[str, object]] = mapped_column(MutableDict.as_mutable(JSON), default=dict)
+    retry_count: Mapped[int] = mapped_column(Integer, default=0)
+    report_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    report_generated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    stages = relationship("ScanRunStage", back_populates="scan_run", cascade="all, delete-orphan")
+    assets = relationship("ScanAsset", back_populates="scan_run", cascade="all, delete-orphan")
+    evidence = relationship("ScanEvidence", back_populates="scan_run", cascade="all, delete-orphan")
+    findings = relationship("ScanFinding", back_populates="scan_run", cascade="all, delete-orphan")
+    failures = relationship("ScanFailure", back_populates="scan_run", cascade="all, delete-orphan")
+
+
+class ScanRunStage(Base):
+    __tablename__ = "scan_run_stages"
+    __table_args__ = (UniqueConstraint("scan_run_id", "name"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    name: Mapped[str] = mapped_column(String(40), index=True)
+    position: Mapped[int] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    attempt: Mapped[int] = mapped_column(Integer, default=0)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    scan_run = relationship("ScanRun", back_populates="stages")
+
+
+class ScanAsset(Base):
+    __tablename__ = "scan_assets"
+    __table_args__ = (UniqueConstraint("scan_run_id", "asset_type", "url"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    asset_type: Mapped[str] = mapped_column(String(40), index=True)
+    url: Mapped[str] = mapped_column(String(1000))
+    method: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    attributes: Mapped[dict[str, object]] = mapped_column(
+        MutableDict.as_mutable(JSON), default=dict
+    )
+    discovered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    scan_run = relationship("ScanRun", back_populates="assets")
+
+
+class ScanEvidence(Base):
+    __tablename__ = "scan_evidence"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    asset_id: Mapped[int | None] = mapped_column(
+        ForeignKey("scan_assets.id"), nullable=True, index=True
+    )
+    evidence_type: Mapped[str] = mapped_column(String(64), index=True)
+    title: Mapped[str] = mapped_column(String(500))
+    source_url: Mapped[str] = mapped_column(String(1000))
+    summary: Mapped[str] = mapped_column(Text)
+    data: Mapped[dict[str, object]] = mapped_column(MutableDict.as_mutable(JSON), default=dict)
+    collected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    scan_run = relationship("ScanRun", back_populates="evidence")
+
+
+class ScanFinding(Base):
+    __tablename__ = "scan_findings"
+    __table_args__ = (UniqueConstraint("scan_run_id", "dedup_key"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    dedup_key: Mapped[str] = mapped_column(String(255))
+    title: Mapped[str] = mapped_column(String(500))
+    category: Mapped[str] = mapped_column(String(120), index=True)
+    severity: Mapped[str] = mapped_column(String(32), index=True)
+    confidence: Mapped[str] = mapped_column(String(32), index=True)
+    summary: Mapped[str] = mapped_column(Text)
+    remediation: Mapped[str] = mapped_column(Text)
+    asset_ids: Mapped[list[int]] = mapped_column(JSON, default=list)
+    evidence_ids: Mapped[list[int]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    scan_run = relationship("ScanRun", back_populates="findings")
+
+
+class ScanFailure(Base):
+    __tablename__ = "scan_failures"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    stage: Mapped[str] = mapped_column(String(40), index=True)
+    code: Mapped[str] = mapped_column(String(120), index=True)
+    message: Mapped[str] = mapped_column(Text)
+    url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    retryable: Mapped[bool] = mapped_column(default=False)
+    attempt: Mapped[int] = mapped_column(Integer, default=1)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    scan_run = relationship("ScanRun", back_populates="failures")

--- a/app/redaction/service.py
+++ b/app/redaction/service.py
@@ -17,6 +17,7 @@ class RedactionService:
         r"(?i)([\"']?)(session(?:id)?|password|secret|token|api[_-]?key|key)([\"']?\s*[:=]\s*)(['\"]?)([^\"'\s,;}{]+)"
     )
     _token_like_pattern = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
+    _control_character_pattern = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
     _sensitive_key_names = {
         "cookie",
         "set-cookie",
@@ -37,7 +38,7 @@ class RedactionService:
     def redact_text(self, value: str | None, *, limit: int = 400) -> str:
         if not value:
             return ""
-        redacted = value
+        redacted = self._control_character_pattern.sub(" ", value)
         redacted = self._email_pattern.sub(self._mask_email, redacted)
         redacted = self._bearer_pattern.sub(r"\1***", redacted)
         redacted = self._cookie_pattern.sub(lambda match: f"{match.group(1)}: ***", redacted)

--- a/app/schemas/scan.py
+++ b/app/schemas/scan.py
@@ -93,6 +93,8 @@ class FetchResult(BaseModel):
     headers: dict[str, str]
     content_type: str | None = None
     body_text: str = ""
+    body_size_bytes: int = 0
+    body_is_text: bool = True
     title: str | None = None
     discovered_urls: list[str] = Field(default_factory=list)
     redirects: list[str] = Field(default_factory=list)

--- a/app/schemas/scan.py
+++ b/app/schemas/scan.py
@@ -1,0 +1,112 @@
+"""Interface-neutral contracts for the URL scan application service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class ScanRunStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    COMPLETED_WITH_WARNINGS = "completed_with_warnings"
+    FAILED = "failed"
+
+
+class ScanStageName(str, Enum):
+    VALIDATE = "validate"
+    DISCOVER = "discover"
+    COLLECT = "collect"
+    NORMALIZE = "normalize"
+    ANALYZE = "analyze"
+    REPORT = "report"
+
+
+class ScanOptions(BaseModel):
+    """Bounded user controls; infrastructure defaults are injected by the service."""
+
+    max_pages: int = Field(default=10, ge=1, le=100)
+    max_depth: int = Field(default=2, ge=0, le=5)
+    request_timeout_seconds: float | None = Field(default=None, gt=0, le=60)
+    overall_timeout_seconds: float | None = Field(default=None, gt=0, le=1800)
+    retry_attempts: int | None = Field(default=None, ge=0, le=2)
+    max_redirects: int = Field(default=5, ge=0, le=10)
+    user_agent: str = Field(default="Garden-Authorized-Asset-Scanner/0.2", max_length=200)
+
+
+class ScanStartRequest(BaseModel):
+    url: str = Field(min_length=1, max_length=1000)
+    options: ScanOptions = Field(default_factory=ScanOptions)
+
+
+class ScanStageView(BaseModel):
+    name: str
+    position: int
+    status: str
+    attempt: int
+    summary: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class ScanFailureView(BaseModel):
+    stage: str
+    code: str
+    message: str
+    url: str | None = None
+    retryable: bool
+    attempt: int
+    occurred_at: datetime
+
+
+class ScanRunView(BaseModel):
+    id: int
+    input_url: str
+    normalized_url: str
+    status: str
+    current_stage: str
+    progress: int
+    retry_count: int
+    report_path: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    report_generated_at: datetime | None = None
+    created_at: datetime
+    stages: list[ScanStageView] = Field(default_factory=list)
+    failures: list[ScanFailureView] = Field(default_factory=list)
+    asset_count: int = 0
+    evidence_count: int = 0
+    finding_count: int = 0
+
+
+class FetchResult(BaseModel):
+    requested_url: str
+    final_url: str
+    status_code: int
+    headers: dict[str, str]
+    content_type: str | None = None
+    body_text: str = ""
+    title: str | None = None
+    discovered_urls: list[str] = Field(default_factory=list)
+    redirects: list[str] = Field(default_factory=list)
+    attempts: int = 1
+    elapsed_ms: int = 0
+
+
+class AnalysisCandidate(BaseModel):
+    dedup_key: str
+    title: str
+    category: str
+    severity: str
+    confidence: str
+    summary: str
+    remediation: str
+    asset_ids: list[int] = Field(default_factory=list)
+    evidence_ids: list[int] = Field(default_factory=list)

--- a/app/services/scan_analysis.py
+++ b/app/services/scan_analysis.py
@@ -1,0 +1,97 @@
+"""Passive, explainable analysis over normalized scan records."""
+
+from __future__ import annotations
+
+import hashlib
+
+from app.models.scan_run import ScanAsset, ScanEvidence
+from app.schemas.scan import AnalysisCandidate
+
+
+class PassiveScanAnalyzer:
+    SECURITY_HEADERS = {
+        "content-security-policy": "Content-Security-Policy",
+        "x-content-type-options": "X-Content-Type-Options",
+    }
+
+    def analyze(
+        self, assets: list[ScanAsset], evidence: list[ScanEvidence]
+    ) -> list[AnalysisCandidate]:
+        evidence_by_asset = {item.asset_id: item for item in evidence if item.asset_id is not None}
+        candidates: list[AnalysisCandidate] = []
+        for asset in assets:
+            item = evidence_by_asset.get(asset.id)
+            headers = item.data.get("headers", {}) if item else {}
+            evidence_ids = [item.id] if item else []
+            content_type = str(asset.attributes.get("content_type") or "").lower()
+            if asset.status_code is not None and asset.status_code >= 400:
+                candidates.append(
+                    self._candidate(
+                        asset,
+                        evidence_ids,
+                        "http-error",
+                        f"页面返回 HTTP {asset.status_code}",
+                        "availability",
+                        "low" if asset.status_code < 500 else "medium",
+                        "high",
+                        "扫描范围内的页面返回错误状态，相关资产可能不可用或需要授权。",
+                        "确认该状态是否符合预期，并记录认证或访问控制要求。",
+                    )
+                )
+            if "html" in content_type:
+                for key, display in self.SECURITY_HEADERS.items():
+                    if key not in headers:
+                        candidates.append(
+                            self._candidate(
+                                asset,
+                                evidence_ids,
+                                f"missing-{key}",
+                                f"缺少 {display} 响应头",
+                                "security-headers",
+                                "low",
+                                "high",
+                                f"HTML 响应未包含 {display}，这是被动观察结果。",
+                                f"评估并在应用或边缘层配置合适的 {display} 策略。",
+                            )
+                        )
+            preview = item.data.get("preview", "") if item else ""
+            if asset.url.startswith("http://") and 'type="password"' in str(preview).lower():
+                candidates.append(
+                    self._candidate(
+                        asset,
+                        evidence_ids,
+                        "password-over-http",
+                        "HTTP 页面包含密码输入框",
+                        "transport-security",
+                        "high",
+                        "high",
+                        "未加密 HTTP 页面包含密码输入控件，凭据可能在传输中暴露。",
+                        "使用 HTTPS，并将 HTTP 请求重定向至经过验证的 HTTPS 入口。",
+                    )
+                )
+        return candidates
+
+    def _candidate(
+        self,
+        asset: ScanAsset,
+        evidence_ids: list[int],
+        rule: str,
+        title: str,
+        category: str,
+        severity: str,
+        confidence: str,
+        summary: str,
+        remediation: str,
+    ) -> AnalysisCandidate:
+        digest = hashlib.sha256(f"{rule}|{asset.url}".encode()).hexdigest()[:32]
+        return AnalysisCandidate(
+            dedup_key=digest,
+            title=title,
+            category=category,
+            severity=severity,
+            confidence=confidence,
+            summary=summary,
+            remediation=remediation,
+            asset_ids=[asset.id],
+            evidence_ids=evidence_ids,
+        )

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -1,0 +1,254 @@
+"""Interface-neutral application service for one URL to one report."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Protocol
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from app.core.errors import ResourceNotFoundError
+from app.core.settings import Settings, get_settings
+from app.db.bootstrap import session_scope
+from app.models.scan_run import ScanRun, ScanRunStage
+from app.schemas.scan import (
+    ScanFailureView,
+    ScanOptions,
+    ScanRunStatus,
+    ScanRunView,
+    ScanStageView,
+)
+from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_pipeline import STAGES, ScanPipeline
+
+
+class ScanDispatcher(Protocol):
+    def submit(self, scan_run_id: int, callback) -> None: ...
+
+
+class InlineScanDispatcher:
+    def submit(self, scan_run_id: int, callback) -> None:
+        callback(scan_run_id)
+
+    def shutdown(self) -> None:
+        return None
+
+
+class ThreadedScanDispatcher:
+    def __init__(self, max_workers: int) -> None:
+        self.executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="garden-scan"
+        )
+
+    def submit(self, scan_run_id: int, callback) -> None:
+        self.executor.submit(callback, scan_run_id)
+
+    def shutdown(self) -> None:
+        self.executor.shutdown(wait=True, cancel_futures=False)
+
+
+class ScanApplicationService:
+    """The sole orchestration entry used by CLI, Web, and HTTP adapters."""
+
+    _start_lock = threading.Lock()
+
+    def __init__(
+        self,
+        *,
+        settings: Settings | None = None,
+        pipeline: ScanPipeline | None = None,
+        dispatcher: ScanDispatcher | None = None,
+    ) -> None:
+        self.settings = settings or get_settings()
+        if pipeline is None:
+            policy = TargetNetworkPolicy(self.settings)
+            pipeline = ScanPipeline(policy=policy, gateway=HttpScanGateway(policy))
+        self.pipeline = pipeline
+        self.dispatcher = dispatcher or ThreadedScanDispatcher(
+            self.settings.scan_max_concurrent_tasks
+        )
+
+    def start_scan(self, url: str, options: ScanOptions | None = None) -> ScanRunView:
+        resolved = self._resolve_options(options or ScanOptions())
+        normalized = self.pipeline.policy.normalize_url(url)
+        active_key = self._active_key(normalized, resolved)
+        with self._start_lock, session_scope() as session:
+            existing = session.scalar(select(ScanRun).where(ScanRun.active_key == active_key))
+            if existing is not None:
+                return self._view(existing)
+            run = ScanRun(
+                input_url=url.strip(),
+                normalized_url=normalized,
+                active_key=active_key,
+                status=ScanRunStatus.QUEUED.value,
+                current_stage="queued",
+                progress=0,
+                options=resolved.model_dump(),
+            )
+            session.add(run)
+            try:
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                existing = session.scalar(select(ScanRun).where(ScanRun.active_key == active_key))
+                if existing is not None:
+                    return self._view(existing)
+                raise
+            session.add_all(
+                [
+                    ScanRunStage(scan_run_id=run.id, name=name, position=index)
+                    for index, name in enumerate(STAGES, start=1)
+                ]
+            )
+            session.commit()
+            run_id = run.id
+        self.dispatcher.submit(run_id, self.execute_scan)
+        return self.get_scan(run_id)
+
+    def execute_scan(self, scan_run_id: int) -> None:
+        with session_scope() as session:
+            self.pipeline.execute(session, scan_run_id)
+
+    def get_scan(self, scan_run_id: int) -> ScanRunView:
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            return self._view(run)
+
+    def list_scans(self, limit: int = 25) -> list[ScanRunView]:
+        with session_scope() as session:
+            runs = list(
+                session.scalars(
+                    select(ScanRun)
+                    .options(
+                        selectinload(ScanRun.stages),
+                        selectinload(ScanRun.failures),
+                        selectinload(ScanRun.assets),
+                        selectinload(ScanRun.evidence),
+                        selectinload(ScanRun.findings),
+                    )
+                    .order_by(ScanRun.id.desc())
+                    .limit(limit)
+                )
+            )
+            return [self._view(run) for run in runs]
+
+    def wait_for_completion(
+        self, scan_run_id: int, *, timeout_seconds: float | None = None
+    ) -> ScanRunView:
+        deadline = time.monotonic() + (
+            timeout_seconds or self.settings.scan_overall_timeout_seconds + 10
+        )
+        while time.monotonic() < deadline:
+            run = self.get_scan(scan_run_id)
+            if run.status in {
+                ScanRunStatus.COMPLETED.value,
+                ScanRunStatus.COMPLETED_WITH_WARNINGS.value,
+                ScanRunStatus.FAILED.value,
+            }:
+                return run
+            time.sleep(0.05)
+        return self.get_scan(scan_run_id)
+
+    def read_report(self, scan_run_id: int) -> str:
+        view = self.get_scan(scan_run_id)
+        if not view.report_path:
+            raise ResourceNotFoundError(f"Scan run {scan_run_id} does not have a report yet.")
+        with open(view.report_path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def shutdown(self) -> None:
+        shutdown = getattr(self.dispatcher, "shutdown", None)
+        if shutdown is not None:
+            shutdown()
+
+    def _get(self, session, scan_run_id: int) -> ScanRun:
+        run = session.scalar(
+            select(ScanRun)
+            .where(ScanRun.id == scan_run_id)
+            .options(
+                selectinload(ScanRun.stages),
+                selectinload(ScanRun.failures),
+                selectinload(ScanRun.assets),
+                selectinload(ScanRun.evidence),
+                selectinload(ScanRun.findings),
+            )
+        )
+        if run is None:
+            raise ResourceNotFoundError(f"Scan run {scan_run_id} was not found.")
+        return run
+
+    def _view(self, run: ScanRun) -> ScanRunView:
+        return ScanRunView(
+            id=run.id,
+            input_url=run.input_url,
+            normalized_url=run.normalized_url,
+            status=run.status,
+            current_stage=run.current_stage,
+            progress=run.progress,
+            retry_count=run.retry_count,
+            report_path=run.report_path,
+            error_code=run.error_code,
+            error_message=run.error_message,
+            started_at=run.started_at,
+            finished_at=run.finished_at,
+            report_generated_at=run.report_generated_at,
+            created_at=run.created_at,
+            stages=[
+                ScanStageView(
+                    name=stage.name,
+                    position=stage.position,
+                    status=stage.status,
+                    attempt=stage.attempt,
+                    summary=stage.summary,
+                    error_code=stage.error_code,
+                    error_message=stage.error_message,
+                    started_at=stage.started_at,
+                    finished_at=stage.finished_at,
+                )
+                for stage in sorted(run.stages, key=lambda item: item.position)
+            ],
+            failures=[
+                ScanFailureView(
+                    stage=item.stage,
+                    code=item.code,
+                    message=item.message,
+                    url=item.url,
+                    retryable=item.retryable,
+                    attempt=item.attempt,
+                    occurred_at=item.occurred_at,
+                )
+                for item in sorted(run.failures, key=lambda item: item.id)
+            ],
+            asset_count=len(run.assets),
+            evidence_count=len(run.evidence),
+            finding_count=len(run.findings),
+        )
+
+    def _resolve_options(self, options: ScanOptions) -> ScanOptions:
+        return options.model_copy(
+            update={
+                "request_timeout_seconds": options.request_timeout_seconds
+                or self.settings.scan_request_timeout_seconds,
+                "overall_timeout_seconds": options.overall_timeout_seconds
+                or self.settings.scan_overall_timeout_seconds,
+                "retry_attempts": (
+                    options.retry_attempts
+                    if options.retry_attempts is not None
+                    else self.settings.scan_retry_attempts
+                ),
+            }
+        )
+
+    def _active_key(self, normalized_url: str, options: ScanOptions) -> str:
+        payload = json.dumps(
+            {"url": normalized_url, "options": options.model_dump()},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()

--- a/app/services/scan_network.py
+++ b/app/services/scan_network.py
@@ -244,7 +244,8 @@ class HttpScanGateway:
                 redirects.append(current)
                 continue
             content_type = response.headers.get("content-type")
-            text = self._decode(body, response.encoding)
+            body_is_text = self._is_text_body(content_type, body)
+            text = self._decode(body, response.encoding) if body_is_text else ""
             title, links = self._parse_html(current, text, content_type)
             return FetchResult(
                 requested_url=url,
@@ -253,6 +254,8 @@ class HttpScanGateway:
                 headers={key.lower(): value for key, value in response.headers.items()},
                 content_type=content_type,
                 body_text=text,
+                body_size_bytes=len(body),
+                body_is_text=body_is_text,
                 title=title,
                 discovered_urls=links,
                 redirects=redirects,
@@ -312,6 +315,15 @@ class HttpScanGateway:
 
     def _decode(self, body: bytes, encoding: str | None) -> str:
         return body.decode(encoding or "utf-8", errors="replace")
+
+    def _is_text_body(self, content_type: str | None, body: bytes) -> bool:
+        media_type = (content_type or "").split(";", 1)[0].strip().lower()
+        if media_type:
+            return media_type.startswith("text/") or any(
+                marker in media_type
+                for marker in ("json", "xml", "javascript", "x-www-form-urlencoded")
+            )
+        return b"\x00" not in body
 
     def _parse_html(
         self, base_url: str, text: str, content_type: str | None

--- a/app/services/scan_network.py
+++ b/app/services/scan_network.py
@@ -1,0 +1,340 @@
+"""Network admission, preflight, redirect control, and bounded HTTP collection."""
+
+from __future__ import annotations
+
+import socket
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import httpx
+
+from app.core.errors import InputValidationError, TargetPolicyError
+from app.core.settings import Settings
+from app.schemas.scan import FetchResult, ScanOptions
+
+MAX_RESPONSE_BYTES = 256 * 1024
+TRANSIENT_STATUS_CODES = {502, 503, 504}
+TRANSIENT_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+)
+
+
+@dataclass(frozen=True)
+class NetworkPreflight:
+    normalized_url: str
+    resolved_addresses: tuple[str, ...]
+    proxy_enabled: bool
+    policy: str
+
+
+class FetchError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        url: str,
+        retryable: bool = False,
+        attempts: int = 1,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.url = url
+        self.retryable = retryable
+        self.attempts = attempts
+
+
+class TargetNetworkPolicy:
+    """Resolve and classify every destination before a connection is attempted."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        resolver: Callable[..., list[tuple]] = socket.getaddrinfo,
+    ) -> None:
+        self.settings = settings
+        self.resolver = resolver
+
+    def normalize_url(self, raw_url: str) -> str:
+        value = raw_url.strip()
+        if not value:
+            raise InputValidationError("URL cannot be blank.")
+        try:
+            parsed = urlparse(value)
+            port = parsed.port
+        except ValueError as error:
+            raise InputValidationError("URL contains an invalid port.") from error
+        if parsed.scheme.lower() not in {"http", "https"}:
+            raise InputValidationError("URL scheme must be http or https.")
+        if not parsed.hostname:
+            raise InputValidationError("URL must include a hostname.")
+        if parsed.username is not None or parsed.password is not None:
+            raise InputValidationError("Credentials must not be embedded in the URL.")
+        host = parsed.hostname.lower().rstrip(".")
+        try:
+            host = host.encode("idna").decode("ascii")
+        except UnicodeError as error:
+            raise InputValidationError("URL hostname is invalid.") from error
+        if port is not None and not 1 <= port <= 65535:
+            raise InputValidationError("URL port must be between 1 and 65535.")
+        host_display = f"[{host}]" if ":" in host else host
+        netloc = f"{host_display}:{port}" if port is not None else host_display
+        path = parsed.path or "/"
+        return urlunparse((parsed.scheme.lower(), netloc, path, "", parsed.query, ""))
+
+    def preflight(self, raw_url: str) -> NetworkPreflight:
+        normalized = self.normalize_url(raw_url)
+        addresses = self.ensure_destination_allowed(normalized)
+        proxy_enabled = bool(self._proxy_for_url(normalized))
+        return NetworkPreflight(
+            normalized_url=normalized,
+            resolved_addresses=tuple(str(address) for address in addresses),
+            proxy_enabled=proxy_enabled,
+            policy=self.policy_name,
+        )
+
+    def ensure_destination_allowed(self, url: str) -> list[IPv4Address | IPv6Address]:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if not host:
+            raise TargetPolicyError("Destination does not include a hostname.")
+        addresses = self._resolve(host, parsed.port or (443 if parsed.scheme == "https" else 80))
+        denied = [address for address in addresses if not self._address_allowed(address)]
+        if denied:
+            rendered = ", ".join(str(address) for address in denied)
+            raise TargetPolicyError(
+                f"Destination resolves to addresses blocked by {self.policy_name}: {rendered}."
+            )
+        return addresses
+
+    @property
+    def policy_name(self) -> str:
+        if self.settings.allow_private_targets and self.settings.allow_non_local_targets:
+            return "authorized-private-and-public"
+        if self.settings.allow_private_targets:
+            return "authorized-private-and-local"
+        if self.settings.allow_non_local_targets:
+            return "public-and-local"
+        return "local-only"
+
+    def proxy_for_url(self, url: str) -> str | None:
+        return self._proxy_for_url(url)
+
+    def _resolve(self, host: str, port: int) -> list[IPv4Address | IPv6Address]:
+        try:
+            direct = ip_address(host)
+        except ValueError:
+            try:
+                records = self.resolver(host, port, type=socket.SOCK_STREAM)
+            except OSError as error:
+                raise TargetPolicyError(f"DNS preflight failed for '{host}': {error}.") from error
+            values = {record[4][0] for record in records if record[4]}
+            if not values:
+                raise TargetPolicyError(
+                    f"DNS preflight returned no addresses for '{host}'."
+                ) from None
+            return sorted((ip_address(value) for value in values), key=str)
+        return [direct]
+
+    def _address_allowed(self, address: IPv4Address | IPv6Address) -> bool:
+        if address.is_unspecified or address.is_multicast or address.is_link_local:
+            return False
+        if address.is_loopback:
+            return True
+        if address.is_private:
+            return self.settings.allow_private_targets
+        if not address.is_global:
+            return False
+        return self.settings.allow_non_local_targets
+
+    def _proxy_for_url(self, url: str) -> str | None:
+        proxy = self.settings.scan_proxy_url
+        if not proxy:
+            return None
+        parsed_proxy = urlparse(proxy)
+        if parsed_proxy.scheme not in {"http", "https", "socks5", "socks5h"}:
+            raise InputValidationError("GARDEN_SCAN_PROXY_URL uses an unsupported scheme.")
+        host = (urlparse(url).hostname or "").lower()
+        bypass = [item.strip().lower() for item in self.settings.scan_no_proxy.split(",")]
+        if any(self._host_matches(host, item) for item in bypass if item):
+            return None
+        return proxy
+
+    def _host_matches(self, host: str, rule: str) -> bool:
+        normalized = rule.lstrip(".")
+        return host == normalized or host.endswith(f".{normalized}")
+
+
+class _HTMLMetadataParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.links: list[str] = []
+        self.title_parts: list[str] = []
+        self.in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        lowered = tag.lower()
+        if lowered == "title":
+            self.in_title = True
+        if lowered not in {"a", "link", "script", "img", "iframe"}:
+            return
+        lookup = dict(attrs)
+        candidate = lookup.get("href") or lookup.get("src")
+        if candidate:
+            self.links.append(candidate)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self.in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title:
+            self.title_parts.append(data.strip())
+
+
+class HttpScanGateway:
+    """A passive HTTP gateway with explicit redirects and one bounded retry by default."""
+
+    def __init__(
+        self,
+        policy: TargetNetworkPolicy,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.policy = policy
+        self.transport = transport
+        self.sleeper = sleeper
+
+    def fetch(self, url: str, options: ScanOptions) -> FetchResult:
+        started = time.monotonic()
+        current = self.policy.normalize_url(url)
+        redirects: list[str] = []
+        total_attempts = 0
+        for redirect_index in range(options.max_redirects + 1):
+            self.policy.ensure_destination_allowed(current)
+            response, body, attempts = self._request_once_with_retry(current, options)
+            total_attempts += attempts
+            if response.status_code in {301, 302, 303, 307, 308}:
+                location = response.headers.get("location")
+                if not location:
+                    raise FetchError(
+                        "redirect_without_location",
+                        f"HTTP {response.status_code} response omitted Location.",
+                        url=current,
+                        attempts=total_attempts,
+                    )
+                if redirect_index >= options.max_redirects:
+                    raise FetchError(
+                        "redirect_limit_exceeded",
+                        f"Redirect limit of {options.max_redirects} was exceeded.",
+                        url=current,
+                        attempts=total_attempts,
+                    )
+                current = self.policy.normalize_url(urljoin(current, location))
+                self.policy.ensure_destination_allowed(current)
+                redirects.append(current)
+                continue
+            content_type = response.headers.get("content-type")
+            text = self._decode(body, response.encoding)
+            title, links = self._parse_html(current, text, content_type)
+            return FetchResult(
+                requested_url=url,
+                final_url=current,
+                status_code=response.status_code,
+                headers={key.lower(): value for key, value in response.headers.items()},
+                content_type=content_type,
+                body_text=text,
+                title=title,
+                discovered_urls=links,
+                redirects=redirects,
+                attempts=total_attempts,
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+        raise AssertionError("unreachable redirect state")
+
+    def _request_once_with_retry(
+        self, url: str, options: ScanOptions
+    ) -> tuple[httpx.Response, bytes, int]:
+        retries = options.retry_attempts or 0
+        proxy = self.policy.proxy_for_url(url)
+        timeout = options.request_timeout_seconds or 5.0
+        for attempt in range(1, retries + 2):
+            try:
+                with httpx.Client(
+                    timeout=timeout,
+                    follow_redirects=False,
+                    trust_env=False,
+                    proxy=proxy,
+                    transport=self.transport,
+                    headers={"User-Agent": options.user_agent, "Accept": "*/*"},
+                ) as client:
+                    with client.stream("GET", url) as response:
+                        chunks: list[bytes] = []
+                        size = 0
+                        for chunk in response.iter_bytes():
+                            remaining = MAX_RESPONSE_BYTES - size
+                            if remaining <= 0:
+                                break
+                            chunks.append(chunk[:remaining])
+                            size += min(len(chunk), remaining)
+                        body = b"".join(chunks)
+                if response.status_code not in TRANSIENT_STATUS_CODES:
+                    return response, body, attempt
+                if attempt > retries:
+                    raise FetchError(
+                        "transient_http_exhausted",
+                        f"HTTP {response.status_code} persisted after {attempt} attempt(s).",
+                        url=url,
+                        retryable=True,
+                        attempts=attempt,
+                    )
+            except TRANSIENT_EXCEPTIONS as error:
+                if attempt > retries:
+                    raise FetchError(
+                        "network_retry_exhausted",
+                        f"Network request failed after {attempt} attempt(s): {error}",
+                        url=url,
+                        retryable=True,
+                        attempts=attempt,
+                    ) from error
+            if attempt <= retries:
+                self.sleeper(0.2 * (2 ** (attempt - 1)))
+        raise AssertionError("unreachable retry state")
+
+    def _decode(self, body: bytes, encoding: str | None) -> str:
+        return body.decode(encoding or "utf-8", errors="replace")
+
+    def _parse_html(
+        self, base_url: str, text: str, content_type: str | None
+    ) -> tuple[str | None, list[str]]:
+        if "html" not in (content_type or "").lower():
+            return None, []
+        parser = _HTMLMetadataParser()
+        try:
+            parser.feed(text)
+        except Exception:
+            return None, []
+        title = " ".join(part for part in parser.title_parts if part).strip() or None
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for candidate in parser.links:
+            joined = urljoin(base_url, candidate)
+            parsed = urlparse(joined)
+            if parsed.scheme not in {"http", "https"}:
+                continue
+            value = urlunparse(
+                (parsed.scheme, parsed.netloc, parsed.path or "/", "", parsed.query, "")
+            )
+            if value not in seen:
+                seen.add(value)
+                normalized.append(value)
+        return title, normalized

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -316,6 +316,8 @@ class ScanPipeline:
         now = datetime.now(timezone.utc)
         attributes = {
             "content_type": result.content_type,
+            "body_size_bytes": result.body_size_bytes,
+            "body_is_text": result.body_is_text,
             "elapsed_ms": result.elapsed_ms,
             "attempts": result.attempts,
             "depth": depth,
@@ -336,7 +338,14 @@ class ScanPipeline:
             session.add(asset)
             session.flush()
         headers = self.redaction_service.redact_mapping(result.headers)
-        preview = self.redaction_service.redact_text(result.body_text, limit=1200)
+        if result.body_is_text:
+            preview = self.redaction_service.redact_text(result.body_text, limit=1200)
+        else:
+            preview = (
+                "[non-text response omitted; "
+                f"content-type={result.content_type or 'unknown'}; "
+                f"size={result.body_size_bytes} bytes]"
+            )
         session.add(
             ScanEvidence(
                 scan_run_id=run.id,

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -1,0 +1,425 @@
+"""Persisted six-stage URL-to-report execution pipeline."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import InputValidationError, TargetPolicyError
+from app.models.scan_run import (
+    ScanAsset,
+    ScanEvidence,
+    ScanFailure,
+    ScanFinding,
+    ScanRun,
+    ScanRunStage,
+)
+from app.redaction.service import RedactionService
+from app.schemas.scan import FetchResult, ScanOptions, ScanRunStatus, ScanStageName
+from app.services.scan_analysis import PassiveScanAnalyzer
+from app.services.scan_network import FetchError, HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_reporting import ScanReportService
+
+STAGES = [stage.value for stage in ScanStageName]
+PROGRESS_AFTER_STAGE = {
+    ScanStageName.VALIDATE.value: 8,
+    ScanStageName.DISCOVER.value: 20,
+    ScanStageName.COLLECT.value: 58,
+    ScanStageName.NORMALIZE.value: 68,
+    ScanStageName.ANALYZE.value: 86,
+    ScanStageName.REPORT.value: 100,
+}
+
+
+class OverallScanTimeout(RuntimeError):
+    pass
+
+
+class ScanPipeline:
+    def __init__(
+        self,
+        *,
+        policy: TargetNetworkPolicy,
+        gateway: HttpScanGateway,
+        analyzer: PassiveScanAnalyzer | None = None,
+        report_service: ScanReportService | None = None,
+        redaction_service: RedactionService | None = None,
+        clock=time.monotonic,
+    ) -> None:
+        self.policy = policy
+        self.gateway = gateway
+        self.analyzer = analyzer or PassiveScanAnalyzer()
+        self.report_service = report_service or ScanReportService()
+        self.redaction_service = redaction_service or RedactionService()
+        self.clock = clock
+
+    def execute(self, session: Session, scan_run_id: int) -> None:
+        run = session.get(ScanRun, scan_run_id)
+        if run is None or run.status not in {
+            ScanRunStatus.QUEUED.value,
+            ScanRunStatus.RUNNING.value,
+        }:
+            return
+        options = ScanOptions.model_validate(run.options)
+        deadline = self.clock() + float(options.overall_timeout_seconds or 90)
+        run.status = ScanRunStatus.RUNNING.value
+        run.started_at = run.started_at or datetime.now(timezone.utc)
+        session.commit()
+        try:
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.VALIDATE.value,
+                deadline,
+                lambda: self._validate(run),
+            )
+            entry = self._run_stage(
+                session,
+                run,
+                ScanStageName.DISCOVER.value,
+                deadline,
+                lambda: self._discover(session, run, options),
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.COLLECT.value,
+                deadline,
+                lambda: self._collect(session, run, entry, options, deadline),
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.NORMALIZE.value,
+                deadline,
+                lambda: self._normalize(session, run),
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.ANALYZE.value,
+                deadline,
+                lambda: self._analyze(session, run),
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.REPORT.value,
+                deadline,
+                lambda: self._report(session, run),
+            )
+            session.refresh(run)
+            run.status = (
+                ScanRunStatus.COMPLETED_WITH_WARNINGS.value
+                if run.failures
+                else ScanRunStatus.COMPLETED.value
+            )
+            run.current_stage = "finished"
+            run.progress = 100
+            run.finished_at = datetime.now(timezone.utc)
+            run.active_key = None
+            session.commit()
+        except Exception as error:  # noqa: BLE001 - stage boundary records diagnostics
+            session.rollback()
+            run = session.get(ScanRun, scan_run_id)
+            if run is None:
+                raise
+            stage_name = run.current_stage if run.current_stage in STAGES else "pipeline"
+            code, retryable, attempts, url = self._error_details(error, run.normalized_url)
+            self._record_failure(
+                session,
+                run,
+                stage=stage_name,
+                code=code,
+                message=str(error),
+                url=url,
+                retryable=retryable,
+                attempt=attempts,
+            )
+            stage = self._stage(session, run.id, stage_name)
+            if stage is not None:
+                stage.status = "failed"
+                stage.error_code = code
+                stage.error_message = str(error)
+                stage.finished_at = datetime.now(timezone.utc)
+            run.status = ScanRunStatus.FAILED.value
+            run.error_code = code
+            run.error_message = str(error)
+            run.finished_at = datetime.now(timezone.utc)
+            run.active_key = None
+            session.commit()
+            self._try_failure_report(session, run)
+
+    def _run_stage(self, session, run, name, deadline, operation):
+        self._check_deadline(deadline)
+        stage = self._stage(session, run.id, name)
+        if stage is None:
+            raise RuntimeError(f"Missing persisted stage '{name}'.")
+        stage.status = "running"
+        stage.attempt += 1
+        stage.started_at = datetime.now(timezone.utc)
+        run.current_stage = name
+        session.commit()
+        result, summary = operation()
+        self._check_deadline(deadline)
+        stage = self._stage(session, run.id, name)
+        stage.status = "completed"
+        stage.summary = summary
+        stage.finished_at = datetime.now(timezone.utc)
+        run = session.get(ScanRun, run.id)
+        run.progress = PROGRESS_AFTER_STAGE[name]
+        session.commit()
+        return result
+
+    def _validate(self, run: ScanRun):
+        result = self.policy.preflight(run.normalized_url)
+        run.normalized_url = result.normalized_url
+        summary = (
+            f"Network preflight passed with policy {result.policy}; "
+            f"resolved {len(result.resolved_addresses)} address(es); "
+            f"proxy={'enabled' if result.proxy_enabled else 'bypassed/disabled'}."
+        )
+        return result, summary
+
+    def _discover(self, session: Session, run: ScanRun, options: ScanOptions):
+        result = self.gateway.fetch(run.normalized_url, options)
+        self._persist_fetch(session, run, result, depth=0)
+        return result, (
+            f"Fetched entry URL with HTTP {result.status_code}; "
+            f"discovered {len(result.discovered_urls)} linked URL(s)."
+        )
+
+    def _collect(
+        self,
+        session: Session,
+        run: ScanRun,
+        entry: FetchResult,
+        options: ScanOptions,
+        deadline: float,
+    ):
+        queue = [(url, 1) for url in entry.discovered_urls]
+        seen = {entry.final_url, run.normalized_url}
+        origin = self._origin(entry.final_url)
+        collected = 1
+        skipped_external = 0
+        while queue and collected < options.max_pages:
+            self._check_deadline(deadline)
+            url, depth = queue.pop(0)
+            if url in seen:
+                continue
+            seen.add(url)
+            if self._origin(url) != origin:
+                skipped_external += 1
+                continue
+            if depth > options.max_depth:
+                continue
+            try:
+                result = self.gateway.fetch(url, options)
+            except (FetchError, InputValidationError, TargetPolicyError) as error:
+                code, retryable, attempts, failed_url = self._error_details(error, url)
+                self._record_failure(
+                    session,
+                    run,
+                    stage=ScanStageName.COLLECT.value,
+                    code=code,
+                    message=str(error),
+                    url=failed_url,
+                    retryable=retryable,
+                    attempt=attempts,
+                )
+                session.commit()
+                continue
+            self._persist_fetch(session, run, result, depth=depth)
+            collected += 1
+            if depth < options.max_depth:
+                queue.extend((candidate, depth + 1) for candidate in result.discovered_urls)
+            session.commit()
+        remaining = len(queue)
+        if remaining:
+            self._record_failure(
+                session,
+                run,
+                stage=ScanStageName.COLLECT.value,
+                code="coverage_limit_reached",
+                message=f"Stopped with {remaining} queued URL(s) because a scan bound was reached.",
+                url=None,
+                retryable=False,
+                attempt=1,
+            )
+        return None, (
+            f"Recorded {collected} same-origin page(s); skipped {skipped_external} external "
+            f"link(s); {remaining} URL(s) remained outside configured bounds."
+        )
+
+    def _normalize(self, session: Session, run: ScanRun):
+        assets = list(session.scalars(select(ScanAsset).where(ScanAsset.scan_run_id == run.id)))
+        evidence = list(
+            session.scalars(select(ScanEvidence).where(ScanEvidence.scan_run_id == run.id))
+        )
+        if not assets:
+            self._record_failure(
+                session,
+                run,
+                stage=ScanStageName.NORMALIZE.value,
+                code="no_assets",
+                message="The scan completed collection without any normalized assets.",
+                url=run.normalized_url,
+                retryable=False,
+                attempt=1,
+            )
+        return None, f"Normalized {len(assets)} asset(s) and {len(evidence)} evidence record(s)."
+
+    def _analyze(self, session: Session, run: ScanRun):
+        assets = list(session.scalars(select(ScanAsset).where(ScanAsset.scan_run_id == run.id)))
+        evidence = list(
+            session.scalars(select(ScanEvidence).where(ScanEvidence.scan_run_id == run.id))
+        )
+        candidates = self.analyzer.analyze(assets, evidence)
+        now = datetime.now(timezone.utc)
+        for candidate in candidates:
+            existing = session.scalar(
+                select(ScanFinding).where(
+                    ScanFinding.scan_run_id == run.id,
+                    ScanFinding.dedup_key == candidate.dedup_key,
+                )
+            )
+            if existing is not None:
+                continue
+            session.add(
+                ScanFinding(
+                    scan_run_id=run.id,
+                    created_at=now,
+                    **candidate.model_dump(),
+                )
+            )
+        session.flush()
+        return None, f"Created {len(candidates)} passive, explainable finding(s)."
+
+    def _report(self, session: Session, run: ScanRun):
+        path = self.report_service.generate(session, run.id)
+        return path, f"Generated structured Markdown report at {path}."
+
+    def _persist_fetch(
+        self, session: Session, run: ScanRun, result: FetchResult, *, depth: int
+    ) -> None:
+        asset = session.scalar(
+            select(ScanAsset).where(
+                ScanAsset.scan_run_id == run.id,
+                ScanAsset.asset_type == "page",
+                ScanAsset.url == result.final_url,
+            )
+        )
+        now = datetime.now(timezone.utc)
+        attributes = {
+            "content_type": result.content_type,
+            "elapsed_ms": result.elapsed_ms,
+            "attempts": result.attempts,
+            "depth": depth,
+            "redirects": result.redirects,
+            "discovered_urls": result.discovered_urls,
+        }
+        if asset is None:
+            asset = ScanAsset(
+                scan_run_id=run.id,
+                asset_type="page",
+                url=result.final_url,
+                method="GET",
+                status_code=result.status_code,
+                title=result.title,
+                attributes=attributes,
+                discovered_at=now,
+            )
+            session.add(asset)
+            session.flush()
+        headers = self.redaction_service.redact_mapping(result.headers)
+        preview = self.redaction_service.redact_text(result.body_text, limit=1200)
+        session.add(
+            ScanEvidence(
+                scan_run_id=run.id,
+                asset_id=asset.id,
+                evidence_type="http_response",
+                title=f"GET {result.final_url} -> HTTP {result.status_code}",
+                source_url=result.final_url,
+                summary=(
+                    f"HTTP {result.status_code}; content-type={result.content_type or '-'}; "
+                    f"elapsed={result.elapsed_ms}ms; attempts={result.attempts}."
+                ),
+                data={"headers": headers, "preview": preview},
+                collected_at=now,
+            )
+        )
+        run.retry_count += max(0, result.attempts - 1)
+        session.flush()
+
+    def _record_failure(
+        self,
+        session: Session,
+        run: ScanRun,
+        *,
+        stage: str,
+        code: str,
+        message: str,
+        url: str | None,
+        retryable: bool,
+        attempt: int,
+    ) -> None:
+        session.add(
+            ScanFailure(
+                scan_run_id=run.id,
+                stage=stage,
+                code=code,
+                message=message,
+                url=url,
+                retryable=retryable,
+                attempt=attempt,
+                occurred_at=datetime.now(timezone.utc),
+            )
+        )
+        run.retry_count += max(0, attempt - 1)
+
+    def _try_failure_report(self, session: Session, run: ScanRun) -> None:
+        try:
+            report_stage = self._stage(session, run.id, ScanStageName.REPORT.value)
+            if report_stage and report_stage.status == "pending":
+                report_stage.status = "running"
+                report_stage.attempt += 1
+                report_stage.started_at = datetime.now(timezone.utc)
+            path = self.report_service.generate(session, run.id)
+            if report_stage:
+                report_stage.status = "completed"
+                report_stage.summary = f"Generated diagnostic failure report at {path}."
+                report_stage.finished_at = datetime.now(timezone.utc)
+            session.commit()
+        except Exception:  # noqa: BLE001 - original failure remains authoritative
+            session.rollback()
+
+    def _stage(self, session: Session, run_id: int, name: str) -> ScanRunStage | None:
+        return session.scalar(
+            select(ScanRunStage).where(
+                ScanRunStage.scan_run_id == run_id, ScanRunStage.name == name
+            )
+        )
+
+    def _check_deadline(self, deadline: float) -> None:
+        if self.clock() > deadline:
+            raise OverallScanTimeout("The overall scan timeout was exceeded.")
+
+    def _origin(self, url: str) -> tuple[str, str, int | None]:
+        parsed = urlparse(url)
+        effective_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        return parsed.scheme, parsed.hostname or "", effective_port
+
+    def _error_details(self, error: Exception, fallback_url: str):
+        if isinstance(error, FetchError):
+            return error.code, error.retryable, error.attempts, error.url
+        if isinstance(error, OverallScanTimeout):
+            return "overall_timeout", False, 1, fallback_url
+        if isinstance(error, InputValidationError):
+            return "network_configuration_invalid", False, 1, fallback_url
+        if isinstance(error, TargetPolicyError):
+            return "target_policy_blocked", False, 1, fallback_url
+        return "stage_execution_failed", False, 1, fallback_url

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +15,8 @@ from app.models.scan_run import ScanRun
 
 class ScanReportService:
     """Render persisted domain records; CLI text is never an input."""
+
+    _control_character_pattern = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
     def __init__(self, output_root: Path | None = None) -> None:
         self.output_root = output_root or (Path.cwd() / "exports" / "scan-reports")
@@ -180,7 +183,10 @@ class ScanReportService:
         return lines
 
     def _cell(self, value: str) -> str:
-        return value.replace("|", "\\|").replace("\n", " ")
+        return self._clean(value).replace("|", "\\|").replace("\n", " ")
 
     def _inline(self, value: str) -> str:
-        return " ".join(value.replace("|", "\\|").split())
+        return " ".join(self._clean(value).replace("|", "\\|").split())
+
+    def _clean(self, value: str) -> str:
+        return self._control_character_pattern.sub(" ", value)

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -1,0 +1,186 @@
+"""Structured Markdown reporting for complete URL scan runs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.errors import ResourceNotFoundError
+from app.models.scan_run import ScanRun
+
+
+class ScanReportService:
+    """Render persisted domain records; CLI text is never an input."""
+
+    def __init__(self, output_root: Path | None = None) -> None:
+        self.output_root = output_root or (Path.cwd() / "exports" / "scan-reports")
+
+    def generate(self, session: Session, scan_run_id: int) -> str:
+        run = session.scalar(
+            select(ScanRun)
+            .where(ScanRun.id == scan_run_id)
+            .options(
+                selectinload(ScanRun.stages),
+                selectinload(ScanRun.assets),
+                selectinload(ScanRun.evidence),
+                selectinload(ScanRun.findings),
+                selectinload(ScanRun.failures),
+            )
+        )
+        if run is None:
+            raise ResourceNotFoundError(f"Scan run {scan_run_id} was not found.")
+        generated_at = datetime.now(timezone.utc)
+        lines = self._render(run, generated_at)
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        path = self.output_root / f"scan-{run.id}.md"
+        path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        run.report_path = str(path)
+        run.report_generated_at = generated_at
+        session.flush()
+        return str(path)
+
+    def _render(self, run: ScanRun, generated_at: datetime) -> list[str]:
+        failures = sorted(run.failures, key=lambda item: item.id)
+        assets = sorted(run.assets, key=lambda item: item.id)
+        evidence = sorted(run.evidence, key=lambda item: item.id)
+        findings = sorted(run.findings, key=lambda item: item.id)
+        stages = sorted(run.stages, key=lambda item: item.position)
+        warning_count = len(failures)
+        summary_status = run.status
+        if summary_status == "running":
+            summary_status = "completed_with_warnings" if failures else "completed"
+        lines = [
+            f"# Garden 资产报告 #{run.id}",
+            "",
+            "## 执行摘要",
+            "",
+            f"- 任务状态：{summary_status}",
+            f"- 入口 URL：{run.normalized_url}",
+            f"- 发现资产：{len(assets)}",
+            f"- 证据记录：{len(evidence)}",
+            f"- 风险或关注项：{len(findings)}",
+            f"- 失败或未覆盖项：{warning_count}",
+            "",
+            "## 扫描范围",
+            "",
+            f"- 起始地址：{run.normalized_url}",
+            f"- 最大页面数：{run.options.get('max_pages', '-')}",
+            f"- 最大深度：{run.options.get('max_depth', '-')}",
+            f"- 单请求超时：{run.options.get('request_timeout_seconds', '-')} 秒",
+            f"- 整体超时：{run.options.get('overall_timeout_seconds', '-')} 秒",
+            "- 请求方法：仅被动 GET；不执行利用、写入或破坏性操作",
+            "- 边界：仅跟随同源页面；每次连接和重定向均重新执行地址策略校验",
+            "",
+            "## 发现的资产",
+            "",
+        ]
+        if not assets:
+            lines.append("未发现可记录的资产。")
+        else:
+            lines.extend(["| ID | 类型 | 状态 | 标题 | URL |", "|---:|---|---:|---|---|"])
+            for asset in assets:
+                lines.append(
+                    f"| A{asset.id} | {asset.asset_type} | {asset.status_code or '-'} | "
+                    f"{self._cell(asset.title or '-')} | {self._cell(asset.url)} |"
+                )
+        lines.extend(["", "## 关键属性", ""])
+        if not assets:
+            lines.append("无可归纳的关键属性。")
+        for asset in assets:
+            content_type = asset.attributes.get("content_type") or "-"
+            elapsed = asset.attributes.get("elapsed_ms")
+            attempts = asset.attributes.get("attempts")
+            lines.append(
+                f"- A{asset.id}：content-type={content_type}，耗时={elapsed or 0}ms，"
+                f"请求尝试={attempts or 1}"
+            )
+        lines.extend(["", "## 证据", ""])
+        if not evidence:
+            lines.append("没有可用证据；请结合失败与未覆盖部分判断报告完整性。")
+        for item in evidence:
+            headers = item.data.get("headers", {})
+            rendered_headers = ", ".join(
+                f"{key}={self._inline(str(value))}" for key, value in sorted(headers.items())[:12]
+            )
+            preview = self._inline(str(item.data.get("preview") or "-"))[:500]
+            lines.extend(
+                [
+                    f"### E{item.id}：{item.title}",
+                    "",
+                    f"- 来源：{item.source_url}",
+                    f"- 资产：A{item.asset_id}" if item.asset_id else "- 资产：未关联",
+                    f"- 摘要：{item.summary}",
+                    f"- 响应头证据：{rendered_headers or '-'}",
+                    f"- 脱敏内容预览：{preview}",
+                    "",
+                ]
+            )
+        lines.extend(["## 风险或关注项", ""])
+        if not findings:
+            lines.append("未识别到风险或关注项。这不代表目标不存在未覆盖风险。")
+        for finding in findings:
+            evidence_refs = ", ".join(f"E{item}" for item in finding.evidence_ids) or "无"
+            asset_refs = ", ".join(f"A{item}" for item in finding.asset_ids) or "无"
+            lines.extend(
+                [
+                    f"### F{finding.id}：{finding.title}",
+                    "",
+                    f"- 严重性 / 置信度：{finding.severity} / {finding.confidence}",
+                    f"- 类别：{finding.category}",
+                    f"- 关联资产：{asset_refs}",
+                    f"- 关联证据：{evidence_refs}",
+                    f"- 说明：{finding.summary}",
+                    f"- 建议：{finding.remediation}",
+                    "",
+                ]
+            )
+
+        def report_status(stage) -> str:
+            if stage.name == "report" and stage.status == "running":
+                return "completed"
+            return stage.status
+
+        completed_stages = sum(1 for stage in stages if report_status(stage) == "completed")
+        lines.extend(
+            [
+                "## 扫描覆盖范围",
+                "",
+                f"- 阶段完成：{completed_stages}/{len(stages)}",
+                f"- 已请求并记录的页面：{len(assets)}/{run.options.get('max_pages', '-')}",
+            ]
+        )
+        for stage in stages:
+            summary = stage.summary
+            if stage.name == "report" and stage.status == "running":
+                summary = "本结构化报告已生成。"
+            lines.append(f"- {stage.name}：{report_status(stage)}；{summary or '-'}")
+        lines.extend(["", "## 失败或未覆盖部分", ""])
+        if not failures:
+            lines.append("未记录阶段失败或单页采集失败。")
+        for failure in failures:
+            location = f"（{failure.url}）" if failure.url else ""
+            lines.append(
+                f"- [{failure.stage}/{failure.code}] {failure.message}{location}；"
+                f"尝试次数={failure.attempt}，可重试={str(failure.retryable).lower()}"
+            )
+        lines.extend(
+            [
+                "",
+                "## 生成时间",
+                "",
+                f"- {generated_at.isoformat()}",
+                "",
+                "---",
+                "本报告仅反映上述边界内的被动资产发现结果，供已授权目标的审阅使用。",
+            ]
+        )
+        return lines
+
+    def _cell(self, value: str) -> str:
+        return value.replace("|", "\\|").replace("\n", " ")
+
+    def _inline(self, value: str) -> str:
+        return " ".join(value.replace("|", "\\|").split())

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,7 @@
         <a href="/" class="text-xl font-semibold tracking-tight">Garden</a>
         <nav class="flex gap-3 text-sm text-slate-600">
           <a href="/" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Dashboard</a>
+          <a href="/scans" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">URL Scans</a>
           <a href="/targets" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Targets</a>
           <a href="/credentials" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Credentials</a>
           <a href="/jobs" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Jobs</a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,20 +6,18 @@
     <div class="grid gap-6 lg:grid-cols-[1.5fr_1fr]">
       <div class="rounded-3xl border border-black/10 bg-white p-8 shadow-sm">
         <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-700">
-          CLI-First Authenticated Verification
+          One URL to a structured report
         </p>
-        <h1 class="mt-3 text-4xl font-semibold tracking-tight">{{ project_name }} Dashboard</h1>
+        <h1 class="mt-3 text-4xl font-semibold tracking-tight">Start an asset scan</h1>
         <p class="mt-4 max-w-3xl text-base leading-7 text-slate-600">
-          Garden is a safe-by-default internal security workflow for authorized post-login verification.
-          The CLI stays primary for repeatable execution, while this dashboard keeps recent workflow state,
-          findings, and retest outcomes easy to review during demos and triage.
+          Submit one authorized HTTP or HTTPS entry URL. Garden validates the network destination,
+          discovers and normalizes assets, analyzes passive evidence, and produces a readable report.
         </p>
-        <div class="mt-6 flex flex-wrap gap-3 text-sm">
-          <a href="/targets" class="rounded-full bg-slate-900 px-4 py-2 text-white">Targets</a>
-          <a href="/inventory" class="rounded-full border border-black/10 px-4 py-2">Inventory</a>
-          <a href="/findings" class="rounded-full border border-black/10 px-4 py-2">Findings</a>
-          <a href="/evidence" class="rounded-full border border-black/10 px-4 py-2">Evidence</a>
-        </div>
+        <form action="/scans" method="post" class="mt-6 grid gap-3 sm:grid-cols-[1fr_auto]">
+          <label class="sr-only" for="scan-url">Entry URL</label>
+          <input id="scan-url" name="url" type="url" required placeholder="http://127.0.0.1:8080/" class="rounded-2xl border border-black/15 bg-white px-4 py-3 outline-none focus:border-emerald-600" />
+          <button class="rounded-2xl bg-slate-900 px-6 py-3 font-medium text-white" type="submit">Start scan</button>
+        </form>
       </div>
       <aside class="rounded-3xl border border-black/10 bg-stone-50 p-6 shadow-sm">
         <h2 class="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">Runtime</h2>
@@ -38,7 +36,7 @@
           </div>
           <div>
             <dt class="text-slate-500">UI Scope</dt>
-            <dd class="mt-1 font-medium">Browse, triage, and review only</dd>
+            <dd class="mt-1 font-medium">Start, track, read, and download</dd>
           </div>
         </dl>
       </aside>

--- a/app/templates/scan_detail.html
+++ b/app/templates/scan_detail.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_badge %}
+
+{% block content %}
+  <section class="space-y-6">
+    <div class="flex items-end justify-between gap-4">
+      <div>
+        <p class="text-sm uppercase tracking-[0.18em] text-emerald-700">URL-to-report run</p>
+        <h1 class="text-3xl font-semibold tracking-tight">Scan #{{ scan.id }}</h1>
+        <p class="mt-2 break-all text-sm text-slate-600">{{ scan.normalized_url }}</p>
+      </div>
+      <a href="/scans" class="rounded-full border border-black/10 px-4 py-2 text-sm">All scans</a>
+    </div>
+    <div class="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+      <div class="flex items-center justify-between">
+        <div>{{ status_badge(scan.status) }} <span class="ml-2 text-sm text-slate-600">{{ scan.current_stage }}</span></div>
+        <div class="text-2xl font-semibold">{{ scan.progress }}%</div>
+      </div>
+      <div class="mt-4 h-3 overflow-hidden rounded-full bg-stone-200"><div class="h-full rounded-full bg-emerald-600" style="width: {{ scan.progress }}%"></div></div>
+      {% if scan.error_message %}<p class="mt-4 rounded-2xl bg-red-50 p-4 text-sm text-red-800"><strong>{{ scan.error_code }}</strong> — {{ scan.error_message }}</p>{% endif %}
+      <dl class="mt-5 grid gap-4 sm:grid-cols-3">
+        <div><dt>Assets</dt><dd>{{ scan.asset_count }}</dd></div>
+        <div><dt>Evidence</dt><dd>{{ scan.evidence_count }}</dd></div>
+        <div><dt>Findings</dt><dd>{{ scan.finding_count }}</dd></div>
+      </dl>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {% for stage in scan.stages %}
+        <div class="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
+          <div class="flex items-center justify-between"><h2 class="font-semibold">{{ stage.position }}. {{ stage.name }}</h2>{{ status_badge(stage.status) }}</div>
+          <p class="mt-3 text-sm leading-6 text-slate-600">{{ stage.summary or stage.error_message or "Waiting" }}</p>
+          <p class="mt-2 text-xs text-slate-500">attempt {{ stage.attempt }}</p>
+        </div>
+      {% endfor %}
+    </div>
+    {% if scan.failures %}
+      <div class="rounded-3xl border border-amber-200 bg-amber-50 p-6">
+        <h2 class="text-lg font-semibold">Failures and uncovered work</h2>
+        <ul class="mt-3 space-y-2 text-sm">
+          {% for failure in scan.failures %}<li><strong>{{ failure.stage }}/{{ failure.code }}</strong> — {{ failure.message }}{% if failure.url %} ({{ failure.url }}){% endif %}</li>{% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+    {% if report %}
+      <div class="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+        <div class="flex items-center justify-between"><h2 class="text-lg font-semibold">Report</h2><a class="rounded-full bg-slate-900 px-4 py-2 text-sm text-white" href="/api/scans/{{ scan.id }}/report?download=true">Download Markdown</a></div>
+        <pre class="mt-5 max-h-[48rem] overflow-auto whitespace-pre-wrap rounded-2xl bg-stone-50 p-5 text-sm leading-6">{{ report }}</pre>
+      </div>
+    {% elif scan.status in ["queued", "running"] %}
+      <script>window.setTimeout(function () { window.location.reload(); }, 1000);</script>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/app/templates/scans_list.html
+++ b/app/templates/scans_list.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from "_macros.html" import status_badge %}
+
+{% block content %}
+  <section class="space-y-6">
+    <div class="flex items-end justify-between">
+      <div>
+        <p class="text-sm uppercase tracking-[0.18em] text-emerald-700">Automatic pipeline</p>
+        <h1 class="text-3xl font-semibold tracking-tight">URL Scans</h1>
+      </div>
+      <a href="/" class="rounded-full bg-slate-900 px-4 py-2 text-sm text-white">New scan</a>
+    </div>
+    <div class="overflow-hidden rounded-3xl border border-black/10 bg-white shadow-sm">
+      <table class="min-w-full divide-y divide-black/5 text-sm">
+        <thead class="bg-stone-50 text-left text-slate-500">
+          <tr><th class="px-5 py-3">ID</th><th class="px-5 py-3">URL</th><th class="px-5 py-3">Status</th><th class="px-5 py-3">Stage</th><th class="px-5 py-3">Progress</th></tr>
+        </thead>
+        <tbody class="divide-y divide-black/5">
+          {% for scan in scans %}
+            <tr class="hover:bg-stone-50">
+              <td class="px-5 py-4 font-medium"><a href="/scans/{{ scan.id }}">#{{ scan.id }}</a></td>
+              <td class="max-w-xl truncate px-5 py-4">{{ scan.normalized_url }}</td>
+              <td class="px-5 py-4">{{ status_badge(scan.status) }}</td>
+              <td class="px-5 py-4">{{ scan.current_stage }}</td>
+              <td class="px-5 py-4">{{ scan.progress }}%</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5" class="px-5 py-8 text-center text-slate-500">No URL scans yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}

--- a/app/workers/README.md
+++ b/app/workers/README.md
@@ -1,4 +1,7 @@
 # Workers
 
-Phase 1 does not introduce background jobs yet. This package exists so later phases can add orchestration helpers without coupling them to API or CLI entrypoints.
-
+URL scans are dispatched through the `ScanDispatcher` interface in
+`app/services/scan_application.py`. The current Web/API runtime uses a bounded
+thread pool; the CLI injects an inline dispatcher while calling the same use
+case. A future durable queue belongs behind that interface and must not move
+pipeline logic into workers or adapters.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - .env
     volumes:
       - ./data:/app/data
-
+      - ./exports:/app/exports

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,244 +1,99 @@
 # Architecture
 
-## Overview
-
-Garden is a CLI-first, minimal-Web-UI-second workflow system for authorized authenticated application surface verification.
-
-The product shape is intentionally narrow:
-
-- CLI is the operational control plane
-- Web UI is a small review and triage surface
-- business logic lives in services
-- adapter/plugin seams exist for login, checks, evidence capture, and exporters
-- outputs are structured and linked instead of being stored as raw traffic piles
-
-## Why CLI-First
-
-Garden is built for AppSec, security engineering, and internal testing teams. Those users need:
-
-- shell-friendly commands
-- repeatable workflows
-- CI or scheduled execution potential
-- composable output
-- low operational overhead
-
-That is why the core workflow is exposed first through `gardenctl`, and why every major phase was implemented through service layers that both CLI and Web routes reuse.
-
-## Why the Web UI Is Minimal
-
-The Web UI exists to support:
-
-- browsing inventory and findings
-- reviewing evidence
-- triaging lifecycle state
-- driving a short live demo
-
-It is intentionally not a SPA and not a heavy management console. This keeps:
-
-- startup simple
-- mental overhead low
-- architecture focused on workflow output rather than frontend complexity
-
-## Major Components
-
-### `app/core/`
-
-- settings loading
-- logging
-- exception helpers
-- target guardrails
-
-### `app/db/`
-
-- SQLAlchemy bootstrap
-- session management
-- base model setup
-
-### `app/models/`
-
-Persistent workflow entities:
-
-- `Target`
-- `CredentialProfile`
-- `ScanJob`
-- `AuthSession`
-- `InventoryRun`
-- `InventoryPage`
-- `InventoryEndpoint`
-- `InventoryParameter`
-- `InventoryAnnotation`
-- `Finding`
-- `FindingRetestRun`
-- `Evidence`
-- `AuditEvent`
-
-### `app/services/`
-
-All workflow logic lives here:
-
-- target CRUD/import
-- credential CRUD
-- session/login orchestration
-- inventory build and export
-- checks and finding lifecycle
-- evidence capture and export
-- retest orchestration
-- report generation
-- dashboard summaries
-
-### `app/integrations/`
-
-External execution seams:
-
-- HTTP login adapter
-- Playwright login adapter
-- Playwright inventory gateway
-- Playwright evidence capture gateway
-
-### `app/security_checks/`
-
-Plugin-style low-risk checks with explicit metadata and bounded trigger logic.
-
-### `app/redaction/`
-
-Central redaction logic used by evidence storage, display, and export flows.
-
-### `app/cli/`
-
-Thin Typer command groups over services.
-
-### `app/api/` + `app/templates/`
-
-Thin FastAPI routes and server-rendered templates for browse/review flows.
-
-## End-to-End Component Relationships
-
-The main workflow is:
-
-1. `TargetService` manages targets.
-2. `CredentialProfileService` manages credential profiles.
-3. `AuthSessionService` resolves login config + secret references and invokes the selected auth adapter.
-4. Successful logins persist `AuthSession` metadata plus a `storage_ref` to raw payload storage.
-5. `InventoryBuildService` either reuses an existing session or performs a fresh login, then creates a `ScanJob` and `InventoryRun`.
-6. `InventoryCollectionService` restores browser/session state and invokes the Playwright collector.
-7. Structured inventory is persisted as pages, endpoints, parameters, and annotations.
-8. `CheckRunService` executes registered low-risk checks against structured inventory.
-9. `FindingService` upserts deduplicated findings and tracks lifecycle state.
-10. `EvidenceService` captures reviewable, redacted evidence for linked findings.
-11. `RetestService` reruns a bounded portion of the workflow for eligible findings.
-12. `FindingExportService` and `ReportService` generate redacted outputs for review and handoff.
-
-## Data Relationships
-
-- A `Target` can have many `CredentialProfile`, `ScanJob`, `AuthSession`, `InventoryRun`, `Finding`, `Evidence`, and `AuditEvent` records.
-- A `CredentialProfile` belongs to one target and can be reused across many jobs, sessions, inventory runs, findings, and evidence items.
-- A `ScanJob` groups a discrete execution step such as inventory, checks, or retest.
-- An `AuthSession` belongs to one target and one credential profile and can be reused by inventory and retest flows.
-- An `InventoryRun` belongs to one target, one credential profile, one session, and one job.
-- A `Finding` belongs to one target, one credential profile, one session, and one job, and stores explicit inventory references.
-- A `FindingRetestRun` records retest outcome and context separately from the main finding row.
-- An `Evidence` record links back to target, profile, session, job, inventory, and optionally finding.
-- `AuditEvent` records login, validation, refresh, lifecycle update, evidence export, retest, and report export activity.
-
-## Login and Session Architecture
-
-Garden uses an adapter strategy for login:
-
-- config parsing is handled separately from execution
-- HTTP flows and Playwright UI flows implement the same conceptual contract
-- login results are normalized before persistence
-- raw sensitive session material is stored behind a pointer rather than inline in display models
-
-This keeps login orchestration reusable and testable instead of collapsing into a single hardcoded browser script.
-
-## Inventory Architecture
-
-Inventory is structured on purpose. Garden does not treat authenticated activity as an opaque blob.
-
-It records:
-
-- visited page URLs and titles
-- timestamps
-- API endpoints and methods
-- status codes
-- parameter names
-- sensitivity annotations
-
-Inventory collection is bounded by:
-
-- `max_pages`
-- `max_depth`
-- `max_requests`
-- `delay_ms`
-- same-origin rules
-- include/exclude path prefixes
-
-## Checks Pipeline
-
-Checks are implemented as separable plugins. Each plugin exposes metadata for:
-
-- name
-- purpose
-- category
-- severity
-- confidence
-- trigger explanation
-- false-positive boundaries
-- remediation notes
-
-Garden's checks remain low-risk and explainable. They do not perform destructive behavior or exploit attempts.
-
-## Evidence and Redaction Pipeline
-
-Evidence is structured, linked, and redacted by default.
-
-Garden captures:
-
-- request metadata
-- response metadata
-- bounded request preview
-- bounded response preview
-- page title
-- URL
-- method
-- status
-- screenshot metadata and file location
-
-Redaction is centralized so CLI, UI, and export paths do not drift apart.
-
-## Lifecycle, Dedup, and Retest
-
-Phase 7 turned Garden into a workflow product:
-
-- findings have explicit lifecycle state
-- status transitions are validated centrally
-- dedup preserves `first_seen` and updates `last_seen`
-- previously fixed findings can reopen when the same issue reappears
-- retest reuses session context when possible and falls back to fresh login when necessary
-- retest results are recorded as first-class workflow data
-
-## Exporters
-
-Export logic remains modular:
-
-- findings export: Markdown, JSON, CSV
-- inventory export: JSON, CSV
-- evidence export: Markdown, JSON
-- reports: Markdown
-
-This keeps output generation understandable and reusable instead of spreading file-writing logic across command handlers.
-
-## Minimal UI Flow
-
-The UI is intentionally simple:
-
-- dashboard
-- targets
-- credentials
-- jobs
-- sessions
-- inventory
-- findings
-- evidence
-
-That is enough to make the workflow demo-ready and reviewable without changing the product identity.
+## Product execution model
+
+Garden's primary execution model is one submitted URL to one persisted report:
+
+```text
+Web form              HTTP API              gardenctl scan
+   \                      |                      /
+    +---------------------+---------------------+
+                          |
+             ScanApplicationService.start_scan
+                          |
+              persistent ScanRun + stages
+                          |
+     validate -> discover -> collect -> normalize -> analyze -> report
+                          |
+       assets + evidence + findings + failures + Markdown report
+```
+
+No adapter owns or duplicates the workflow. `app/services/scan_application.py`
+is the use-case boundary; `app/services/scan_pipeline.py` is the persisted stage
+runner. CLI uses an inline dispatcher so a shell invocation waits for the report.
+The Web and HTTP surfaces use a bounded in-process dispatcher and return a task
+that can be polled.
+
+## Persistent parent task
+
+`ScanRun` represents the user's complete request, unlike the legacy `ScanJob`
+which represents an authenticated inventory/check/retest step. It stores:
+
+- original and normalized URL
+- status, current stage, percentage progress, and timestamps
+- bounded options and an active-submission idempotency key
+- network retry count
+- error code/message and final report path/time
+- six `ScanRunStage` rows with attempt, status, summary, and diagnostics
+
+Normalized child tables are `ScanAsset`, `ScanEvidence`, `ScanFinding`, and
+`ScanFailure`. The report renderer reads these structures directly. It never
+parses console output or temporary CLI text.
+
+## Pipeline stages and failure semantics
+
+1. **validate**: normalize URL, resolve DNS, classify every address, and decide
+   whether an explicitly configured proxy applies before collection starts.
+2. **discover**: perform the first passive GET and extract bounded HTML metadata
+   and links.
+3. **collect**: follow same-origin links within maximum page/depth limits.
+4. **normalize**: verify persisted normalized assets/evidence and record no-result state.
+5. **analyze**: run passive, explainable checks over structured records.
+6. **report**: render the complete Markdown report from persisted domain data.
+
+An entry/preflight failure marks the run and current stage failed, persists the
+failure, and attempts a diagnostic report. A single secondary-page failure is a
+partial failure: collection continues and the final status is
+`completed_with_warnings`. Coverage-limit and request failures are visible in
+both the task API/UI and report.
+
+## Network and SSRF boundary
+
+Only HTTP and HTTPS are accepted. Embedded credentials are rejected. Garden
+resolves and checks every requested or redirected hostname before connecting,
+disallows implicit environment proxies, follows redirects itself, and validates
+each redirect destination. Link-local, multicast, unspecified, and non-global
+special-purpose addresses are blocked. Loopback is allowed for safe local tests.
+
+Remote public targets require `GARDEN_ALLOW_NON_LOCAL_TARGETS=true`. RFC1918/ULA
+targets additionally require `GARDEN_ALLOW_PRIVATE_TARGETS=true`. DNS answers
+containing any disallowed address fail closed.
+
+Requests have a per-request timeout, an overall task deadline, a response-size
+cap, redirect/page/depth caps, and a configurable task concurrency cap. The
+default network behavior is one initial request plus at most one retry, and only
+connect/read transient failures or HTTP 502/503/504 retry.
+
+## User adapters
+
+- `POST /scans` accepts the Web form and redirects directly to its progress page.
+- `POST /api/scans` accepts `{url, options}` and returns the parent task.
+- `GET /api/scans/{id}` returns current stage, progress, failures, and counts.
+- `GET /api/scans/{id}/report` reads or downloads the generated Markdown.
+- `gardenctl scan --url ...` calls the same application service and prints the
+  terminal task result only after the pipeline finishes.
+
+## Legacy authenticated workflow
+
+The credential/session/inventory/check/finding/evidence/retest services remain
+available for advanced authenticated verification. Their adapters remain thin.
+They are not hidden prerequisites for URL scans and their IDs are never required
+to complete the URL-to-report workflow. See `docs/legacy-cli-migration.md`.
+
+## Deployment model
+
+SQLite and the bounded in-process dispatcher are appropriate for the current
+single-process deployment. Run one Uvicorn worker. For horizontal execution,
+replace `ScanDispatcher` with a durable queue implementation while retaining the
+same application-service and pipeline boundaries; the persisted domain model and
+adapters do not need to change.

--- a/docs/demo-walkthrough.md
+++ b/docs/demo-walkthrough.md
@@ -1,5 +1,10 @@
 # Demo Walkthrough
 
+> This is the optional advanced authenticated-workflow walkthrough. The primary
+> product flow now starts from the Web home page, `POST /api/scans`, or
+> `gardenctl scan --url URL` and requires no commands below. See
+> `docs/legacy-cli-migration.md` for the boundary between the two flows.
+
 ## Goal
 
 Demonstrate a complete safe local Garden workflow in 5 to 10 minutes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ## 说明
 
-这份文档是 Garden 的部署与运行草稿，重点覆盖：
+这份文档覆盖从全新环境安装到“一次提交 URL，自动得到报告”的完整运行方式：
 
 - 本地开发部署
 - Docker 方式运行
@@ -93,6 +93,18 @@ curl -s http://127.0.0.1:8000/healthz
 
 - `http://127.0.0.1:8000/`
 
+首页输入一个已授权 URL 后即可查看六阶段真实进度，并在完成后直接阅读或下载报告。
+
+也可以只调用一次 HTTP 接口：
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/api/scans \
+  -H 'content-type: application/json' \
+  -d '{"url":"http://127.0.0.1:8080/"}'
+```
+
+响应中的 `id` 可用于 Web/API 查看进度；不需要执行 inventory、checks 或 report 命令。
+
 ## 三、CLI 基础验证
 
 激活虚拟环境后执行：
@@ -101,6 +113,7 @@ curl -s http://127.0.0.1:8000/healthz
 gardenctl --help
 gardenctl version
 gardenctl healthcheck
+gardenctl scan --url http://127.0.0.1:8080/
 ```
 
 ## 四、Docker 方式运行
@@ -116,6 +129,7 @@ docker build -t garden:local .
 ```bash
 docker run --rm -it \
   -p 8000:8000 \
+  -v "$(pwd)/exports:/app/exports" \
   -e GARDEN_DATABASE_URL=sqlite+pysqlite:///./data/garden.db \
   -e GARDEN_ALLOW_NON_LOCAL_TARGETS=false \
   -e GARDEN_DEMO_ADMIN_PASSWORD=demo-admin-password \
@@ -141,7 +155,9 @@ docker run --rm -it \
 docker compose up --build
 ```
 
-## 五、推荐的本地演示流程
+## 五、旧版登录后高级工作流（可选）
+
+下面这些命令只用于需要登录态、人工 triage 或 retest 的高级流程；它们不是 URL 自动扫描的前置或后置步骤。
 
 ### 1. 导入 target
 
@@ -331,6 +347,14 @@ Garden 默认只允许本地目标。
 ```bash
 export GARDEN_ALLOW_NON_LOCAL_TARGETS=true
 ```
+
+公网域名只需要上述开关；RFC1918/ULA 内网目标还需要：
+
+```bash
+export GARDEN_ALLOW_PRIVATE_TARGETS=true
+```
+
+link-local/云元数据、组播和未指定地址始终拒绝。默认每个请求首次失败后最多重试一次，且仅限连接/读取瞬断或 502/503/504。可通过 `GARDEN_SCAN_RETRY_ATTEMPTS=0` 完全关闭重试。
 
 ### 3. Playwright 无法运行
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,8 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Garden — 登录态安全验证工作流</title>
+<title>Garden — 一个 URL 到资产报告</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231e5f48'/%3E%3Cpath d='M18 34c0-11 8-19 22-20-1 13-8 22-20 22m0 0c7 1 13 5 16 12M20 36v14' fill='none' stroke='white' stroke-width='5' stroke-linecap='round'/%3E%3C/svg%3E"/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
@@ -293,8 +294,8 @@ pre{
   <div class="orb orb-2"></div>
   <div class="orb orb-3"></div>
 <section class="hero">
-  <h1>Garden: 登录后的<em>安全验证</em>工作流</h1>
-  <p class="lead">CLI-first 的内部工具，把授权场景下的登录、盘点、检查、取证、复测串成一条可重复、可审计的管线。</p>
+  <h1>Garden: 一个 URL 到<em>资产报告</em></h1>
+  <p class="lead">提交一次已授权入口，自动完成预检、发现、采集、分析和证据报告；Web、API、CLI 共用同一核心服务。</p>
   <div class="btns">
     <button class="btn pri" onclick="showDocs('intro')">Read the docs</button>
     <a class="btn" href="https://github.com/Moxxkidd/Garden" target="_blank">View on GitHub</a>
@@ -305,14 +306,14 @@ pre{
 <section class="feat">
   <div class="grid">
     <div class="item">
-      <div class="label">Login-driven</div>
-      <h3>登录态驱动</h3>
-      <p>HTTP / Playwright 适配器执行真实登录，创建可复用的 AuthSession，覆盖匿名扫瞄器无法进入的 OA、ERP、管理后台。</p>
+      <div class="label">One URL</div>
+      <h3>一次提交</h3>
+      <p>普通用户只需输入 HTTP(S) URL；不需要创建 target、复制任务 ID 或手动运行中间 CLI。</p>
     </div>
     <div class="item">
       <div class="label">End-to-end</div>
       <h3>完整工作流闭环</h3>
-      <p>从一条 <code>gardenctl scan</code> 到完整分步流程都能覆盖：target → credential → login → session → inventory → checks → findings → evidence → retest → export，12 个 CLI 子命令组全链路贯通。</p>
+      <p><code>validate → discover → collect → normalize → analyze → report</code> 六阶段持久化执行，进度、失败、覆盖缺口和报告位置均可查询。</p>
     </div>
     <div class="item">
       <div class="label">Safe by default</div>
@@ -325,18 +326,14 @@ pre{
 <div class="extra" style="margin-bottom:48px">
   <div class="tag">Pipeline</div>
   <h2>工作流</h2>
-  <p class="sub">10 个阶段，每个阶段产出结构化数据，不是纯文本日志。</p>
+  <p class="sub">6 个自动阶段，每个阶段产出结构化数据，不是纯文本日志。</p>
   <div class="pipeline" id="pipeline-bar">
-    <span>target</span> <b>&rarr;</b>
-    <span>credential</span> <b>&rarr;</b>
-    <span>login</span> <b>&rarr;</b>
-    <span>session</span> <b>&rarr;</b>
-    <span>inventory</span> <b>&rarr;</b>
-    <span>checks</span> <b>&rarr;</b>
-    <span>findings</span> <b>&rarr;</b>
-    <span>evidence</span> <b>&rarr;</b>
-    <span>retest</span> <b>&rarr;</b>
-    <span>export</span>
+    <span>validate</span> <b>&rarr;</b>
+    <span>discover</span> <b>&rarr;</b>
+    <span>collect</span> <b>&rarr;</b>
+    <span>normalize</span> <b>&rarr;</b>
+    <span>analyze</span> <b>&rarr;</b>
+    <span>report</span>
   </div>
 </div>
 
@@ -362,7 +359,7 @@ pre{
     <li>evidence 和导出默认脱敏</li>
     <li>inventory 结构化，不退化流量堆</li>
     <li>所有关键操作记审计日志</li>
-    <li>CLI-first，Web UI 最小化</li>
+    <li>application-service-first，CLI / Web / API 是薄适配层</li>
   </ul>
 </div>
 
@@ -372,17 +369,13 @@ pre{
   <pre>$ git clone https://github.com/Moxxkidd/Garden.git
 $ cd garden
 $ pip install -e '.[dev]'
-$ playwright install chromium
 $ cp .env.example .env
 
-$ gardenctl scan \
-    --url http://127.0.0.1:8888/ \
-    --username 'test@123.com' \
-    --password 'Test12345678!' \
-    --username-selector '#basic_email' \
-    --password-selector '#basic_password' \
-    --submit-selector 'button:has-text("Login") >> nth=1' \
-    --success-text 'Dashboard'</pre>
+$ make demo
+# open http://127.0.0.1:8000 and submit one URL
+
+# or use the same core service from CLI:
+$ gardenctl scan --url http://127.0.0.1:8888/</pre>
 </div>
 
 <footer class="home-footer">
@@ -458,19 +451,18 @@ intro:{b:'快速开始 > 简介',h:`
 <h1>简介</h1>
 <div class="meta-row"><div>字数<span>450</span></div><div>阅读时间<span>3 min</span></div></div>
 
-<p>Garden is a <strong>CLI-first</strong> security workflow tool for authorized post-login application surface verification. It is not a traditional "scanner" — it is an internal security workflow subsystem for enterprise AppSec teams.</p>
+<p>Garden is an <strong>application-service-first</strong> asset workflow for authorized targets. A user submits one URL and receives persisted progress, structured evidence, findings, coverage, failures, and a readable report.</p>
 
-<p>For terminal-only use, <code>gardenctl scan</code> accepts a URL, username, and password, then drives login, authenticated inventory, checks, findings, evidence, and a Markdown report without requiring a YAML login config.</p>
+<p>Web, HTTP API, and <code>gardenctl scan</code> all call the same <code>ScanApplicationService.start_scan</code>; no adapter owns hidden orchestration.</p>
 
 <h2>核心工作流</h2>
-<pre>target &rarr; credential profile &rarr; login &rarr; authenticated session
-      &rarr; inventory &rarr; checks &rarr; findings &rarr; evidence
-      &rarr; triage &rarr; retest &rarr; export</pre>
+<pre>URL &rarr; validate/network preflight &rarr; discover &rarr; collect
+    &rarr; normalize &rarr; analyze &rarr; report</pre>
 
-<p>Garden 产出的不是跑过了什么命令，而是结构化工作流产物：target 清单、credential profile 清单、authenticated session 记录、审计事件、scan jobs、结构化 inventory、可解释的 findings、关联的脱敏 evidence、retest 记录，以及 Markdown / JSON / CSV 导出。</p>
+<p>核心 URL 流程持久化 ScanRun、六阶段状态、资产、脱敏证据、被动 findings、失败与覆盖缺口，并直接生成 Markdown 资产报告。原有 target、credential、session、inventory 和 retest 数据继续服务高级认证工作流。</p>
 
 <h2>推荐使用顺序</h2>
-<pre>$ gardenctl scan --url http://127.0.0.1:8888/ --username test@123.com
+<pre>$ gardenctl scan --url http://127.0.0.1:8888/
 
 # or run the explicit workflow:
 $ gardenctl healthcheck
@@ -485,7 +477,7 @@ $ gardenctl findings update-status
 $ gardenctl retest run
 $ gardenctl findings export      # or report generate</pre>
 
-<div class="tip">Garden 的核心定位不是找更多洞，而是把登录后业务系统的安全验证，做成一个可重复、可审计、可复测、可工程化落地的流程。</div>
+<div class="tip">普通用户只提交一次 URL；需要登录态和人工复测时，才进入保留的高级认证工作流。</div>
 `},
 install:{b:'快速开始 > 安装',h:`
 <h1>安装</h1>
@@ -520,20 +512,16 @@ quickstart:{b:'快速开始 > Demo 演练',h:`
 
 <p>5～10 分钟走完完整 Garden 工作流。使用内置 demo target 演示。</p>
 
-<h2>1. 一条命令扫描本地 crAPI</h2>
+<h2>1. 一条命令扫描已授权本地目标</h2>
 <pre>$ gardenctl scan \
     --url http://127.0.0.1:8888/ \
-    --username 'test@123.com' \
-    --password 'Test12345678!' \
-    --username-selector '#basic_email' \
-    --password-selector '#basic_password' \
-    --submit-selector 'button:has-text("Login") >> nth=1' \
-    --success-text 'Dashboard' \
     --max-pages 10 \
     --max-depth 1 \
-    --max-requests 50</pre>
+    --request-timeout 5 \
+    --overall-timeout 90 \
+    --retries 1</pre>
 
-<p>该命令会自动完成登录、authenticated inventory、checks、findings、evidence capture，并输出 <code>exports/reports/job-&lt;id&gt;.md</code> 报告路径。</p>
+<p>该命令会自动完成网络预检、同源发现与采集、结果标准化、结构化分析和 Markdown 报告生成，并输出 <code>exports/scan-reports/scan-&lt;id&gt;.md</code> 路径。</p>
 
 <h2>2. 或启动内置 demo 服务</h2>
 <pre>$ make demo</pre>
@@ -961,20 +949,14 @@ report:{b:'证据与报告 > 报告生成',h:`
 'cli-scan':{b:'CLI 参考 > gardenctl scan',h:`
 <h1>gardenctl scan</h1>
 <div class="meta-row"><div>字数<span>160</span></div><div>阅读时间<span>1 min</span></div></div>
-<pre>gardenctl scan --url URL --username USER [--password PASSWORD]
-               [--username-selector CSS] [--password-selector CSS]
-               [--submit-selector CSS] [--success-text TEXT]
-               [--max-pages N] [--max-depth N] [--max-requests N]</pre>
-<p><code>scan</code> 是终端一键工作流：输入 URL、账号和密码后，自动创建 target / credential profile，完成登录、inventory、checks、findings、evidence 和 Markdown report。</p>
+<pre>gardenctl scan --url URL [--max-pages N] [--max-depth N]
+               [--request-timeout SECONDS] [--overall-timeout SECONDS]
+               [--retries 0|1|2]</pre>
+<p><code>scan</code> 是核心 URL 流水线的终端适配器：只输入一个 URL，自动完成预检、发现、采集、标准化、分析和 Markdown 报告。</p>
 <pre>gardenctl scan \\
   --url http://127.0.0.1:8888/ \\
-  --username 'test@123.com' \\
-  --password 'Test12345678!' \\
-  --username-selector '#basic_email' \\
-  --password-selector '#basic_password' \\
-  --submit-selector 'button:has-text("Login") >> nth=1' \\
-  --success-text 'Dashboard'</pre>
-<div class="tip">密码可以通过隐藏交互输入或 <code>GARDEN_QUICKSCAN_PASSWORD</code> 环境变量传入；非本地授权目标仍需显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>。</div>
+  --max-pages 10 --max-depth 1 --retries 1</pre>
+<div class="tip">非本地公网目标需显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>；RFC1918/ULA 内网还需 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</div>
 `},
 'cli-target':{b:'CLI 参考 > gardenctl target',h:`
 <h1>gardenctl target</h1>
@@ -1054,33 +1036,32 @@ architecture:{b:'进阶 > 架构设计',h:`
 <h1>架构设计</h1>
 <div class="meta-row"><div>字数<span>350</span></div><div>阅读时间<span>3 min</span></div></div>
 
-<h2>Layered design</h2>
-<pre>CLI (Typer)  &mdash;&rarr;  Services  &mdash;&rarr;  Models / DB
-Web (FastAPI) &mdash;&rarr;  Services  &mdash;&rarr;  Models / DB
-                   &darr;
-             Adapters / Plugins
-             (HTTP Auth, Playwright Auth,
-              Playwright Inventory, Checks)</pre>
+<h2>Core execution model</h2>
+<pre>Web / HTTP API / CLI
+          &darr;
+ScanApplicationService.start_scan(url, options)
+          &darr;
+validate &rarr; discover &rarr; collect &rarr; normalize &rarr; analyze &rarr; report
+          &darr;
+ScanRun + assets + evidence + findings + failures</pre>
 
 <h2>端到端组件关系</h2>
 <ul class="check-list">
-  <li>TargetService 管理目标</li>
-  <li>CredentialProfileService 管理凭证档案</li>
-  <li>AuthSessionService 解析 login config + secret，调用选定的 auth adapter</li>
-  <li>InventoryBuildService 创建 ScanJob + InventoryRun，驱动采集管线</li>
-  <li>InventoryCollectionService 恢复浏览器状态，调用 Playwright 采集器</li>
-  <li>CheckRunService 执行注册的低风险 checks</li>
-  <li>FindingService upsert 去重 findings，跟踪生命周期状态</li>
-  <li>EvidenceService 采集脱敏的可审阅 evidence</li>
-  <li>RetestService 对符合条件的 findings 重跑验证</li>
-  <li>FindingExportService + ReportService 生成脱敏输出</li>
+  <li>ScanApplicationService 是 CLI、Web、API 无关的唯一用例入口</li>
+  <li>持久化 ScanRun 记录状态、进度、阶段、重试、错误和报告位置</li>
+  <li>TargetNetworkPolicy 在连接和每次重定向前执行 DNS / SSRF 校验</li>
+  <li>ScanPipeline 自动执行六阶段，并显式记录部分失败与覆盖上限</li>
+  <li>PassiveScanAnalyzer 只分析统一资产和证据结构</li>
+  <li>ScanReportService 从持久化结构直接生成报告，不解析 CLI 文本</li>
+  <li>原有认证 service 保留为高级工作流，不是 URL 扫描隐藏前置步骤</li>
 </ul>
 
 <h2>Data entities</h2>
-<pre>Target, CredentialProfile, ScanJob, AuthSession,
-InventoryRun, InventoryPage, InventoryEndpoint,
-InventoryParameter, InventoryAnnotation,
-Finding, FindingRetestRun, Evidence, AuditEvent</pre>
+<pre>ScanRun, ScanRunStage, ScanAsset, ScanEvidence,
+ScanFinding, ScanFailure
+
+Advanced: Target, CredentialProfile, ScanJob, AuthSession,
+InventoryRun, Finding, Evidence, FindingRetestRun</pre>
 `},
 guardrails:{b:'进阶 > 安全护栏',h:`
 <h1>安全护栏</h1>
@@ -1091,6 +1072,9 @@ guardrails:{b:'进阶 > 安全护栏',h:`
 <ul class="check-list">
   <li>默认仅允许本地 / demo 目标</li>
   <li>非本地目标需 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</li>
+  <li>RFC1918 / ULA 内网目标需额外设置 GARDEN_ALLOW_PRIVATE_TARGETS=true</li>
+  <li>每个连接与重定向都执行 DNS / SSRF 策略检查</li>
+  <li>请求、整体任务、页面、深度、响应体和并发均有上限</li>
   <li>不做破坏性测试</li>
   <li>不做 exploit execution</li>
   <li>不做 brute-force / fuzzing</li>
@@ -1108,6 +1092,9 @@ outputs:{b:'进阶 > 结构化产出',h:`
 <p>Garden 产出的不是跑过了什么命令，而是结构化工作流产物：</p>
 
 <ul class="check-list">
+  <li>ScanRun 父任务、六阶段进度、错误与报告位置</li>
+  <li>统一的 ScanAsset / ScanEvidence / ScanFinding / ScanFailure</li>
+  <li>包含摘要、范围、资产、证据、风险、覆盖和失败的 Markdown 资产报告</li>
   <li>Target manifests</li>
   <li>Credential profile 清单</li>
   <li>Authenticated session 记录</li>
@@ -1123,7 +1110,7 @@ outputs:{b:'进阶 > 结构化产出',h:`
   <li>Job Markdown 报告</li>
 </ul>
 
-<div class="tip">Garden 的价值不是做了扫描，而是把登录后验证工作变成了可审阅、可复测、可导出的流程。</div>
+<div class="tip">普通用户无需理解内部 job ID；所有自动步骤和缺口都由同一个父任务串联并持久化。</div>
 `},
 constraints:{b:'进阶 > 设计约束',h:`
 <h1>设计约束</h1>

--- a/docs/legacy-cli-migration.md
+++ b/docs/legacy-cli-migration.md
@@ -1,0 +1,30 @@
+# Legacy CLI Migration
+
+## What changed
+
+Before this refactor, `gardenctl scan` required a username/password and created a
+target, credential profile, login session, inventory job, checks job, and report
+inside the command handler. The command was the business orchestrator.
+
+`gardenctl scan` now accepts one URL and calls `ScanApplicationService.start_scan`.
+It automatically waits for the persisted six-stage run and prints the final
+report location. Removed scan-specific authentication/selector flags are not
+required for the anonymous asset-report product flow.
+
+```bash
+gardenctl scan --url http://127.0.0.1:8080/
+```
+
+Use `--max-pages`, `--max-depth`, `--request-timeout`, `--overall-timeout`, and
+`--retries` to adjust safe bounds. `--retries` means retries after the first
+request and is capped at two.
+
+## Advanced authenticated workflow
+
+Existing target, credential, login, session, inventory, checks, findings,
+evidence, retest, and legacy job-report commands remain available. Use those
+explicit commands only when authenticated exploration or lifecycle triage is the
+actual task. They do not need to be run before or after `gardenctl scan`.
+
+No old data tables are removed. `ScanJob` remains the advanced workflow step
+record; `ScanRun` is the new URL-to-report parent task.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -46,6 +46,18 @@ Remote targets require:
 - an explicit configuration change such as `GARDEN_ALLOW_NON_LOCAL_TARGETS=true`
 - a consciously authorized environment
 
+Private RFC1918/ULA targets require the separate
+`GARDEN_ALLOW_PRIVATE_TARGETS=true` opt-in. URL scans resolve and classify DNS
+answers before connecting and repeat admission checks for redirects. Embedded
+URL credentials, link-local/cloud-metadata destinations, multicast, unspecified
+addresses, mixed allowed/denied DNS answers, unsupported schemes, and unbounded
+redirects are rejected. Environment proxy variables are ignored unless a scan
+proxy is explicitly configured.
+
+Passive collection is bounded by per-request and overall timeouts, response-size,
+page/depth, redirect, retry, and concurrent-task limits. Only GET requests are
+issued by the automatic URL pipeline.
+
 ## Non-Destructive Behavior
 
 Garden's checks are marker-based and review-oriented. They are not meant to alter state or exploit vulnerabilities.

--- a/docs/url-scan-refactor-checklist.md
+++ b/docs/url-scan-refactor-checklist.md
@@ -1,0 +1,89 @@
+# URL Scan Core Refactor Checklist
+
+This document is the living audit and acceptance checklist for the URL-to-report
+execution model. It must be updated whenever an implementation or verification
+stage changes.
+
+## Audited legacy execution chain
+
+```text
+gardenctl scan
+  -> parse URL and prompt for username/password in app/cli/scan.py
+  -> create/reuse Target
+  -> create CredentialProfile with an environment-secret reference
+  -> InventoryBuildService (login/session + inventory ScanJob)
+  -> CheckRunService (a second ScanJob + findings/evidence)
+  -> ReportService(checks job id)
+  -> print several IDs and the report path
+```
+
+The Web surface only browses legacy records. There is no HTTP or Web start
+endpoint. `ScanJob` represents an inventory/check/retest step, not the complete
+user request, and has no stage/progress/retry/report fields. The one-command
+orchestration and transient credential setup are duplicated in the CLI adapter.
+
+## Coupling and hidden-step findings
+
+- [x] CLI owns end-to-end orchestration and transient state transfer.
+- [x] Inventory and checks create separate jobs; no persisted parent run exists.
+- [x] Report generation receives a checks job ID and cannot represent the full run.
+- [x] Web/API cannot start the workflow and cannot show true pipeline progress.
+- [x] Entry requires credentials even when an anonymous URL scan is sufficient.
+- [x] Network policy is host-string based and does not validate DNS answers or redirects.
+- [x] Proxy abstraction is a placeholder and network preflight is implicit.
+- [x] Partial coverage and individual request failures are not report sections.
+
+## Target execution model
+
+```text
+CLI / Web form / HTTP API
+          |
+          v
+ScanApplicationService.start_scan(url, options)
+          |
+          v
+persistent ScanRun + bounded dispatcher
+          |
+          v
+validate/network preflight -> discover -> collect -> normalize -> analyze -> report
+          |
+          v
+assets + evidence + findings + failures + stages + final report
+```
+
+## Implementation and acceptance
+
+- [x] Core application service is independent of CLI, Web, and HTTP.
+- [x] Persistent parent task records status, progress, stage, errors, retries, and report.
+- [x] Assets, evidence, findings, failures, and stage outcomes use normalized structures.
+- [x] Network preflight runs before collection; retries are bounded and diagnostic.
+- [x] URL scheme, credentials, DNS answers, redirects, SSRF policy, timeout, and concurrency are bounded.
+- [x] Duplicate active submissions are idempotent.
+- [x] A failed stage is explicit; partial results never look complete.
+- [x] Report uses persisted structured data and contains every required section.
+- [x] CLI is a thin adapter over the core service.
+- [x] HTTP API can start once, inspect progress/failure, and read/download the report.
+- [x] Web UI can submit one URL, follow progress, and read/download the report.
+- [x] Invalid URL, duplicate, timeout, partial failure, and no-result behavior are tested.
+- [x] Unit tests cover network policy, retry rules, analysis, and report structure.
+- [x] Integration tests cover the complete persisted pipeline.
+- [x] End-to-end test covers user entry through final report.
+- [x] All legacy tests pass after migration.
+- [x] A real local fixture run has been executed and its report inspected.
+- [x] README, architecture, operation, and legacy CLI migration docs are current.
+- [x] Package wheel builds, declared dependencies are consistent, and CLI/database startup passes.
+
+## Final verification evidence (2026-07-21)
+
+- `pytest -q`: 85 passed, including all pre-refactor tests and 11 URL-pipeline tests.
+- `ruff check .`, `ruff format --check .`, and `git diff --check`: passed.
+- `pip check`: no broken requirements.
+- Wheel build: `garden-0.1.0-py3-none-any.whl` built without dependency resolution.
+- Fresh-install smoke: the wheel plus declared runtime dependencies installed into
+  an isolated venv; `gardenctl healthcheck` passed with a new SQLite file.
+- CLI smoke: `gardenctl --help` exposed the one-URL scan entry and advanced commands.
+- Real TCP run: one `POST /api/scans` against the bundled loopback fixture reached
+  100%, all six stages completed, and persisted 3 assets, 3 evidence records,
+  and 7 passive findings.
+- Final inspected report: `exports/scan-reports/scan-1.md`; every required section,
+  linked evidence, fixture asset, coverage line, and generation time was present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "garden"
 version = "0.1.0"
-description = "CLI-first authenticated application surface verification workflow tool."
+description = "One-URL automated asset discovery, analysis, and evidence reporting service."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/scripts/e2e_url_scan.py
+++ b/scripts/e2e_url_scan.py
@@ -1,0 +1,124 @@
+"""Run a real TCP URL-to-report smoke test against the bundled local fixture."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import httpx
+import uvicorn
+
+
+class QuietFixtureHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return None
+
+
+def main() -> int:
+    workspace = Path(__file__).resolve().parents[1]
+    fixture_root = workspace / "tests" / "fixtures" / "url_scan_site"
+    fixture = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        partial(QuietFixtureHandler, directory=str(fixture_root)),
+    )
+    fixture_thread = threading.Thread(target=fixture.serve_forever, daemon=True)
+    fixture_thread.start()
+
+    os.environ.setdefault(
+        "GARDEN_DATABASE_URL",
+        "sqlite+pysqlite:////private/tmp/garden-url-scan-e2e.db",
+    )
+    os.environ["GARDEN_ALLOW_NON_LOCAL_TARGETS"] = "false"
+    os.environ["GARDEN_ALLOW_PRIVATE_TARGETS"] = "false"
+    from app.core.settings import clear_settings_cache
+    from app.db.bootstrap import reset_database_state
+    from app.main import create_app
+
+    clear_settings_cache()
+    reset_database_state()
+    api_port = int(os.environ.get("GARDEN_E2E_API_PORT", "8013"))
+    server = uvicorn.Server(
+        uvicorn.Config(create_app(), host="127.0.0.1", port=api_port, log_level="warning")
+    )
+    api_thread = threading.Thread(target=server.run, daemon=True)
+    api_thread.start()
+    deadline = time.monotonic() + 10
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("Garden API did not start within 10 seconds.")
+
+    try:
+        with httpx.Client(timeout=5) as client:
+            response = client.post(
+                f"http://127.0.0.1:{api_port}/api/scans",
+                json={
+                    "url": f"http://127.0.0.1:{fixture.server_port}/",
+                    "options": {"max_pages": 5, "max_depth": 1, "retry_attempts": 0},
+                },
+            )
+            response.raise_for_status()
+            initial = response.json()
+            scan_id = initial["id"]
+            deadline = time.monotonic() + 15
+            current = initial
+            while current["status"] in {"queued", "running"} and time.monotonic() < deadline:
+                time.sleep(0.05)
+                status_response = client.get(f"http://127.0.0.1:{api_port}/api/scans/{scan_id}")
+                status_response.raise_for_status()
+                current = status_response.json()
+            report_response = client.get(f"http://127.0.0.1:{api_port}/api/scans/{scan_id}/report")
+            report_response.raise_for_status()
+            detail_response = client.get(f"http://127.0.0.1:{api_port}/scans/{scan_id}")
+            detail_response.raise_for_status()
+        report = report_response.text
+        required_sections = [
+            "执行摘要",
+            "扫描范围",
+            "发现的资产",
+            "关键属性",
+            "证据",
+            "风险或关注项",
+            "扫描覆盖范围",
+            "失败或未覆盖部分",
+            "生成时间",
+        ]
+        result = {
+            "scan_id": scan_id,
+            "status": current["status"],
+            "progress": current["progress"],
+            "stage_statuses": {stage["name"]: stage["status"] for stage in current["stages"]},
+            "asset_count": current["asset_count"],
+            "evidence_count": current["evidence_count"],
+            "finding_count": current["finding_count"],
+            "failure_codes": [failure["code"] for failure in current["failures"]],
+            "report_path": current["report_path"],
+            "required_sections_present": all(
+                f"## {section}" in report for section in required_sections
+            ),
+            "fixture_assets_present": all(
+                text in report for text in ["Garden Local Fixture", "Garden Fixture Asset Detail"]
+            ),
+            "web_detail_contains_report": "Garden Local Fixture" in detail_response.text,
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        if current["status"] not in {"completed", "completed_with_warnings"}:
+            return 1
+        if not result["required_sections_present"] or not result["fixture_assets_present"]:
+            return 1
+        return 0
+    finally:
+        server.should_exit = True
+        api_thread.join(timeout=10)
+        fixture.shutdown()
+        fixture.server_close()
+        fixture_thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/url_scan_site/about.html
+++ b/tests/fixtures/url_scan_site/about.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Garden Fixture Asset Detail</title></head>
+  <body>
+    <h1>Asset detail</h1>
+    <p>Evidence text from a safe, authorized local target.</p>
+  </body>
+</html>

--- a/tests/fixtures/url_scan_site/index.html
+++ b/tests/fixtures/url_scan_site/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Garden Local Fixture</title></head>
+  <body>
+    <h1>Authorized local asset fixture</h1>
+    <p>This deterministic site is used for real end-to-end scan verification.</p>
+    <a href="/about.html">About the fixture</a>
+    <a href="/missing.html">Known missing page</a>
+  </body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,8 @@ def test_index_page_loads(app) -> None:
     assert response.status_code == 200
     assert "Garden" in response.text
     assert "Dashboard" in response.text
-    assert "CLI-First Authenticated Verification" in response.text
+    assert "One URL to a structured report" in response.text
+    assert "Start scan" in response.text
 
 
 def test_management_pages_render(app, seeded_findings) -> None:

--- a/tests/test_quick_scan_cli.py
+++ b/tests/test_quick_scan_cli.py
@@ -1,16 +1,16 @@
+from datetime import datetime, timezone
+
 from typer.testing import CliRunner
 
 import app.cli.scan as scan_cli
 from app.cli.main import app
-from app.schemas.finding import CheckRunSummary
-from app.schemas.inventory import InventoryBuildSummary, InventoryCounts
-from app.schemas.reporting import JobReportResult
+from app.schemas.scan import ScanRunView
 from app.services.login_configs import LoginConfigService, encode_inline_login_config
 
 runner = CliRunner()
 
 
-def test_inline_playwright_config_round_trip() -> None:
+def test_inline_playwright_config_round_trip_for_legacy_commands() -> None:
     encoded = encode_inline_login_config(
         {
             "adapter": "playwright",
@@ -19,97 +19,53 @@ def test_inline_playwright_config_round_trip() -> None:
             "auto_detect_selectors": True,
         }
     )
-
     config = LoginConfigService().load(encoded)
-
     assert config.adapter == "playwright"
     assert config.login_url == "/login"
-    assert config.validate_url == "/"
     assert config.auto_detect_selectors is True
-    assert config.username_selector == "auto"
 
 
-def test_quick_scan_splits_login_url_from_target_origin() -> None:
-    base_url, login_path = scan_cli._split_target_and_login_url(
-        "http://127.0.0.1:8888/login?next=/dashboard"
-    )
+def test_scan_command_is_thin_adapter_over_core_service(monkeypatch) -> None:
+    calls = []
 
-    assert base_url == "http://127.0.0.1:8888"
-    assert login_path == "/login?next=/dashboard"
+    class FakeScanService:
+        def __init__(self, *, dispatcher):
+            assert dispatcher.__class__.__name__ == "InlineScanDispatcher"
 
-
-def test_scan_command_runs_terminal_workflow_without_config_files(monkeypatch) -> None:
-    class FakeInventoryService:
-        def __init__(self) -> None:
-            self.calls = []
-
-        def build_from_target_profile(self, session, target_name, profile_name, controls):
-            self.calls.append((target_name, profile_name, controls.max_pages))
-            return InventoryBuildSummary(
-                inventory_run_id=11,
-                scan_job_id=21,
-                target_name=target_name,
-                profile_name=profile_name,
-                auth_session_id=31,
+        def start_scan(self, url, options):
+            calls.append((url, options.max_pages, options.max_depth, options.retry_attempts))
+            return ScanRunView(
+                id=41,
+                input_url=url,
+                normalized_url=url,
                 status="completed",
-                counts=InventoryCounts(pages=2, endpoints=1, parameters=0, annotations=0),
-                summary="Collected 2 pages.",
+                current_stage="finished",
+                progress=100,
+                retry_count=0,
+                report_path="exports/scan-reports/scan-41.md",
+                created_at=datetime.now(timezone.utc),
+                asset_count=2,
+                evidence_count=2,
+                finding_count=1,
             )
 
-    class FakeCheckService:
-        def run_inventory_checks(self, session, inventory_run_id):
-            assert inventory_run_id == 11
-            return CheckRunSummary(
-                inventory_run_id=11,
-                scan_job_id=41,
-                target_name="quick-127-0-0-1-8888",
-                profile_name="quick-user-example-local",
-                session_id=31,
-                findings_created=0,
-                findings_updated=0,
-                total_findings=0,
-                summary="Checks completed.",
-            )
-
-    class FakeReportService:
-        def generate(self, session, *, job_id, export_format):
-            assert job_id == 41
-            assert export_format == "md"
-            return JobReportResult(
-                job_id=job_id,
-                format="md",
-                output_path="exports/reports/job-41.md",
-            )
-
-    class FakeFindingService:
-        def list(self, session, *, job_id=None):
-            assert job_id == 41
-            return []
-
-    fake_inventory = FakeInventoryService()
-    monkeypatch.setattr(scan_cli, "inventory_service", fake_inventory)
-    monkeypatch.setattr(scan_cli, "check_service", FakeCheckService())
-    monkeypatch.setattr(scan_cli, "report_service", FakeReportService())
-    monkeypatch.setattr(scan_cli, "finding_service", FakeFindingService())
-
+    monkeypatch.setattr(scan_cli, "ScanApplicationService", FakeScanService)
     result = runner.invoke(
         app,
         [
             "scan",
             "--url",
-            "http://127.0.0.1:8888/login",
-            "--username",
-            "user@example.local",
-            "--password",
-            "secret",
-            "--profile-name",
-            "quick-user-example-local",
+            "http://127.0.0.1:8888/",
             "--max-pages",
             "3",
+            "--max-depth",
+            "1",
+            "--retries",
+            "0",
         ],
     )
 
     assert result.exit_code == 0
-    assert fake_inventory.calls == [("quick-127-0-0-1-8888", "quick-user-example-local", 3)]
-    assert "Quick Scan Result" in result.stdout
-    assert "exports/reports/job-41.md" in result.stdout
+    assert calls == [("http://127.0.0.1:8888/", 3, 1, 0)]
+    assert "Automatic URL Scan Result" in result.stdout
+    assert "exports/scan-reports/scan-41.md" in result.stdout

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import time
+
+import httpx
+from fastapi.testclient import TestClient
+
+import app.main as main_app
+from app.core.errors import InputValidationError, TargetPolicyError
+from app.core.settings import get_settings
+from app.schemas.scan import ScanOptions
+from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
+from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_pipeline import ScanPipeline
+from app.services.scan_reporting import ScanReportService
+
+
+def _loopback_resolver(host, port, **kwargs):
+    return [(2, 1, 6, "", ("127.0.0.1", port))]
+
+
+def _service(tmp_path, handler, *, clock=time.monotonic):
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    gateway = HttpScanGateway(
+        policy,
+        transport=httpx.MockTransport(handler),
+        sleeper=lambda _: None,
+    )
+    pipeline = ScanPipeline(
+        policy=policy,
+        gateway=gateway,
+        report_service=ScanReportService(tmp_path / "reports"),
+        clock=clock,
+    )
+    return ScanApplicationService(
+        settings=settings,
+        pipeline=pipeline,
+        dispatcher=InlineScanDispatcher(),
+    )
+
+
+def test_network_policy_validates_url_and_blocks_link_local() -> None:
+    settings = get_settings().model_copy(
+        update={"allow_non_local_targets": True, "allow_private_targets": True}
+    )
+    metadata_policy = TargetNetworkPolicy(
+        settings,
+        resolver=lambda host, port, **kwargs: [(2, 1, 6, "", ("169.254.169.254", port))],
+    )
+    try:
+        metadata_policy.preflight("http://metadata.invalid/latest")
+    except TargetPolicyError as error:
+        assert "blocked" in str(error)
+    else:
+        raise AssertionError("Expected link-local metadata address to be blocked.")
+
+    local_policy = TargetNetworkPolicy(get_settings(), resolver=_loopback_resolver)
+    try:
+        local_policy.normalize_url("ftp://127.0.0.1/file")
+    except InputValidationError as error:
+        assert "http or https" in str(error)
+    else:
+        raise AssertionError("Expected invalid scheme to be rejected.")
+    try:
+        local_policy.normalize_url("http://user:secret@127.0.0.1/")
+    except InputValidationError as error:
+        assert "Credentials" in str(error)
+    else:
+        raise AssertionError("Expected embedded credentials to be rejected.")
+
+
+def test_network_retry_is_single_and_only_for_transient_failure() -> None:
+    calls = []
+
+    def handler(request):
+        calls.append(str(request.url))
+        if len(calls) == 1:
+            raise httpx.ConnectError("temporary disconnect", request=request)
+        return httpx.Response(200, headers={"content-type": "text/html"}, text="<title>OK</title>")
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    gateway = HttpScanGateway(
+        policy, transport=httpx.MockTransport(handler), sleeper=lambda _: None
+    )
+    result = gateway.fetch(
+        "http://127.0.0.1/",
+        ScanOptions(request_timeout_seconds=1, retry_attempts=1),
+    )
+    assert result.attempts == 2
+    assert len(calls) == 2
+
+
+def test_redirect_to_link_local_is_blocked_before_second_request() -> None:
+    calls = []
+
+    def handler(request):
+        calls.append(str(request.url))
+        return httpx.Response(302, headers={"location": "http://169.254.169.254/latest"})
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    gateway = HttpScanGateway(policy, transport=httpx.MockTransport(handler))
+    try:
+        gateway.fetch(
+            "http://127.0.0.1/",
+            ScanOptions(request_timeout_seconds=1, retry_attempts=0),
+        )
+    except TargetPolicyError as error:
+        assert "blocked" in str(error)
+    else:
+        raise AssertionError("Expected redirect to link-local metadata to be blocked.")
+    assert len(calls) == 1
+
+
+def test_complete_pipeline_persists_structured_data_and_report(tmp_path) -> None:
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html", "server": "fixture"},
+                text='<html><title>Home</title><a href="/about">About</a></html>',
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html", "x-content-type-options": "nosniff"},
+            text="<html><title>About</title><p>Fixture</p></html>",
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions(max_pages=5, retry_attempts=0))
+    assert scan.status == "completed"
+    assert scan.progress == 100
+    assert scan.asset_count == 2
+    assert scan.evidence_count == 2
+    assert scan.finding_count >= 1
+    assert [stage.status for stage in scan.stages] == ["completed"] * 6
+    report = service.read_report(scan.id)
+    for heading in [
+        "执行摘要",
+        "扫描范围",
+        "发现的资产",
+        "关键属性",
+        "证据",
+        "风险或关注项",
+        "扫描覆盖范围",
+        "失败或未覆盖部分",
+        "生成时间",
+    ]:
+        assert f"## {heading}" in report
+    assert "Home" in report
+    assert "E" in report
+
+
+def test_partial_page_failure_completes_with_warning_and_diagnostic_report(tmp_path) -> None:
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<a href="/broken">Broken</a>',
+            )
+        raise httpx.ConnectError("fixture connection dropped", request=request)
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions(retry_attempts=0))
+    assert scan.status == "completed_with_warnings"
+    assert scan.failures[0].code == "network_retry_exhausted"
+    report = service.read_report(scan.id)
+    assert "fixture connection dropped" in report
+    assert "completed_with_warnings" in report
+
+
+def test_empty_success_response_has_explicit_single_asset_result(tmp_path) -> None:
+    service = _service(tmp_path, lambda request: httpx.Response(204))
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions(max_pages=1, retry_attempts=0))
+    assert scan.status == "completed"
+    assert scan.asset_count == 1
+    assert scan.finding_count == 0
+    report = service.read_report(scan.id)
+    assert "未识别到风险或关注项" in report
+    assert "HTTP 204" in report
+
+
+def test_page_limit_is_reported_as_incomplete_coverage(tmp_path) -> None:
+    def handler(request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html"},
+            text='<a href="/one">One</a><a href="/two">Two</a>',
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions(max_pages=1, retry_attempts=0))
+    assert scan.status == "completed_with_warnings"
+    assert any(failure.code == "coverage_limit_reached" for failure in scan.failures)
+    assert "coverage_limit_reached" in service.read_report(scan.id)
+
+
+def test_active_duplicate_submission_returns_same_parent_task(tmp_path) -> None:
+    class HoldingDispatcher:
+        def __init__(self):
+            self.ids = []
+
+        def submit(self, scan_run_id, callback):
+            self.ids.append(scan_run_id)
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    pipeline = ScanPipeline(
+        policy=policy,
+        gateway=HttpScanGateway(policy, transport=httpx.MockTransport(lambda request: None)),
+        report_service=ScanReportService(tmp_path / "reports"),
+    )
+    dispatcher = HoldingDispatcher()
+    service = ScanApplicationService(settings=settings, pipeline=pipeline, dispatcher=dispatcher)
+    first = service.start_scan("http://127.0.0.1/")
+    second = service.start_scan("http://127.0.0.1/")
+    assert first.id == second.id
+    assert dispatcher.ids == [first.id]
+
+
+def test_overall_timeout_is_persisted_and_gets_failure_report(tmp_path) -> None:
+    class AdvancingClock:
+        def __init__(self):
+            self.value = 0.0
+
+        def __call__(self):
+            self.value += 0.6
+            return self.value
+
+    service = _service(
+        tmp_path,
+        lambda request: httpx.Response(204),
+        clock=AdvancingClock(),
+    )
+    scan = service.start_scan(
+        "http://127.0.0.1/", ScanOptions(overall_timeout_seconds=1, retry_attempts=0)
+    )
+    assert scan.status == "failed"
+    assert scan.error_code == "overall_timeout"
+    assert scan.report_path is not None
+    assert "overall_timeout" in service.read_report(scan.id)
+
+
+def test_web_and_http_entry_run_end_to_end(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    url = "http://127.0.0.1:8765/"
+
+    def handler(request):
+        body = '<html><title>Local Fixture</title><a href="/asset">Asset</a></html>'
+        if request.url.path == "/asset":
+            body = "<html><title>Asset Detail</title><p>safe local data</p></html>"
+        return httpx.Response(200, headers={"content-type": "text/html"}, text=body)
+
+    service = _service(tmp_path, handler)
+    monkeypatch.setattr(main_app, "ScanApplicationService", lambda settings: service)
+    with TestClient(main_app.create_app()) as client:
+        submitted = client.post("/scans", data={"url": url}, follow_redirects=False)
+        assert submitted.status_code == 303
+        scan_id = int(submitted.headers["location"].rsplit("/", 1)[-1])
+        payload = client.get(f"/api/scans/{scan_id}").json()
+        assert payload["status"] == "completed"
+        detail = client.get(f"/scans/{scan_id}")
+        report = client.get(f"/api/scans/{scan_id}/report")
+        download = client.get(f"/api/scans/{scan_id}/report?download=true")
+        api_submission = client.post("/api/scans", json={"url": url})
+    assert detail.status_code == 200
+    assert "Local Fixture" in detail.text
+    assert report.status_code == 200
+    assert "Asset Detail" in report.text
+    assert download.status_code == 200
+    assert api_submission.status_code == 202
+    assert api_submission.json()["status"] == "completed"
+    assert (tmp_path / "reports" / f"scan-{scan_id}.md").exists()
+
+
+def test_http_entry_rejects_invalid_url_before_dispatch(monkeypatch) -> None:
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+        ),
+        dispatcher=InlineScanDispatcher(),
+    )
+    monkeypatch.setattr(main_app, "ScanApplicationService", lambda settings: service)
+    with TestClient(main_app.create_app()) as client:
+        response = client.post("/api/scans", json={"url": "file:///etc/passwd"})
+    assert response.status_code == 400
+    assert "http or https" in response.json()["detail"]

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -153,6 +153,31 @@ def test_complete_pipeline_persists_structured_data_and_report(tmp_path) -> None
     assert "E" in report
 
 
+def test_binary_response_is_described_without_polluting_markdown(tmp_path) -> None:
+    binary_body = b"\x00\x01\x02binary\x7f\x80data"
+
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<a href="/favicon.ico">Icon</a>',
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "image/x-icon"},
+            content=binary_body,
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions(max_pages=2, retry_attempts=0))
+    report = service.read_report(scan.id)
+    assert "non-text response omitted" in report
+    assert "content-type=image/x-icon" in report
+    assert f"size={len(binary_body)} bytes" in report
+    assert "\x00" not in report
+
+
 def test_partial_page_failure_completes_with_warning_and_diagnostic_report(tmp_path) -> None:
     def handler(request):
         if request.url.path == "/":


### PR DESCRIPTION
## What

- Replace the CLI-driven scan chain with a core `ScanApplicationService.start_scan(url, options)`.
- Persist scan runs, per-stage progress, retries, assets, evidence, findings, failures, and report locations.
- Execute one automatic six-stage pipeline: validation, discovery, collection, normalization, analysis, and reporting.
- Make Web, HTTP API, and CLI thin adapters over the same application service.
- Add URL safety controls for protocols, private-network policy, timeouts, concurrency, retries, redirects, and SSRF-resistant address validation.
- Generate structured Markdown reports directly from persisted scan data and omit binary response bodies from readable evidence previews.
- Update README, architecture/deployment/migration documentation, and the GitHub Pages frontend for the one-URL workflow.

## Why

The visible one-click experience previously still depended on manually chained CLI-era business logic. This refactor makes “submit one URL, receive a readable evidence-backed report” the system’s actual execution model.

## Impact

- Users submit a URL once and can follow real persisted stage progress through Web or API.
- Partial failures and configured coverage limits are explicit in the final report.
- Existing legacy commands remain available, with migration guidance.
- Private targets are denied by default and can be enabled explicitly for authorized labs.
- Binary assets such as favicons are recorded as typed/size-bounded evidence without polluting Markdown with control bytes.

## Verification

- `.venv/bin/pytest -q` — 86 passed
- `.venv/bin/ruff check .` — passed
- `.venv/bin/ruff format --check .` — 143 files formatted
- `git diff --check` — passed
- Real TCP end-to-end run against OWASP Juice Shop at `127.0.0.1:13000` completed all 6 stages and generated `exports/scan-reports/scan-1.md`
- Juice Shop report contains 10 assets, 10 evidence records, one passive finding, explicit bounded-coverage warning, every required section, and no binary control bytes
- GitHub Pages frontend checked in a real browser: updated navigation/content rendered correctly with zero console errors or warnings
- GitHub Actions — Python 3.10, Python 3.12, Docker build, and CLI smoke all pass
