### PR TITLE
建立统一验证运行与三上下文采集

### DIFF
--- a/app/db/bootstrap.py
+++ b/app/db/bootstrap.py
@@ -7,7 +7,7 @@ from alembic import command
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -18,6 +18,14 @@ logger = get_logger(__name__)
 _DATABASE_URL: str | None = None
 _ENGINE: Engine | None = None
 _SESSION_FACTORY: sessionmaker[Session] | None = None
+
+
+def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record) -> None:
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("PRAGMA foreign_keys=ON")
+    finally:
+        cursor.close()
 
 
 def _migration_assets_root() -> Path:
@@ -106,6 +114,8 @@ def init_database(database_url: str) -> None:
         pool_pre_ping=True,
         connect_args=connect_args,
     )
+    if database_url.startswith("sqlite"):
+        event.listen(_ENGINE, "connect", _enable_sqlite_foreign_keys)
     _SESSION_FACTORY = sessionmaker(
         bind=_ENGINE,
         autoflush=False,

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -29,6 +29,10 @@ class ObservedEndpoint:
     set_cookie_names: list[str] = field(default_factory=list)
     cookie_issue_flags: list[str] = field(default_factory=list)
     parameters: dict[str, list[str]] = field(default_factory=dict)
+    request_url: str | None = None
+    request_headers: dict[str, str] = field(default_factory=dict)
+    request_body: bytes | None = None
+    response_headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -132,10 +136,19 @@ class SyncPlaywrightInventoryGateway:
                     request_counter += 1
                     set_cookie_names, cookie_issue_flags = self._extract_cookie_metadata(response)
                     content_type = response.header_value("content-type")
+                    try:
+                        request_body = request.post_data_buffer
+                    except Exception:
+                        request_body = None
+                    try:
+                        response_headers = response.all_headers()
+                    except Exception:
+                        response_headers = {}
                     endpoints.append(
                         ObservedEndpoint(
                             method=request.method.upper(),
                             url=self._normalize_endpoint_url(request.url),
+                            request_url=request.url,
                             path=urlparse(request.url).path or "/",
                             status_code=response.status,
                             observed_at=datetime.now(timezone.utc),
@@ -145,6 +158,9 @@ class SyncPlaywrightInventoryGateway:
                             set_cookie_names=set_cookie_names,
                             cookie_issue_flags=cookie_issue_flags,
                             parameters=self._extract_parameters(request),
+                            request_headers=dict(request.headers),
+                            request_body=request_body,
+                            response_headers=response_headers,
                         )
                     )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@
 
 from app.models.audit_event import AuditEvent
 from app.models.auth_session import AuthSession
+from app.models.coverage_difference import CoverageDifference
 from app.models.credential_profile import CredentialProfile
 from app.models.evidence import Evidence
 from app.models.finding import Finding
@@ -11,7 +12,10 @@ from app.models.inventory_endpoint import InventoryEndpoint
 from app.models.inventory_page import InventoryPage
 from app.models.inventory_parameter import InventoryParameter
 from app.models.inventory_run import InventoryRun
+from app.models.replay_execution import ReplayExecution
+from app.models.scan_context import ScanContext
 from app.models.scan_job import ScanJob
+from app.models.scan_request import ScanRequest
 from app.models.scan_run import (
     ScanAsset,
     ScanEvidence,
@@ -25,6 +29,7 @@ from app.models.target import Target
 __all__ = [
     "AuditEvent",
     "AuthSession",
+    "CoverageDifference",
     "CredentialProfile",
     "Evidence",
     "Finding",
@@ -34,7 +39,10 @@ __all__ = [
     "InventoryPage",
     "InventoryParameter",
     "InventoryRun",
+    "ReplayExecution",
+    "ScanContext",
     "ScanJob",
+    "ScanRequest",
     "ScanRun",
     "ScanRunStage",
     "ScanAsset",

--- a/app/models/auth_session.py
+++ b/app/models/auth_session.py
@@ -40,5 +40,6 @@ class AuthSession(TimestampMixin, Base):
     scan_job = relationship("ScanJob", back_populates="auth_sessions")
     audit_events = relationship("AuditEvent", back_populates="auth_session")
     inventory_runs = relationship("InventoryRun", back_populates="auth_session")
+    scan_contexts = relationship("ScanContext", back_populates="auth_session")
     findings = relationship("Finding", back_populates="auth_session")
     evidences = relationship("Evidence", back_populates="auth_session")

--- a/app/models/coverage_difference.py
+++ b/app/models/coverage_difference.py
@@ -1,0 +1,33 @@
+"""匿名、用户与管理员上下文之间的被动覆盖差异。"""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, Boolean, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin
+
+
+class CoverageDifference(TimestampMixin, Base):
+    __tablename__ = "coverage_differences"
+    __table_args__ = (UniqueConstraint("scan_run_id", "identity_key"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    identity_key: Mapped[str] = mapped_column(String(1000), index=True)
+    classification: Mapped[str] = mapped_column(String(64), index=True)
+    anonymous_state: Mapped[str] = mapped_column(String(32), default="unknown")
+    user_state: Mapped[str] = mapped_column(String(32), default="unknown")
+    admin_state: Mapped[str] = mapped_column(String(32), default="unknown")
+    anonymous_present: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    user_present: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    admin_present: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    context_summaries: Mapped[dict[str, object]] = mapped_column(
+        MutableDict.as_mutable(JSON), default=dict
+    )
+    confidence: Mapped[str] = mapped_column(String(32), default="low", index=True)
+    diagnostic: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    scan_run = relationship("ScanRun", back_populates="coverage_differences")

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -33,6 +33,34 @@ class JobStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class AssessmentMode(str, Enum):
+    QUICK = "quick"
+    AUTHENTICATED_COVERAGE = "authenticated_coverage"
+
+
+class ContextKind(str, Enum):
+    ANONYMOUS = "anonymous"
+    USER = "user"
+    ADMIN = "admin"
+
+
+class ReplayVerdict(str, Enum):
+    BLOCKED = "blocked"
+    EQUIVALENT_ACCESS = "equivalent_access"
+    CHANGED_RESPONSE = "changed_response"
+    INCONCLUSIVE = "inconclusive"
+
+
+class CompletenessStatus(str, Enum):
+    PENDING = "pending"
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    MISSING_USER_CONTEXT = "missing_user_context"
+    MISSING_ADMIN_CONTEXT = "missing_admin_context"
+    ACTIVE_CHECKS_INCOMPLETE = "active_checks_incomplete"
+    LEGACY_SINGLE_CONTEXT = "legacy_single_context"
+
+
 class SessionStatus(str, Enum):
     ACTIVE = "active"
     EXPIRED = "expired"

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -88,6 +88,7 @@ class AuditEventType(str, Enum):
     LOGIN_ATTEMPT = "login_attempt"
     SESSION_VALIDATION = "session_validation"
     SESSION_REFRESH = "session_refresh"
+    CONTEXT_ESTABLISHMENT = "context_establishment"
     FINDING_STATUS_UPDATE = "finding_status_update"
     EVIDENCE_EXPORT = "evidence_export"
     RETEST_RUN = "retest_run"

--- a/app/models/replay_execution.py
+++ b/app/models/replay_execution.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -21,13 +30,32 @@ class ReplayExecution(TimestampMixin, Base):
             "target_context_id",
             "policy_hash",
         ),
+        ForeignKeyConstraint(
+            ["scan_run_id", "source_request_id", "source_context_id"],
+            [
+                "scan_requests.scan_run_id",
+                "scan_requests.id",
+                "scan_requests.source_context_id",
+            ],
+            name="fk_replay_executions_run_source_request_context",
+        ),
+        ForeignKeyConstraint(
+            ["scan_run_id", "source_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_replay_executions_run_source_context",
+        ),
+        ForeignKeyConstraint(
+            ["scan_run_id", "target_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_replay_executions_run_target_context",
+        ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
-    source_request_id: Mapped[int] = mapped_column(ForeignKey("scan_requests.id"), index=True)
-    source_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
-    target_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
+    source_request_id: Mapped[int] = mapped_column(index=True)
+    source_context_id: Mapped[int] = mapped_column(index=True)
+    target_context_id: Mapped[int] = mapped_column(index=True)
     policy_snapshot: Mapped[dict[str, object]] = mapped_column(
         MutableDict.as_mutable(JSON), default=dict
     )
@@ -48,14 +76,21 @@ class ReplayExecution(TimestampMixin, Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     scan_run = relationship("ScanRun", back_populates="replay_executions")
-    source_request = relationship("ScanRequest", back_populates="replay_executions")
+    source_request = relationship(
+        "ScanRequest",
+        back_populates="replay_executions",
+        foreign_keys=[scan_run_id, source_request_id, source_context_id],
+        viewonly=True,
+    )
     source_context = relationship(
         "ScanContext",
         back_populates="source_replay_executions",
-        foreign_keys=[source_context_id],
+        foreign_keys=[scan_run_id, source_context_id],
+        viewonly=True,
     )
     target_context = relationship(
         "ScanContext",
         back_populates="target_replay_executions",
-        foreign_keys=[target_context_id],
+        foreign_keys=[scan_run_id, target_context_id],
+        viewonly=True,
     )

--- a/app/models/replay_execution.py
+++ b/app/models/replay_execution.py
@@ -1,0 +1,61 @@
+"""受策略约束的跨上下文授权重放执行记录。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.ext.mutable import MutableDict, MutableList
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin
+
+
+class ReplayExecution(TimestampMixin, Base):
+    __tablename__ = "replay_executions"
+    __table_args__ = (
+        UniqueConstraint(
+            "scan_run_id",
+            "source_request_id",
+            "target_context_id",
+            "policy_hash",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    source_request_id: Mapped[int] = mapped_column(ForeignKey("scan_requests.id"), index=True)
+    source_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
+    target_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
+    policy_snapshot: Mapped[dict[str, object]] = mapped_column(
+        MutableDict.as_mutable(JSON), default=dict
+    )
+    policy_hash: Mapped[str] = mapped_column(String(128))
+    status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    redirects: Mapped[list[str]] = mapped_column(MutableList.as_mutable(JSON), default=list)
+    response_status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    response_final_url_redacted: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    response_fingerprint: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    response_summary_redacted: Mapped[dict[str, object]] = mapped_column(
+        MutableDict.as_mutable(JSON), default=dict
+    )
+    verdict: Mapped[str | None] = mapped_column(String(40), nullable=True, index=True)
+    verdict_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    scan_run = relationship("ScanRun", back_populates="replay_executions")
+    source_request = relationship("ScanRequest", back_populates="replay_executions")
+    source_context = relationship(
+        "ScanContext",
+        back_populates="source_replay_executions",
+        foreign_keys=[source_context_id],
+    )
+    target_context = relationship(
+        "ScanContext",
+        back_populates="target_replay_executions",
+        foreign_keys=[target_context_id],
+    )

--- a/app/models/scan_context.py
+++ b/app/models/scan_context.py
@@ -1,0 +1,60 @@
+"""每次统一验证运行中的身份上下文。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin
+
+
+class ScanContext(TimestampMixin, Base):
+    __tablename__ = "scan_contexts"
+    __table_args__ = (UniqueConstraint("scan_run_id", "kind"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    kind: Mapped[str] = mapped_column(String(32), index=True)
+    credential_profile_id: Mapped[int | None] = mapped_column(
+        ForeignKey("credential_profiles.id"), nullable=True, index=True
+    )
+    auth_session_id: Mapped[int | None] = mapped_column(
+        ForeignKey("auth_sessions.id"), nullable=True, index=True
+    )
+    status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    login_status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    session_validation_status: Mapped[str] = mapped_column(
+        String(40), default="pending", index=True
+    )
+    collection_status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    completeness: Mapped[str] = mapped_column(String(64), default="pending", index=True)
+    asset_count: Mapped[int] = mapped_column(Integer, default=0)
+    request_count: Mapped[int] = mapped_column(Integer, default=0)
+    failure_count: Mapped[int] = mapped_column(Integer, default=0)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    scan_run = relationship("ScanRun", back_populates="contexts")
+    credential_profile = relationship("CredentialProfile")
+    auth_session = relationship("AuthSession", back_populates="scan_contexts")
+    assets = relationship("ScanAsset", back_populates="context")
+    requests = relationship(
+        "ScanRequest",
+        back_populates="source_context",
+        foreign_keys="ScanRequest.source_context_id",
+    )
+    source_replay_executions = relationship(
+        "ReplayExecution",
+        back_populates="source_context",
+        foreign_keys="ReplayExecution.source_context_id",
+    )
+    target_replay_executions = relationship(
+        "ReplayExecution",
+        back_populates="target_context",
+        foreign_keys="ReplayExecution.target_context_id",
+    )

--- a/app/models/scan_context.py
+++ b/app/models/scan_context.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -13,7 +21,14 @@ from app.models.mixins import TimestampMixin
 
 class ScanContext(TimestampMixin, Base):
     __tablename__ = "scan_contexts"
-    __table_args__ = (UniqueConstraint("scan_run_id", "kind"),)
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('anonymous', 'user', 'admin')",
+            name="ck_scan_contexts_kind",
+        ),
+        UniqueConstraint("scan_run_id", "kind", name="uq_scan_contexts_run_kind"),
+        UniqueConstraint("scan_run_id", "id", name="uq_scan_contexts_run_id_id"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
@@ -42,19 +57,27 @@ class ScanContext(TimestampMixin, Base):
     scan_run = relationship("ScanRun", back_populates="contexts")
     credential_profile = relationship("CredentialProfile")
     auth_session = relationship("AuthSession", back_populates="scan_contexts")
-    assets = relationship("ScanAsset", back_populates="context")
+    assets = relationship(
+        "ScanAsset",
+        back_populates="context",
+        foreign_keys="[ScanAsset.scan_run_id, ScanAsset.context_id]",
+        viewonly=True,
+    )
     requests = relationship(
         "ScanRequest",
         back_populates="source_context",
-        foreign_keys="ScanRequest.source_context_id",
+        foreign_keys="[ScanRequest.scan_run_id, ScanRequest.source_context_id]",
+        viewonly=True,
     )
     source_replay_executions = relationship(
         "ReplayExecution",
         back_populates="source_context",
-        foreign_keys="ReplayExecution.source_context_id",
+        foreign_keys=("[ReplayExecution.scan_run_id, ReplayExecution.source_context_id]"),
+        viewonly=True,
     )
     target_replay_executions = relationship(
         "ReplayExecution",
         back_populates="target_context",
-        foreign_keys="ReplayExecution.target_context_id",
+        foreign_keys=("[ReplayExecution.scan_run_id, ReplayExecution.target_context_id]"),
+        viewonly=True,
     )

--- a/app/models/scan_request.py
+++ b/app/models/scan_request.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-from sqlalchemy import JSON, Boolean, ForeignKey, String, Text
+from urllib.parse import parse_qsl, quote, urlsplit, urlunsplit
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.mutable import MutableList
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from app.db.base import Base
 from app.models.mixins import TimestampMixin
@@ -12,16 +22,31 @@ from app.models.mixins import TimestampMixin
 
 class ScanRequest(TimestampMixin, Base):
     __tablename__ = "scan_requests"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["scan_run_id", "source_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_scan_requests_run_source_context",
+        ),
+        ForeignKeyConstraint(
+            ["scan_run_id", "asset_id"],
+            ["scan_assets.scan_run_id", "scan_assets.id"],
+            name="fk_scan_requests_run_asset",
+        ),
+        UniqueConstraint(
+            "scan_run_id",
+            "id",
+            "source_context_id",
+            name="uq_scan_requests_run_id_source_context",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
-    source_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
-    asset_id: Mapped[int | None] = mapped_column(
-        ForeignKey("scan_assets.id"), nullable=True, index=True
-    )
+    source_context_id: Mapped[int] = mapped_column(index=True)
+    asset_id: Mapped[int | None] = mapped_column(nullable=True, index=True)
     method: Mapped[str] = mapped_column(String(16), index=True)
-    normalized_url: Mapped[str] = mapped_column(String(1000))
-    redacted_url: Mapped[str] = mapped_column(String(1000))
+    normalized_redacted_url: Mapped[str] = mapped_column(String(1000))
     header_names: Mapped[list[str]] = mapped_column(MutableList.as_mutable(JSON), default=list)
     fingerprint: Mapped[str] = mapped_column(String(128), index=True)
     replay_allowed: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -29,11 +54,78 @@ class ScanRequest(TimestampMixin, Base):
     replay_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     protected_storage_ref: Mapped[str] = mapped_column(String(1000))
 
+    @classmethod
+    def from_capture(
+        cls,
+        *,
+        scan_run_id: int,
+        source_context_id: int,
+        method: str,
+        raw_url: str,
+        header_names: list[str],
+        fingerprint: str,
+        protected_storage_ref: str,
+        asset_id: int | None = None,
+    ) -> ScanRequest:
+        return cls(
+            scan_run_id=scan_run_id,
+            source_context_id=source_context_id,
+            asset_id=asset_id,
+            method=method.upper(),
+            normalized_redacted_url=_normalize_and_redact_url(raw_url),
+            header_names=sorted(set(header_names)),
+            fingerprint=fingerprint,
+            protected_storage_ref=protected_storage_ref,
+        )
+
+    @validates("normalized_redacted_url")
+    def validate_normalized_redacted_url(self, _key: str, value: str) -> str:
+        parsed = urlsplit(value)
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("normalized_redacted_url 必须脱敏。")
+        if any(
+            query_value not in {"", "[REDACTED]"}
+            for _name, query_value in parse_qsl(parsed.query, keep_blank_values=True)
+        ):
+            raise ValueError("normalized_redacted_url 必须脱敏。")
+        return value
+
     scan_run = relationship("ScanRun", back_populates="requests")
     source_context = relationship(
         "ScanContext",
         back_populates="requests",
-        foreign_keys=[source_context_id],
+        foreign_keys=[scan_run_id, source_context_id],
+        viewonly=True,
     )
-    asset = relationship("ScanAsset", back_populates="requests")
-    replay_executions = relationship("ReplayExecution", back_populates="source_request")
+    asset = relationship(
+        "ScanAsset",
+        back_populates="requests",
+        foreign_keys=[scan_run_id, asset_id],
+        viewonly=True,
+    )
+    replay_executions = relationship(
+        "ReplayExecution",
+        back_populates="source_request",
+        foreign_keys=(
+            "[ReplayExecution.scan_run_id, ReplayExecution.source_request_id, "
+            "ReplayExecution.source_context_id]"
+        ),
+        viewonly=True,
+    )
+
+
+def _normalize_and_redact_url(raw_url: str) -> str:
+    parsed = urlsplit(raw_url)
+    host = (parsed.hostname or "").lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = parsed.port
+    if port is not None and not (
+        (parsed.scheme.lower() == "http" and port == 80)
+        or (parsed.scheme.lower() == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+    path = parsed.path or "/"
+    query_names = sorted(name for name, _value in parse_qsl(parsed.query, keep_blank_values=True))
+    query = "&".join(f"{quote(name, safe='')}=[REDACTED]" for name in query_names)
+    return urlunsplit((parsed.scheme.lower(), host, path, query, ""))

--- a/app/models/scan_request.py
+++ b/app/models/scan_request.py
@@ -1,0 +1,39 @@
+"""可审计且不直接保存敏感精确值的捕获请求。"""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, Boolean, ForeignKey, String, Text
+from sqlalchemy.ext.mutable import MutableList
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin
+
+
+class ScanRequest(TimestampMixin, Base):
+    __tablename__ = "scan_requests"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    source_context_id: Mapped[int] = mapped_column(ForeignKey("scan_contexts.id"), index=True)
+    asset_id: Mapped[int | None] = mapped_column(
+        ForeignKey("scan_assets.id"), nullable=True, index=True
+    )
+    method: Mapped[str] = mapped_column(String(16), index=True)
+    normalized_url: Mapped[str] = mapped_column(String(1000))
+    redacted_url: Mapped[str] = mapped_column(String(1000))
+    header_names: Mapped[list[str]] = mapped_column(MutableList.as_mutable(JSON), default=list)
+    fingerprint: Mapped[str] = mapped_column(String(128), index=True)
+    replay_allowed: Mapped[bool] = mapped_column(Boolean, default=False)
+    replay_status: Mapped[str] = mapped_column(String(40), default="pending", index=True)
+    replay_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    protected_storage_ref: Mapped[str] = mapped_column(String(1000))
+
+    scan_run = relationship("ScanRun", back_populates="requests")
+    source_context = relationship(
+        "ScanContext",
+        back_populates="requests",
+        foreign_keys=[source_context_id],
+    )
+    asset = relationship("ScanAsset", back_populates="requests")
+    replay_executions = relationship("ReplayExecution", back_populates="source_request")

--- a/app/models/scan_run.py
+++ b/app/models/scan_run.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -107,13 +117,17 @@ class ScanAsset(Base):
             "url",
             name="uq_scan_assets_run_context_type_url",
         ),
+        UniqueConstraint("scan_run_id", "id", name="uq_scan_assets_run_id_id"),
+        ForeignKeyConstraint(
+            ["scan_run_id", "context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_scan_assets_run_context",
+        ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
-    context_id: Mapped[int | None] = mapped_column(
-        ForeignKey("scan_contexts.id"), nullable=True, index=True
-    )
+    context_id: Mapped[int | None] = mapped_column(nullable=True, index=True)
     identity_key: Mapped[str | None] = mapped_column(String(1000), nullable=True, index=True)
     asset_type: Mapped[str] = mapped_column(String(40), index=True)
     url: Mapped[str] = mapped_column(String(1000))
@@ -126,8 +140,18 @@ class ScanAsset(Base):
     discovered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     scan_run = relationship("ScanRun", back_populates="assets")
-    context = relationship("ScanContext", back_populates="assets")
-    requests = relationship("ScanRequest", back_populates="asset")
+    context = relationship(
+        "ScanContext",
+        back_populates="assets",
+        foreign_keys=[scan_run_id, context_id],
+        viewonly=True,
+    )
+    requests = relationship(
+        "ScanRequest",
+        back_populates="asset",
+        foreign_keys="[ScanRequest.scan_run_id, ScanRequest.asset_id]",
+        viewonly=True,
+    )
 
 
 class ScanEvidence(Base):

--- a/app/models/scan_run.py
+++ b/app/models/scan_run.py
@@ -14,12 +14,23 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
 )
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from app.db.base import Base
 from app.models.mixins import TimestampMixin
+
+TERMINAL_SCAN_RUN_STATUSES = frozenset(
+    {
+        "completed",
+        "completed_with_warnings",
+        "failed",
+        "incomplete",
+        "interrupted",
+    }
+)
 
 
 class ScanRun(TimestampMixin, Base):
@@ -206,3 +217,12 @@ class ScanFailure(Base):
     occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     scan_run = relationship("ScanRun", back_populates="failures")
+
+
+@event.listens_for(Session, "before_flush")
+def clear_terminal_scan_run_active_keys(session: Session, _flush_context, _instances) -> None:
+    """Enforce the active-key invariant at the shared ORM persistence boundary."""
+
+    for instance in session.new.union(session.dirty):
+        if isinstance(instance, ScanRun) and instance.status in TERMINAL_SCAN_RUN_STATUSES:
+            instance.active_key = None

--- a/app/models/scan_run.py
+++ b/app/models/scan_run.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -16,6 +16,13 @@ class ScanRun(TimestampMixin, Base):
     __tablename__ = "scan_runs"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    mode: Mapped[str] = mapped_column(String(40), default="quick", index=True)
+    target_id: Mapped[int | None] = mapped_column(
+        ForeignKey("targets.id"), nullable=True, index=True
+    )
+    source_run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("scan_runs.id"), nullable=True, index=True
+    )
     input_url: Mapped[str] = mapped_column(String(1000))
     normalized_url: Mapped[str] = mapped_column(String(1000), index=True)
     active_key: Mapped[str | None] = mapped_column(String(64), unique=True, nullable=True)
@@ -24,6 +31,12 @@ class ScanRun(TimestampMixin, Base):
     progress: Mapped[int] = mapped_column(Integer, default=0)
     options: Mapped[dict[str, object]] = mapped_column(MutableDict.as_mutable(JSON), default=dict)
     retry_count: Mapped[int] = mapped_column(Integer, default=0)
+    active_checks_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    authorization_confirmed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    authorization_confirmed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    completeness: Mapped[str] = mapped_column(String(64), default="pending", index=True)
     report_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     error_code: Mapped[str | None] = mapped_column(String(120), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -33,8 +46,33 @@ class ScanRun(TimestampMixin, Base):
         DateTime(timezone=True), nullable=True
     )
 
+    target = relationship("Target")
+    source_run = relationship(
+        "ScanRun",
+        back_populates="derived_runs",
+        foreign_keys=[source_run_id],
+        remote_side=[id],
+    )
+    derived_runs = relationship(
+        "ScanRun",
+        back_populates="source_run",
+        foreign_keys=[source_run_id],
+    )
     stages = relationship("ScanRunStage", back_populates="scan_run", cascade="all, delete-orphan")
+    contexts = relationship(
+        "ScanContext",
+        back_populates="scan_run",
+        cascade="all, delete-orphan",
+        order_by="ScanContext.id",
+    )
     assets = relationship("ScanAsset", back_populates="scan_run", cascade="all, delete-orphan")
+    requests = relationship("ScanRequest", back_populates="scan_run", cascade="all, delete-orphan")
+    coverage_differences = relationship(
+        "CoverageDifference", back_populates="scan_run", cascade="all, delete-orphan"
+    )
+    replay_executions = relationship(
+        "ReplayExecution", back_populates="scan_run", cascade="all, delete-orphan"
+    )
     evidence = relationship("ScanEvidence", back_populates="scan_run", cascade="all, delete-orphan")
     findings = relationship("ScanFinding", back_populates="scan_run", cascade="all, delete-orphan")
     failures = relationship("ScanFailure", back_populates="scan_run", cascade="all, delete-orphan")
@@ -61,10 +99,22 @@ class ScanRunStage(Base):
 
 class ScanAsset(Base):
     __tablename__ = "scan_assets"
-    __table_args__ = (UniqueConstraint("scan_run_id", "asset_type", "url"),)
+    __table_args__ = (
+        UniqueConstraint(
+            "scan_run_id",
+            "context_id",
+            "asset_type",
+            "url",
+            name="uq_scan_assets_run_context_type_url",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     scan_run_id: Mapped[int] = mapped_column(ForeignKey("scan_runs.id"), index=True)
+    context_id: Mapped[int | None] = mapped_column(
+        ForeignKey("scan_contexts.id"), nullable=True, index=True
+    )
+    identity_key: Mapped[str | None] = mapped_column(String(1000), nullable=True, index=True)
     asset_type: Mapped[str] = mapped_column(String(40), index=True)
     url: Mapped[str] = mapped_column(String(1000))
     method: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -76,6 +126,8 @@ class ScanAsset(Base):
     discovered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     scan_run = relationship("ScanRun", back_populates="assets")
+    context = relationship("ScanContext", back_populates="assets")
+    requests = relationship("ScanRequest", back_populates="asset")
 
 
 class ScanEvidence(Base):

--- a/app/schemas/assessment.py
+++ b/app/schemas/assessment.py
@@ -1,0 +1,125 @@
+"""统一 quick 与认证覆盖验证的传输协议。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind, ReplayVerdict
+from app.schemas.scan import ScanOptions
+
+
+class AssessmentStartRequest(BaseModel):
+    url: str = Field(min_length=1, max_length=1000)
+    mode: AssessmentMode = AssessmentMode.QUICK
+    target_id: int | None = Field(default=None, gt=0)
+    source_run_id: int | None = Field(default=None, gt=0)
+    user_profile_id: int | None = Field(default=None, gt=0)
+    admin_profile_id: int | None = Field(default=None, gt=0)
+    active_checks_enabled: bool = False
+    authorization_confirmed: bool = False
+    authorization_confirmed_by: str | None = Field(default=None, max_length=255)
+    options: ScanOptions = Field(default_factory=ScanOptions)
+
+    @model_validator(mode="after")
+    def validate_mode_and_authorization(self) -> AssessmentStartRequest:
+        profile_ids = (self.user_profile_id, self.admin_profile_id)
+        if self.mode == AssessmentMode.QUICK and any(item is not None for item in profile_ids):
+            raise ValueError("quick 模式不接受认证凭证档案。")
+        if self.mode == AssessmentMode.AUTHENTICATED_COVERAGE and any(
+            item is None for item in profile_ids
+        ):
+            raise ValueError("authenticated_coverage 模式必须同时提供 user/admin 凭证档案。")
+        if self.active_checks_enabled and not self.authorization_confirmed:
+            raise ValueError("启用主动重放前必须显式确认授权。")
+        return self
+
+
+class ScanContextView(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    kind: ContextKind
+    credential_profile_id: int | None = None
+    auth_session_id: int | None = None
+    status: str
+    login_status: str = "pending"
+    session_validation_status: str = "pending"
+    collection_status: str = "pending"
+    completeness: str = CompletenessStatus.PENDING.value
+    asset_count: int = 0
+    request_count: int = 0
+    failure_count: int = 0
+    error_code: str | None = None
+    error_message: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class CoverageDifferenceView(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    identity_key: str
+    classification: str
+    anonymous_state: str = "unknown"
+    user_state: str = "unknown"
+    admin_state: str = "unknown"
+    anonymous_present: bool | None = None
+    user_present: bool | None = None
+    admin_present: bool | None = None
+    context_summaries: dict[str, object] = Field(default_factory=dict)
+    confidence: str = "low"
+    diagnostic: str | None = None
+
+
+class ReplayExecutionView(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    source_request_id: int
+    source_context_id: int
+    target_context_id: int
+    status: str
+    verdict: ReplayVerdict | None = None
+    verdict_reason: str | None = None
+    response_status_code: int | None = None
+    response_final_url_redacted: str | None = None
+    response_fingerprint: str | None = None
+    response_summary_redacted: dict[str, object] = Field(default_factory=dict)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class AssessmentRunView(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    mode: AssessmentMode
+    target_id: int | None = None
+    source_run_id: int | None = None
+    status: str = "queued"
+    current_stage: str = "queued"
+    progress: int = 0
+    completeness: str
+    active_checks_enabled: bool
+    authorization_confirmed_at: datetime | None = None
+    authorization_confirmed_by: str | None = None
+    contexts: list[ScanContextView] = Field(default_factory=list)
+    context_counts: dict[str, int] = Field(
+        default_factory=lambda: {"anonymous": 0, "user": 0, "admin": 0}
+    )
+    difference_count: int = Field(default=0, ge=0)
+    replay_count: int = Field(default=0, ge=0)
+
+    @field_validator("context_counts")
+    @classmethod
+    def validate_context_counts(cls, value: dict[str, int]) -> dict[str, int]:
+        allowed_keys = {item.value for item in ContextKind}
+        unknown_keys = set(value) - allowed_keys
+        if unknown_keys:
+            raise ValueError("context_counts 只能包含 anonymous、user、admin。")
+        if any(count < 0 for count in value.values()):
+            raise ValueError("context_counts 不能包含负数。")
+        return value

--- a/app/schemas/assessment.py
+++ b/app/schemas/assessment.py
@@ -6,8 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind, ReplayVerdict
-from app.schemas.scan import ScanOptions
+from app.models.enums import AssessmentMode, ContextKind, ReplayVerdict
+from app.schemas.scan import ScanOptions, ScanRunView
 
 
 class AssessmentStartRequest(BaseModel):
@@ -34,27 +34,6 @@ class AssessmentStartRequest(BaseModel):
         if self.active_checks_enabled and not self.authorization_confirmed:
             raise ValueError("启用主动重放前必须显式确认授权。")
         return self
-
-
-class ScanContextView(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    kind: ContextKind
-    credential_profile_id: int | None = None
-    auth_session_id: int | None = None
-    status: str
-    login_status: str = "pending"
-    session_validation_status: str = "pending"
-    collection_status: str = "pending"
-    completeness: str = CompletenessStatus.PENDING.value
-    asset_count: int = 0
-    request_count: int = 0
-    failure_count: int = 0
-    error_code: str | None = None
-    error_message: str | None = None
-    started_at: datetime | None = None
-    finished_at: datetime | None = None
 
 
 class CoverageDifferenceView(BaseModel):
@@ -92,21 +71,13 @@ class ReplayExecutionView(BaseModel):
     finished_at: datetime | None = None
 
 
-class AssessmentRunView(BaseModel):
+class AssessmentRunView(ScanRunView):
     model_config = ConfigDict(from_attributes=True)
 
-    id: int
-    mode: AssessmentMode
-    target_id: int | None = None
-    source_run_id: int | None = None
-    status: str = "queued"
-    current_stage: str = "queued"
-    progress: int = 0
     completeness: str
     active_checks_enabled: bool
     authorization_confirmed_at: datetime | None = None
     authorization_confirmed_by: str | None = None
-    contexts: list[ScanContextView] = Field(default_factory=list)
     context_counts: dict[str, int] = Field(
         default_factory=lambda: {"anonymous": 0, "user": 0, "admin": 0}
     )

--- a/app/schemas/scan.py
+++ b/app/schemas/scan.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
 
 
 class ScanRunStatus(str, Enum):
@@ -14,13 +16,17 @@ class ScanRunStatus(str, Enum):
     COMPLETED = "completed"
     COMPLETED_WITH_WARNINGS = "completed_with_warnings"
     FAILED = "failed"
+    INCOMPLETE = "incomplete"
+    INTERRUPTED = "interrupted"
 
 
 class ScanStageName(str, Enum):
     VALIDATE = "validate"
-    DISCOVER = "discover"
+    ESTABLISH_CONTEXTS = "establish_contexts"
     COLLECT = "collect"
     NORMALIZE = "normalize"
+    COMPARE_COVERAGE = "compare_coverage"
+    REPLAY_AUTHORIZATION = "replay_authorization"
     ANALYZE = "analyze"
     REPORT = "report"
 
@@ -64,8 +70,32 @@ class ScanFailureView(BaseModel):
     occurred_at: datetime
 
 
+class ScanContextView(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    kind: ContextKind
+    credential_profile_id: int | None = None
+    auth_session_id: int | None = None
+    status: str
+    login_status: str = "pending"
+    session_validation_status: str = "pending"
+    collection_status: str = "pending"
+    completeness: str = CompletenessStatus.PENDING.value
+    asset_count: int = 0
+    request_count: int = 0
+    failure_count: int = 0
+    error_code: str | None = None
+    error_message: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
 class ScanRunView(BaseModel):
     id: int
+    mode: AssessmentMode = AssessmentMode.QUICK
+    target_id: int | None = None
+    source_run_id: int | None = None
     input_url: str
     normalized_url: str
     status: str
@@ -79,6 +109,7 @@ class ScanRunView(BaseModel):
     finished_at: datetime | None = None
     report_generated_at: datetime | None = None
     created_at: datetime
+    contexts: list[ScanContextView] = Field(default_factory=list)
     stages: list[ScanStageView] = Field(default_factory=list)
     failures: list[ScanFailureView] = Field(default_factory=list)
     asset_count: int = 0

--- a/app/services/context_collection.py
+++ b/app/services/context_collection.py
@@ -1,0 +1,398 @@
+"""将不同身份上下文的采集结果写入统一验证运行模型。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.scan_context import ScanContext
+from app.models.scan_request import ScanRequest
+from app.models.scan_run import ScanAsset, ScanRun
+from app.redaction.service import RedactionService
+from app.schemas.inventory import InventoryBuildControls
+from app.schemas.scan import ScanOptions
+from app.services.coverage_identity import (
+    canonical_asset_identity,
+    redacted_observed_url,
+    stable_response_signature,
+)
+from app.services.inventory_collection import InventoryCollectionService
+from app.services.scan_network import HttpScanGateway
+from app.services.session_storage import SessionStorageService
+
+
+@dataclass(frozen=True)
+class ObservedRequest:
+    method: str
+    url: str
+    headers: dict[str, str]
+    body: bytes | None
+    status_code: int
+    response_headers: dict[str, str]
+    response_text: str
+
+
+@dataclass(frozen=True)
+class ObservedResource:
+    asset_type: str
+    method: str
+    url: str
+    status_code: int | None
+    title: str | None
+    attributes: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ContextCollectionSummary:
+    context_id: int
+    asset_count: int
+    request_count: int
+    failure_count: int
+
+
+class ContextCollectionGateway(Protocol):
+    def collect(
+        self,
+        run: ScanRun,
+        context: ScanContext,
+    ) -> tuple[list[ObservedResource], list[ObservedRequest]]: ...
+
+
+class DefaultContextCollectionGateway:
+    """Adapt passive HTTP and authenticated Playwright collection to one protocol."""
+
+    def __init__(
+        self,
+        *,
+        http_gateway: HttpScanGateway,
+        inventory_service: InventoryCollectionService | None = None,
+    ) -> None:
+        self.http_gateway = http_gateway
+        self.inventory_service = inventory_service or InventoryCollectionService()
+
+    def collect(
+        self,
+        run: ScanRun,
+        context: ScanContext,
+    ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
+        if context.kind == "anonymous":
+            return self._collect_anonymous(run)
+        return self._collect_authenticated(run, context)
+
+    def _collect_anonymous(
+        self,
+        run: ScanRun,
+    ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
+        options = ScanOptions.model_validate(run.options)
+        queue: list[tuple[str, int]] = [(run.normalized_url, 0)]
+        seen: set[str] = set()
+        origin = _origin(run.normalized_url)
+        resources: list[ObservedResource] = []
+        requests: list[ObservedRequest] = []
+        while queue and len(resources) < options.max_pages:
+            url, depth = queue.pop(0)
+            if url in seen or depth > options.max_depth or _origin(url) != origin:
+                continue
+            seen.add(url)
+            result = self.http_gateway.fetch(url, options)
+            resources.append(
+                ObservedResource(
+                    asset_type="page",
+                    method="GET",
+                    url=result.final_url,
+                    status_code=result.status_code,
+                    title=result.title,
+                    attributes={
+                        "content_type": result.content_type,
+                        "body_size_bytes": result.body_size_bytes,
+                        "depth": depth,
+                        "redirect_count": len(result.redirects),
+                        "response_text": result.body_text if result.body_is_text else "",
+                    },
+                )
+            )
+            requests.append(
+                ObservedRequest(
+                    method="GET",
+                    url=result.final_url,
+                    headers={"accept": "*/*", "user-agent": options.user_agent},
+                    body=None,
+                    status_code=result.status_code,
+                    response_headers=result.headers,
+                    response_text=result.body_text if result.body_is_text else "",
+                )
+            )
+            if depth < options.max_depth:
+                queue.extend((candidate, depth + 1) for candidate in result.discovered_urls)
+        return resources, requests
+
+    def _collect_authenticated(
+        self,
+        run: ScanRun,
+        context: ScanContext,
+    ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
+        target = run.target
+        auth_session = context.auth_session
+        if target is None or auth_session is None:
+            raise ValueError("认证上下文采集需要 target 和已验证会话。")
+        options = ScanOptions.model_validate(run.options)
+        result = self.inventory_service.collect(
+            target,
+            auth_session,
+            InventoryBuildControls(
+                max_pages=options.max_pages,
+                max_depth=options.max_depth,
+                max_requests=min(500, max(1, options.max_pages * 10)),
+                delay_ms=0,
+            ),
+        )
+        resources = [
+            ObservedResource(
+                asset_type="page",
+                method="GET",
+                url=page.url,
+                status_code=page.status_code,
+                title=page.title,
+                attributes={
+                    "content_type": "text/html",
+                    "cache_control": page.cache_control,
+                    "depth": page.depth,
+                    "response_text": page.text_preview or "",
+                },
+            )
+            for page in result.pages
+        ]
+        requests: list[ObservedRequest] = []
+        for endpoint in result.endpoints:
+            exact_url = endpoint.request_url or endpoint.url
+            resources.append(
+                ObservedResource(
+                    asset_type="endpoint",
+                    method=endpoint.method,
+                    url=exact_url,
+                    status_code=endpoint.status_code,
+                    title=None,
+                    attributes={
+                        "content_type": endpoint.content_type,
+                        "cache_control": endpoint.cache_control,
+                        "parameter_names": endpoint.parameters,
+                        "response_text": endpoint.response_preview or "",
+                    },
+                )
+            )
+            response_headers = dict(endpoint.response_headers)
+            if endpoint.content_type and "content-type" not in response_headers:
+                response_headers["content-type"] = endpoint.content_type
+            if endpoint.cache_control and "cache-control" not in response_headers:
+                response_headers["cache-control"] = endpoint.cache_control
+            requests.append(
+                ObservedRequest(
+                    method=endpoint.method,
+                    url=exact_url,
+                    headers=dict(endpoint.request_headers),
+                    body=endpoint.request_body,
+                    status_code=endpoint.status_code,
+                    response_headers=response_headers,
+                    response_text=endpoint.response_preview or "",
+                )
+            )
+        return resources, requests
+
+
+class ContextCollectionService:
+    """Persist gateway-neutral observations without ordinary-field secrets."""
+
+    def __init__(
+        self,
+        *,
+        gateway: ContextCollectionGateway,
+        storage_service: SessionStorageService | None = None,
+        redaction_service: RedactionService | None = None,
+    ) -> None:
+        self.gateway = gateway
+        self.storage_service = storage_service or SessionStorageService()
+        self.redaction_service = redaction_service or RedactionService()
+
+    def collect(
+        self,
+        session: Session,
+        run: ScanRun,
+        context: ScanContext,
+    ) -> ContextCollectionSummary:
+        if context.scan_run_id != run.id:
+            raise ValueError("采集上下文不属于指定验证运行。")
+        resources, requests = self.gateway.collect(run, context)
+        asset_by_identity: dict[str, ScanAsset] = {}
+        for resource in resources:
+            asset = self._persist_resource(session, run, context, resource)
+            asset_by_identity[asset.identity_key or ""] = asset
+        session.flush()
+
+        seen_request_fingerprints: set[str] = set()
+        for observed in requests:
+            identity_key = canonical_asset_identity(observed.method, observed.url)
+            asset = asset_by_identity.get(identity_key)
+            if asset is None:
+                asset = self._persist_resource(
+                    session,
+                    run,
+                    context,
+                    ObservedResource(
+                        asset_type="endpoint",
+                        method=observed.method,
+                        url=observed.url,
+                        status_code=observed.status_code,
+                        title=None,
+                        attributes={
+                            "content_type": observed.response_headers.get("content-type"),
+                            "response_text": observed.response_text,
+                        },
+                    ),
+                )
+                asset_by_identity[identity_key] = asset
+                session.flush()
+            fingerprint = self._request_fingerprint(observed)
+            if fingerprint in seen_request_fingerprints:
+                continue
+            seen_request_fingerprints.add(fingerprint)
+            storage_ref = self.storage_service.write_request_payload(
+                run.id,
+                context.id,
+                {
+                    "method": observed.method.upper(),
+                    "url": observed.url,
+                    "headers": observed.headers,
+                    "body": observed.body.decode("utf-8", errors="replace")
+                    if observed.body is not None
+                    else None,
+                    "status_code": observed.status_code,
+                    "response_headers": observed.response_headers,
+                    "response_text": observed.response_text,
+                },
+            )
+            session.add(
+                ScanRequest.from_capture(
+                    scan_run_id=run.id,
+                    source_context_id=context.id,
+                    asset_id=asset.id,
+                    method=observed.method,
+                    raw_url=observed.url,
+                    header_names=list(observed.headers),
+                    fingerprint=fingerprint,
+                    protected_storage_ref=storage_ref,
+                )
+            )
+
+        session.flush()
+        assets = list(
+            session.scalars(
+                select(ScanAsset).where(
+                    ScanAsset.scan_run_id == run.id,
+                    ScanAsset.context_id == context.id,
+                )
+            )
+        )
+        stored_requests = list(
+            session.scalars(
+                select(ScanRequest).where(
+                    ScanRequest.scan_run_id == run.id,
+                    ScanRequest.source_context_id == context.id,
+                )
+            )
+        )
+        context.status = "completed"
+        context.collection_status = "completed"
+        context.completeness = "complete"
+        context.asset_count = len(assets)
+        context.request_count = len(stored_requests)
+        context.finished_at = datetime.now(timezone.utc)
+        session.flush()
+        return ContextCollectionSummary(
+            context_id=context.id,
+            asset_count=context.asset_count,
+            request_count=context.request_count,
+            failure_count=context.failure_count,
+        )
+
+    def _persist_resource(
+        self,
+        session: Session,
+        run: ScanRun,
+        context: ScanContext,
+        resource: ObservedResource,
+    ) -> ScanAsset:
+        identity_key = canonical_asset_identity(resource.method, resource.url)
+        asset = session.scalar(
+            select(ScanAsset).where(
+                ScanAsset.scan_run_id == run.id,
+                ScanAsset.context_id == context.id,
+                ScanAsset.identity_key == identity_key,
+            )
+        )
+        attributes = dict(resource.attributes)
+        response_text = attributes.pop("response_text", None)
+        content_type = attributes.get("content_type")
+        if isinstance(response_text, str):
+            attributes["content_signature"] = stable_response_signature(
+                response_text,
+                content_type if isinstance(content_type, str) else None,
+            )
+        redacted_attributes = self.redaction_service.redact_mapping(attributes)
+        if asset is None:
+            asset = ScanAsset(
+                scan_run_id=run.id,
+                context_id=context.id,
+                identity_key=identity_key,
+                asset_type=resource.asset_type,
+                url=redacted_observed_url(resource.url),
+                method=resource.method.upper(),
+                status_code=resource.status_code,
+                title=self.redaction_service.redact_text(resource.title, limit=500)
+                if resource.title
+                else None,
+                attributes=redacted_attributes,
+                discovered_at=datetime.now(timezone.utc),
+            )
+            session.add(asset)
+            session.flush()
+            return asset
+        asset.status_code = resource.status_code
+        asset.title = (
+            self.redaction_service.redact_text(resource.title, limit=500)
+            if resource.title
+            else asset.title
+        )
+        asset.attributes.update(redacted_attributes)
+        return asset
+
+    def _request_fingerprint(self, observed: ObservedRequest) -> str:
+        content_type = observed.response_headers.get("content-type")
+        payload = {
+            "method": observed.method.upper(),
+            "identity": canonical_asset_identity(observed.method, observed.url),
+            "body_hash": hashlib.sha256(observed.body or b"").hexdigest(),
+            "response_status": observed.status_code,
+            "response_signature": stable_response_signature(
+                observed.response_text,
+                content_type,
+            ),
+        }
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+
+
+def _origin(url: str) -> tuple[str, str, int]:
+    parsed = urlparse(url)
+    return (
+        parsed.scheme.lower(),
+        (parsed.hostname or "").lower(),
+        parsed.port or (443 if parsed.scheme.lower() == "https" else 80),
+    )

--- a/app/services/context_establishment.py
+++ b/app/services/context_establishment.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core.errors import GardenError, InputValidationError, ResourceNotFoundError
+from app.core.errors import InputValidationError, ResourceNotFoundError
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import (
     AssessmentMode,
@@ -137,8 +137,9 @@ class ContextEstablishmentService:
         now = datetime.now(timezone.utc)
         context.started_at = context.started_at or now
         try:
-            auth_session = self.auth_service.ensure_valid_for_profile(session, profile.id)
-        except GardenError:
+            with session.begin_nested():
+                auth_session = self.auth_service.ensure_valid_for_profile(session, profile.id)
+        except Exception:  # noqa: BLE001 - context boundary persists a redacted failure
             context.auth_session_id = None
             context.status = "failed"
             context.login_status = "failed"

--- a/app/services/context_establishment.py
+++ b/app/services/context_establishment.py
@@ -1,0 +1,225 @@
+"""建立统一验证运行的匿名、用户和管理员上下文。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.errors import GardenError, InputValidationError, ResourceNotFoundError
+from app.models.credential_profile import CredentialProfile
+from app.models.enums import (
+    AssessmentMode,
+    AuditEventStatus,
+    AuditEventType,
+    CompletenessStatus,
+    ContextKind,
+)
+from app.models.scan_context import ScanContext
+from app.models.scan_run import ScanRun
+from app.models.target import Target
+from app.services.audit import AuditService
+from app.services.sessions import AuthSessionService
+
+
+class ContextEstablishmentService:
+    """Validate identities and bind verified auth sessions to persisted contexts."""
+
+    def __init__(
+        self,
+        *,
+        auth_service: AuthSessionService | None = None,
+        audit_service: AuditService | None = None,
+    ) -> None:
+        self.auth_service = auth_service or AuthSessionService()
+        self.audit_service = audit_service or AuditService()
+
+    def establish(self, session: Session, run: ScanRun) -> list[ScanContext]:
+        contexts = self._existing_contexts(session, run)
+        anonymous = self._establish_anonymous(session, run, contexts)
+        if run.mode == AssessmentMode.QUICK.value:
+            return [anonymous]
+
+        user_profile, admin_profile = self._validate_authenticated_run(session, run, contexts)
+        user = self._establish_authenticated(
+            session,
+            run,
+            contexts[ContextKind.USER.value],
+            user_profile,
+        )
+        admin = self._establish_authenticated(
+            session,
+            run,
+            contexts[ContextKind.ADMIN.value],
+            admin_profile,
+        )
+        self._set_run_completeness(run, user, admin)
+        session.flush()
+        return [anonymous, user, admin]
+
+    def _existing_contexts(self, session: Session, run: ScanRun) -> dict[str, ScanContext]:
+        contexts = {
+            context.kind: context
+            for context in session.scalars(
+                select(ScanContext)
+                .where(ScanContext.scan_run_id == run.id)
+                .order_by(ScanContext.id)
+            )
+        }
+        required = {ContextKind.ANONYMOUS.value}
+        if run.mode == AssessmentMode.AUTHENTICATED_COVERAGE.value:
+            required.update({ContextKind.USER.value, ContextKind.ADMIN.value})
+        missing = sorted(required - contexts.keys())
+        if missing:
+            raise InputValidationError(f"验证运行缺少预创建上下文：{', '.join(missing)}。")
+        return contexts
+
+    def _validate_authenticated_run(
+        self,
+        session: Session,
+        run: ScanRun,
+        contexts: dict[str, ScanContext],
+    ) -> tuple[CredentialProfile, CredentialProfile]:
+        user = self._profile(session, contexts[ContextKind.USER.value])
+        admin = self._profile(session, contexts[ContextKind.ADMIN.value])
+        if user.target_id != admin.target_id:
+            raise InputValidationError("user/admin 凭证档案必须属于同一目标。")
+        if user.role != ContextKind.USER.value:
+            raise InputValidationError("user 上下文必须绑定角色精确为 user 的凭证档案。")
+        if admin.role != ContextKind.ADMIN.value:
+            raise InputValidationError("admin 上下文必须绑定角色精确为 admin 的凭证档案。")
+        if run.target_id != user.target_id:
+            raise InputValidationError("验证运行 target 与凭证档案 target 不一致。")
+        target = session.get(Target, user.target_id)
+        if target is None:
+            raise ResourceNotFoundError(f"Target {user.target_id} was not found.")
+        if self._origin(run.normalized_url) != self._origin(target.base_url):
+            raise InputValidationError("验证运行 URL 必须与 target base URL 同源。")
+        return user, admin
+
+    def _profile(self, session: Session, context: ScanContext) -> CredentialProfile:
+        if context.credential_profile_id is None:
+            raise InputValidationError(f"{context.kind} 上下文缺少凭证档案。")
+        profile = session.get(CredentialProfile, context.credential_profile_id)
+        if profile is None:
+            raise ResourceNotFoundError(
+                f"Credential profile {context.credential_profile_id} was not found."
+            )
+        return profile
+
+    def _establish_anonymous(
+        self,
+        session: Session,
+        run: ScanRun,
+        contexts: dict[str, ScanContext],
+    ) -> ScanContext:
+        context = contexts[ContextKind.ANONYMOUS.value]
+        now = datetime.now(timezone.utc)
+        context.status = "ready"
+        context.login_status = "not_applicable"
+        context.session_validation_status = "not_applicable"
+        context.started_at = context.started_at or now
+        context.finished_at = now
+        context.error_code = None
+        context.error_message = None
+        self._audit(session, run, context, succeeded=True)
+        return context
+
+    def _establish_authenticated(
+        self,
+        session: Session,
+        run: ScanRun,
+        context: ScanContext,
+        profile: CredentialProfile,
+    ) -> ScanContext:
+        now = datetime.now(timezone.utc)
+        context.started_at = context.started_at or now
+        try:
+            auth_session = self.auth_service.ensure_valid_for_profile(session, profile.id)
+        except GardenError:
+            context.auth_session_id = None
+            context.status = "failed"
+            context.login_status = "failed"
+            context.session_validation_status = "invalid"
+            context.failure_count += 1
+            context.error_code = "authentication_session_unavailable"
+            context.error_message = "Authentication session could not be established and validated."
+            context.finished_at = now
+            self._audit(session, run, context, succeeded=False)
+            return context
+
+        if (
+            auth_session.target_id != run.target_id
+            or auth_session.credential_profile_id != profile.id
+        ):
+            context.auth_session_id = None
+            context.status = "failed"
+            context.login_status = "failed"
+            context.session_validation_status = "invalid"
+            context.failure_count += 1
+            context.error_code = "authentication_session_mismatch"
+            context.error_message = "Validated session ownership did not match the context."
+            context.finished_at = now
+            self._audit(session, run, context, succeeded=False)
+            return context
+
+        context.auth_session_id = auth_session.id
+        context.status = "ready"
+        context.login_status = "succeeded"
+        context.session_validation_status = "valid"
+        context.error_code = None
+        context.error_message = None
+        context.finished_at = now
+        self._audit(session, run, context, succeeded=True)
+        return context
+
+    def _set_run_completeness(self, run: ScanRun, user: ScanContext, admin: ScanContext) -> None:
+        failed = {context.kind for context in (user, admin) if context.status == "failed"}
+        if not failed:
+            return
+        run.status = "incomplete"
+        if failed == {ContextKind.USER.value, ContextKind.ADMIN.value}:
+            run.completeness = CompletenessStatus.INCOMPLETE.value
+        elif ContextKind.ADMIN.value in failed:
+            run.completeness = CompletenessStatus.MISSING_ADMIN_CONTEXT.value
+        else:
+            run.completeness = CompletenessStatus.MISSING_USER_CONTEXT.value
+        run.error_code = "context_establishment_failed"
+        run.error_message = "One or more required authentication contexts could not be established."
+        run.finished_at = datetime.now(timezone.utc)
+
+    def _audit(
+        self,
+        session: Session,
+        run: ScanRun,
+        context: ScanContext,
+        *,
+        succeeded: bool,
+    ) -> None:
+        self.audit_service.record(
+            session,
+            AuditEventType.CONTEXT_ESTABLISHMENT,
+            AuditEventStatus.SUCCESS if succeeded else AuditEventStatus.FAILURE,
+            {
+                "scan_run_id": run.id,
+                "context_kind": context.kind,
+                "credential_profile_id": context.credential_profile_id,
+                "auth_session_id": context.auth_session_id,
+                "result": "success" if succeeded else "failure",
+            },
+            target_id=run.target_id,
+            credential_profile_id=context.credential_profile_id,
+            auth_session_id=context.auth_session_id,
+        )
+
+    def _origin(self, url: str) -> tuple[str, str, int]:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise InputValidationError("验证运行与 target URL 必须是有效 HTTP(S) URL。")
+        try:
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        except ValueError as error:
+            raise InputValidationError("验证运行与 target URL 端口无效。") from error
+        return parsed.scheme.lower(), parsed.hostname.lower(), port

--- a/app/services/coverage_identity.py
+++ b/app/services/coverage_identity.py
@@ -1,0 +1,132 @@
+"""统一验证运行中的资产身份和稳定响应指纹。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qsl, quote, urlsplit, urlunsplit
+
+_DYNAMIC_JSON_KEYS = {
+    "csrf",
+    "csrftoken",
+    "generated",
+    "generatedat",
+    "nonce",
+    "requestid",
+    "session",
+    "sessionid",
+    "timestamp",
+    "traceid",
+}
+_ISO_TIMESTAMP = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:?\d{2})?\b"
+)
+_DYNAMIC_ASSIGNMENT = re.compile(
+    r"(?i)\b(generated(?:_at)?|nonce|request[_-]?id|session(?:[_-]?id)?|trace[_-]?id)"
+    r"(\s*[:=]\s*)([^\s,;}&]+)"
+)
+_UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.I,
+)
+_PERCENT_ESCAPE = re.compile(r"%([0-9A-Fa-f]{2})")
+_UNRESERVED = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+
+def canonical_asset_identity(method: str, url: str) -> str:
+    """Return a value-independent identity for one observed HTTP asset."""
+
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("资产身份只接受绝对 HTTP(S) URL。")
+    normalized_method = method.strip().upper()
+    if not normalized_method:
+        raise ValueError("资产身份需要 HTTP 方法。")
+    path = _normalize_path(parsed.path or "/")
+    path = path.rstrip("/") or "/"
+    parameter_names = sorted(
+        {name for name, _value in parse_qsl(parsed.query, keep_blank_values=True)}
+    )
+    suffix = (
+        f"?{'&'.join(quote(name, safe='') for name in parameter_names)}" if parameter_names else ""
+    )
+    return f"{normalized_method}:{path}{suffix}"
+
+
+def stable_response_signature(text: str, content_type: str | None) -> str:
+    """Hash response content after removing common per-request dynamic values."""
+
+    media_type = (content_type or "").split(";", 1)[0].strip().lower()
+    normalized: str
+    if media_type == "application/json" or media_type.endswith("+json"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            normalized = _normalize_dynamic_text(text)
+        else:
+            normalized = json.dumps(
+                _normalize_json(payload),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+    else:
+        normalized = _normalize_dynamic_text(text)
+    material = f"{media_type}\n{normalized}".encode("utf-8", errors="replace")
+    return hashlib.sha256(material).hexdigest()
+
+
+def redacted_observed_url(raw_url: str) -> str:
+    """Normalize an observed URL while retaining names but not credential or query values."""
+
+    parsed = urlsplit(raw_url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = parsed.port
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+    path = parsed.path or "/"
+    query_names = sorted(name for name, _value in parse_qsl(parsed.query, keep_blank_values=True))
+    query = "&".join(f"{quote(name, safe='')}=[REDACTED]" for name in query_names)
+    return urlunsplit((scheme, host, path, query, ""))
+
+
+def _normalize_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+            normalized[str(key)] = (
+                "<dynamic>" if normalized_key in _DYNAMIC_JSON_KEYS else _normalize_json(item)
+            )
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_json(item) for item in value]
+    if isinstance(value, str):
+        return _normalize_dynamic_text(value)
+    return value
+
+
+def _normalize_dynamic_text(value: str) -> str:
+    normalized = _ISO_TIMESTAMP.sub("<timestamp>", value)
+    normalized = _UUID.sub("<uuid>", normalized)
+    normalized = _DYNAMIC_ASSIGNMENT.sub(
+        lambda match: f"{match.group(1).lower()}{match.group(2)}<dynamic>",
+        normalized,
+    )
+    return " ".join(normalized.split())
+
+
+def _normalize_path(value: str) -> str:
+    def normalize_escape(match: re.Match[str]) -> str:
+        decoded = chr(int(match.group(1), 16))
+        return decoded if decoded in _UNRESERVED else f"%{match.group(1).upper()}"
+
+    normalized = _PERCENT_ESCAPE.sub(normalize_escape, value)
+    return quote(normalized, safe="/%:@!$&'()*+,;=-._~")

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -7,17 +7,24 @@ import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from typing import Protocol
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import Session, selectinload
 
-from app.core.errors import ResourceNotFoundError
+from app.core.errors import InputValidationError, ResourceNotFoundError
 from app.core.settings import Settings, get_settings
 from app.db.bootstrap import session_scope
+from app.models.credential_profile import CredentialProfile
+from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
+from app.models.scan_context import ScanContext
 from app.models.scan_run import ScanRun, ScanRunStage
+from app.models.target import Target
+from app.schemas.assessment import AssessmentRunView, AssessmentStartRequest
 from app.schemas.scan import (
+    ScanContextView,
     ScanFailureView,
     ScanOptions,
     ScanRunStatus,
@@ -26,6 +33,44 @@ from app.schemas.scan import (
 )
 from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_pipeline import STAGES, ScanPipeline
+
+TERMINAL_RUN_STATUSES = {
+    ScanRunStatus.COMPLETED.value,
+    ScanRunStatus.COMPLETED_WITH_WARNINGS.value,
+    ScanRunStatus.FAILED.value,
+    ScanRunStatus.INCOMPLETE.value,
+    ScanRunStatus.INTERRUPTED.value,
+}
+
+
+def create_assessment_stages(session: Session, run: ScanRun) -> None:
+    """原子创建固定八阶段，并显式标记 quick 不适用的阶段。"""
+
+    now = datetime.now(timezone.utc)
+    stages = []
+    for position, name in enumerate(STAGES, start=1):
+        values: dict[str, object] = {
+            "scan_run_id": run.id,
+            "name": name,
+            "position": position,
+        }
+        if run.mode == AssessmentMode.QUICK.value:
+            if name == "establish_contexts":
+                values.update(
+                    status="completed",
+                    attempt=1,
+                    summary="Created the anonymous quick-scan context.",
+                    started_at=now,
+                    finished_at=now,
+                )
+            elif name in {"compare_coverage", "replay_authorization"}:
+                values.update(
+                    status="skipped",
+                    summary="Not applicable to a single-context quick assessment.",
+                    finished_at=now,
+                )
+        stages.append(ScanRunStage(**values))
+    session.add_all(stages)
 
 
 class ScanDispatcher(Protocol):
@@ -75,21 +120,48 @@ class ScanApplicationService:
         )
 
     def start_scan(self, url: str, options: ScanOptions | None = None) -> ScanRunView:
-        resolved = self._resolve_options(options or ScanOptions())
-        normalized = self.pipeline.policy.normalize_url(url)
-        active_key = self._active_key(normalized, resolved)
+        assessment = self.start_assessment(
+            AssessmentStartRequest(
+                url=url,
+                mode=AssessmentMode.QUICK,
+                options=options or ScanOptions(),
+            )
+        )
+        return ScanRunView.model_validate(assessment.model_dump())
+
+    def start_assessment(self, request: AssessmentStartRequest) -> AssessmentRunView:
+        resolved = self._resolve_options(request.options)
+        normalized = self.pipeline.policy.normalize_url(request.url)
         with self._start_lock, session_scope() as session:
+            target_id = self._resolve_target_id(session, request)
+            self._validate_source_run(session, request, target_id)
+            active_key = self._active_key(normalized, request, resolved, target_id)
             existing = session.scalar(select(ScanRun).where(ScanRun.active_key == active_key))
             if existing is not None:
-                return self._view(existing)
+                return self._assessment_view(existing)
             run = ScanRun(
-                input_url=url.strip(),
+                mode=request.mode.value,
+                target_id=target_id,
+                source_run_id=request.source_run_id,
+                input_url=request.url.strip(),
                 normalized_url=normalized,
                 active_key=active_key,
                 status=ScanRunStatus.QUEUED.value,
                 current_stage="queued",
                 progress=0,
                 options=resolved.model_dump(),
+                active_checks_enabled=request.active_checks_enabled,
+                authorization_confirmed_at=(
+                    datetime.now(timezone.utc) if request.authorization_confirmed else None
+                ),
+                authorization_confirmed_by=(
+                    request.authorization_confirmed_by if request.authorization_confirmed else None
+                ),
+                completeness=(
+                    CompletenessStatus.LEGACY_SINGLE_CONTEXT.value
+                    if request.mode == AssessmentMode.QUICK
+                    else CompletenessStatus.PENDING.value
+                ),
             )
             session.add(run)
             try:
@@ -98,18 +170,15 @@ class ScanApplicationService:
                 session.rollback()
                 existing = session.scalar(select(ScanRun).where(ScanRun.active_key == active_key))
                 if existing is not None:
-                    return self._view(existing)
+                    return self._assessment_view(existing)
                 raise
-            session.add_all(
-                [
-                    ScanRunStage(scan_run_id=run.id, name=name, position=index)
-                    for index, name in enumerate(STAGES, start=1)
-                ]
-            )
+            session.add_all(self._assessment_contexts(run, request))
+            create_assessment_stages(session, run)
             session.commit()
             run_id = run.id
-        self.dispatcher.submit(run_id, self.execute_scan)
-        return self.get_scan(run_id)
+        if request.mode == AssessmentMode.QUICK:
+            self.dispatcher.submit(run_id, self.execute_scan)
+        return self.get_assessment(run_id)
 
     def execute_scan(self, scan_run_id: int) -> None:
         with session_scope() as session:
@@ -120,6 +189,11 @@ class ScanApplicationService:
             run = self._get(session, scan_run_id)
             return self._view(run)
 
+    def get_assessment(self, scan_run_id: int) -> AssessmentRunView:
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            return self._assessment_view(run)
+
     def list_scans(self, limit: int = 25) -> list[ScanRunView]:
         with session_scope() as session:
             runs = list(
@@ -127,10 +201,13 @@ class ScanApplicationService:
                     select(ScanRun)
                     .options(
                         selectinload(ScanRun.stages),
+                        selectinload(ScanRun.contexts),
                         selectinload(ScanRun.failures),
                         selectinload(ScanRun.assets),
                         selectinload(ScanRun.evidence),
                         selectinload(ScanRun.findings),
+                        selectinload(ScanRun.coverage_differences),
+                        selectinload(ScanRun.replay_executions),
                     )
                     .order_by(ScanRun.id.desc())
                     .limit(limit)
@@ -142,15 +219,15 @@ class ScanApplicationService:
         self, scan_run_id: int, *, timeout_seconds: float | None = None
     ) -> ScanRunView:
         deadline = time.monotonic() + (
-            timeout_seconds or self.settings.scan_overall_timeout_seconds + 10
+            timeout_seconds
+            if timeout_seconds is not None
+            else self.settings.scan_overall_timeout_seconds + 10
         )
         while time.monotonic() < deadline:
             run = self.get_scan(scan_run_id)
-            if run.status in {
-                ScanRunStatus.COMPLETED.value,
-                ScanRunStatus.COMPLETED_WITH_WARNINGS.value,
-                ScanRunStatus.FAILED.value,
-            }:
+            if run.status in TERMINAL_RUN_STATUSES:
+                self._clear_active_key(scan_run_id)
+                run = self.get_scan(scan_run_id)
                 return run
             time.sleep(0.05)
         return self.get_scan(scan_run_id)
@@ -173,10 +250,13 @@ class ScanApplicationService:
             .where(ScanRun.id == scan_run_id)
             .options(
                 selectinload(ScanRun.stages),
+                selectinload(ScanRun.contexts),
                 selectinload(ScanRun.failures),
                 selectinload(ScanRun.assets),
                 selectinload(ScanRun.evidence),
                 selectinload(ScanRun.findings),
+                selectinload(ScanRun.coverage_differences),
+                selectinload(ScanRun.replay_executions),
             )
         )
         if run is None:
@@ -184,22 +264,44 @@ class ScanApplicationService:
         return run
 
     def _view(self, run: ScanRun) -> ScanRunView:
-        return ScanRunView(
-            id=run.id,
-            input_url=run.input_url,
-            normalized_url=run.normalized_url,
-            status=run.status,
-            current_stage=run.current_stage,
-            progress=run.progress,
-            retry_count=run.retry_count,
-            report_path=run.report_path,
-            error_code=run.error_code,
-            error_message=run.error_message,
-            started_at=run.started_at,
-            finished_at=run.finished_at,
-            report_generated_at=run.report_generated_at,
-            created_at=run.created_at,
-            stages=[
+        return ScanRunView(**self._view_data(run))
+
+    def _assessment_view(self, run: ScanRun) -> AssessmentRunView:
+        context_counts = {kind.value: 0 for kind in ContextKind}
+        for context in run.contexts:
+            context_counts[context.kind] += 1
+        return AssessmentRunView(
+            **self._view_data(run),
+            completeness=run.completeness,
+            active_checks_enabled=run.active_checks_enabled,
+            authorization_confirmed_at=run.authorization_confirmed_at,
+            authorization_confirmed_by=run.authorization_confirmed_by,
+            context_counts=context_counts,
+            difference_count=len(run.coverage_differences),
+            replay_count=len(run.replay_executions),
+        )
+
+    def _view_data(self, run: ScanRun) -> dict[str, object]:
+        return {
+            "id": run.id,
+            "mode": run.mode,
+            "target_id": run.target_id,
+            "source_run_id": run.source_run_id,
+            "input_url": run.input_url,
+            "normalized_url": run.normalized_url,
+            "status": run.status,
+            "current_stage": run.current_stage,
+            "progress": run.progress,
+            "retry_count": run.retry_count,
+            "report_path": run.report_path,
+            "error_code": run.error_code,
+            "error_message": run.error_message,
+            "started_at": run.started_at,
+            "finished_at": run.finished_at,
+            "report_generated_at": run.report_generated_at,
+            "created_at": run.created_at,
+            "contexts": [ScanContextView.model_validate(item) for item in run.contexts],
+            "stages": [
                 ScanStageView(
                     name=stage.name,
                     position=stage.position,
@@ -213,7 +315,7 @@ class ScanApplicationService:
                 )
                 for stage in sorted(run.stages, key=lambda item: item.position)
             ],
-            failures=[
+            "failures": [
                 ScanFailureView(
                     stage=item.stage,
                     code=item.code,
@@ -225,10 +327,10 @@ class ScanApplicationService:
                 )
                 for item in sorted(run.failures, key=lambda item: item.id)
             ],
-            asset_count=len(run.assets),
-            evidence_count=len(run.evidence),
-            finding_count=len(run.findings),
-        )
+            "asset_count": len(run.assets),
+            "evidence_count": len(run.evidence),
+            "finding_count": len(run.findings),
+        }
 
     def _resolve_options(self, options: ScanOptions) -> ScanOptions:
         return options.model_copy(
@@ -245,10 +347,98 @@ class ScanApplicationService:
             }
         )
 
-    def _active_key(self, normalized_url: str, options: ScanOptions) -> str:
+    def _active_key(
+        self,
+        normalized_url: str,
+        request: AssessmentStartRequest,
+        options: ScanOptions,
+        target_id: int | None,
+    ) -> str:
         payload = json.dumps(
-            {"url": normalized_url, "options": options.model_dump()},
+            {
+                "url": normalized_url,
+                "mode": request.mode.value,
+                "target_id": target_id,
+                "user_profile_id": request.user_profile_id,
+                "admin_profile_id": request.admin_profile_id,
+                "active_checks_enabled": request.active_checks_enabled,
+                "options": options.model_dump(),
+            },
             sort_keys=True,
             separators=(",", ":"),
         )
         return hashlib.sha256(payload.encode()).hexdigest()
+
+    def _resolve_target_id(self, session, request: AssessmentStartRequest) -> int | None:
+        if request.mode == AssessmentMode.QUICK:
+            if request.target_id is not None and session.get(Target, request.target_id) is None:
+                raise ResourceNotFoundError(f"Target {request.target_id} was not found.")
+            return request.target_id
+
+        user_profile = session.get(CredentialProfile, request.user_profile_id)
+        admin_profile = session.get(CredentialProfile, request.admin_profile_id)
+        if user_profile is None:
+            raise ResourceNotFoundError(
+                f"Credential profile {request.user_profile_id} was not found."
+            )
+        if admin_profile is None:
+            raise ResourceNotFoundError(
+                f"Credential profile {request.admin_profile_id} was not found."
+            )
+        if user_profile.target_id != admin_profile.target_id:
+            raise InputValidationError("user/admin 凭证档案必须属于同一 target。")
+        if request.target_id is not None and request.target_id != user_profile.target_id:
+            raise InputValidationError("请求 target 与凭证档案 target 不一致。")
+        return user_profile.target_id
+
+    def _validate_source_run(
+        self, session, request: AssessmentStartRequest, target_id: int | None
+    ) -> None:
+        if request.source_run_id is None:
+            return
+        if request.mode != AssessmentMode.AUTHENTICATED_COVERAGE:
+            raise InputValidationError("source_run_id 只用于升级到 authenticated_coverage。")
+        source = session.get(ScanRun, request.source_run_id)
+        if source is None:
+            raise ResourceNotFoundError(f"Scan run {request.source_run_id} was not found.")
+        if (
+            source.mode != AssessmentMode.QUICK.value
+            or source.status not in TERMINAL_RUN_STATUSES
+            or source.target_id != target_id
+        ):
+            raise InputValidationError("source_run_id 必须引用同一 target 的已终态 quick run。")
+
+    def _assessment_contexts(
+        self, run: ScanRun, request: AssessmentStartRequest
+    ) -> list[ScanContext]:
+        contexts = [
+            ScanContext(
+                scan_run_id=run.id,
+                kind=ContextKind.ANONYMOUS.value,
+                status="pending",
+            )
+        ]
+        if request.mode == AssessmentMode.AUTHENTICATED_COVERAGE:
+            contexts.extend(
+                [
+                    ScanContext(
+                        scan_run_id=run.id,
+                        kind=ContextKind.USER.value,
+                        credential_profile_id=request.user_profile_id,
+                        status="pending",
+                    ),
+                    ScanContext(
+                        scan_run_id=run.id,
+                        kind=ContextKind.ADMIN.value,
+                        credential_profile_id=request.admin_profile_id,
+                        status="pending",
+                    ),
+                ]
+            )
+        return contexts
+
+    def _clear_active_key(self, scan_run_id: int) -> None:
+        with session_scope() as session:
+            run = session.get(ScanRun, scan_run_id)
+            if run is not None and run.status in TERMINAL_RUN_STATUSES:
+                run.active_key = None

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -20,7 +20,7 @@ from app.db.bootstrap import session_scope
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
 from app.models.scan_context import ScanContext
-from app.models.scan_run import ScanRun, ScanRunStage
+from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES, ScanRun, ScanRunStage
 from app.models.target import Target
 from app.schemas.assessment import AssessmentRunView, AssessmentStartRequest
 from app.schemas.scan import (
@@ -33,14 +33,6 @@ from app.schemas.scan import (
 )
 from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_pipeline import STAGES, ScanPipeline
-
-TERMINAL_RUN_STATUSES = {
-    ScanRunStatus.COMPLETED.value,
-    ScanRunStatus.COMPLETED_WITH_WARNINGS.value,
-    ScanRunStatus.FAILED.value,
-    ScanRunStatus.INCOMPLETE.value,
-    ScanRunStatus.INTERRUPTED.value,
-}
 
 
 def create_assessment_stages(session: Session, run: ScanRun) -> None:
@@ -225,9 +217,7 @@ class ScanApplicationService:
         )
         while time.monotonic() < deadline:
             run = self.get_scan(scan_run_id)
-            if run.status in TERMINAL_RUN_STATUSES:
-                self._clear_active_key(scan_run_id)
-                run = self.get_scan(scan_run_id)
+            if run.status in TERMINAL_SCAN_RUN_STATUSES:
                 return run
             time.sleep(0.05)
         return self.get_scan(scan_run_id)
@@ -362,6 +352,7 @@ class ScanApplicationService:
                 "user_profile_id": request.user_profile_id,
                 "admin_profile_id": request.admin_profile_id,
                 "active_checks_enabled": request.active_checks_enabled,
+                "source_run_id": request.source_run_id,
                 "options": options.model_dump(),
             },
             sort_keys=True,
@@ -403,7 +394,7 @@ class ScanApplicationService:
             raise ResourceNotFoundError(f"Scan run {request.source_run_id} was not found.")
         if (
             source.mode != AssessmentMode.QUICK.value
-            or source.status not in TERMINAL_RUN_STATUSES
+            or source.status not in TERMINAL_SCAN_RUN_STATUSES
             or source.target_id != target_id
         ):
             raise InputValidationError("source_run_id 必须引用同一 target 的已终态 quick run。")
@@ -436,9 +427,3 @@ class ScanApplicationService:
                 ]
             )
         return contexts
-
-    def _clear_active_key(self, scan_run_id: int) -> None:
-        with session_scope() as session:
-            run = session.get(ScanRun, scan_run_id)
-            if run is not None and run.status in TERMINAL_RUN_STATUSES:
-                run.active_key = None

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -10,6 +10,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.errors import InputValidationError, TargetPolicyError
+from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
+from app.models.scan_context import ScanContext
 from app.models.scan_run import (
     ScanAsset,
     ScanEvidence,
@@ -20,6 +22,7 @@ from app.models.scan_run import (
 )
 from app.redaction.service import RedactionService
 from app.schemas.scan import FetchResult, ScanOptions, ScanRunStatus, ScanStageName
+from app.services.context_establishment import ContextEstablishmentService
 from app.services.scan_analysis import PassiveScanAnalyzer
 from app.services.scan_network import FetchError, HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_reporting import ScanReportService
@@ -27,6 +30,7 @@ from app.services.scan_reporting import ScanReportService
 STAGES = [stage.value for stage in ScanStageName]
 PROGRESS_AFTER_STAGE = {
     ScanStageName.VALIDATE.value: 8,
+    ScanStageName.ESTABLISH_CONTEXTS.value: 18,
     ScanStageName.COLLECT.value: 58,
     ScanStageName.NORMALIZE.value: 68,
     ScanStageName.ANALYZE.value: 86,
@@ -47,6 +51,7 @@ class ScanPipeline:
         analyzer: PassiveScanAnalyzer | None = None,
         report_service: ScanReportService | None = None,
         redaction_service: RedactionService | None = None,
+        context_service: ContextEstablishmentService | None = None,
         clock=time.monotonic,
     ) -> None:
         self.policy = policy
@@ -54,7 +59,58 @@ class ScanPipeline:
         self.analyzer = analyzer or PassiveScanAnalyzer()
         self.report_service = report_service or ScanReportService()
         self.redaction_service = redaction_service or RedactionService()
+        self.context_service = context_service or ContextEstablishmentService()
         self.clock = clock
+
+    def establish_contexts(self, session: Session, scan_run_id: int) -> list[ScanContext]:
+        """Execute only the authenticated context-establishment stage."""
+
+        run = session.get(ScanRun, scan_run_id)
+        if run is None:
+            raise InputValidationError(f"Scan run {scan_run_id} was not found.")
+        if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
+            raise InputValidationError("Only authenticated coverage runs establish three contexts.")
+        stage = self._stage(session, run.id, ScanStageName.ESTABLISH_CONTEXTS.value)
+        if stage is None:
+            raise RuntimeError("Missing persisted stage 'establish_contexts'.")
+
+        stage.status = "running"
+        stage.attempt += 1
+        stage.started_at = datetime.now(timezone.utc)
+        run.current_stage = ScanStageName.ESTABLISH_CONTEXTS.value
+        session.flush()
+        try:
+            contexts = self.context_service.establish(session, run)
+        except Exception as error:
+            session.rollback()
+            run = session.get(ScanRun, scan_run_id)
+            stage = self._stage(session, scan_run_id, ScanStageName.ESTABLISH_CONTEXTS.value)
+            if run is not None:
+                run.status = ScanRunStatus.INCOMPLETE.value
+                run.completeness = CompletenessStatus.INCOMPLETE.value
+                run.error_code = "context_establishment_invalid"
+                run.error_message = str(error)
+                run.finished_at = datetime.now(timezone.utc)
+            if stage is not None:
+                stage.status = "failed"
+                stage.error_code = "context_establishment_invalid"
+                stage.error_message = str(error)
+                stage.finished_at = datetime.now(timezone.utc)
+            session.commit()
+            raise
+
+        if run.status == ScanRunStatus.INCOMPLETE.value:
+            stage.status = "failed"
+            stage.error_code = run.error_code
+            stage.error_message = run.error_message
+            stage.summary = "One or more required authentication contexts failed."
+        else:
+            stage.status = "completed"
+            stage.summary = "Established anonymous, user, and admin contexts."
+            run.progress = PROGRESS_AFTER_STAGE[ScanStageName.ESTABLISH_CONTEXTS.value]
+        stage.finished_at = datetime.now(timezone.utc)
+        session.commit()
+        return contexts
 
     def execute(self, session: Session, scan_run_id: int) -> None:
         run = session.get(ScanRun, scan_run_id)
@@ -114,6 +170,7 @@ class ScanPipeline:
             run.progress = 100
             run.finished_at = datetime.now(timezone.utc)
             run.active_key = None
+            self._finalize_quick_context(session, run)
             session.commit()
         except Exception as error:  # noqa: BLE001 - stage boundary records diagnostics
             session.rollback()
@@ -392,6 +449,28 @@ class ScanPipeline:
             )
         )
         run.retry_count += max(0, attempt - 1)
+
+    def _finalize_quick_context(self, session: Session, run: ScanRun) -> None:
+        if run.mode != AssessmentMode.QUICK.value:
+            return
+        context = session.scalar(
+            select(ScanContext).where(
+                ScanContext.scan_run_id == run.id,
+                ScanContext.kind == ContextKind.ANONYMOUS.value,
+            )
+        )
+        if context is None:
+            raise RuntimeError("Missing persisted anonymous quick-scan context.")
+        context.status = run.status
+        context.login_status = "not_applicable"
+        context.session_validation_status = "not_applicable"
+        context.collection_status = "completed"
+        context.completeness = CompletenessStatus.LEGACY_SINGLE_CONTEXT.value
+        context.asset_count = len(run.assets)
+        context.request_count = len(run.requests)
+        context.failure_count = len(run.failures)
+        context.started_at = context.started_at or run.started_at
+        context.finished_at = run.finished_at
 
     def _try_failure_report(self, session: Session, run: ScanRun) -> None:
         try:

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -1,4 +1,4 @@
-"""Persisted six-stage URL-to-report execution pipeline."""
+"""Quick URL-to-report execution mapped onto the unified assessment stages."""
 
 from __future__ import annotations
 
@@ -27,7 +27,6 @@ from app.services.scan_reporting import ScanReportService
 STAGES = [stage.value for stage in ScanStageName]
 PROGRESS_AFTER_STAGE = {
     ScanStageName.VALIDATE.value: 8,
-    ScanStageName.DISCOVER.value: 20,
     ScanStageName.COLLECT.value: 58,
     ScanStageName.NORMALIZE.value: 68,
     ScanStageName.ANALYZE.value: 86,
@@ -77,19 +76,12 @@ class ScanPipeline:
                 deadline,
                 lambda: self._validate(run),
             )
-            entry = self._run_stage(
-                session,
-                run,
-                ScanStageName.DISCOVER.value,
-                deadline,
-                lambda: self._discover(session, run, options),
-            )
             self._run_stage(
                 session,
                 run,
                 ScanStageName.COLLECT.value,
                 deadline,
-                lambda: self._collect(session, run, entry, options, deadline),
+                lambda: self._discover_and_collect(session, run, options, deadline),
             )
             self._run_stage(
                 session,
@@ -192,6 +184,17 @@ class ScanPipeline:
             f"Fetched entry URL with HTTP {result.status_code}; "
             f"discovered {len(result.discovered_urls)} linked URL(s)."
         )
+
+    def _discover_and_collect(
+        self,
+        session: Session,
+        run: ScanRun,
+        options: ScanOptions,
+        deadline: float,
+    ):
+        entry, discovery_summary = self._discover(session, run, options)
+        result, collection_summary = self._collect(session, run, entry, options, deadline)
+        return result, f"{discovery_summary} {collection_summary}"
 
     def _collect(
         self,

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -22,7 +22,13 @@ from app.models.scan_run import (
 )
 from app.redaction.service import RedactionService
 from app.schemas.scan import FetchResult, ScanOptions, ScanRunStatus, ScanStageName
+from app.services.context_collection import (
+    ContextCollectionService,
+    ContextCollectionSummary,
+    DefaultContextCollectionGateway,
+)
 from app.services.context_establishment import ContextEstablishmentService
+from app.services.coverage_identity import canonical_asset_identity, redacted_observed_url
 from app.services.scan_analysis import PassiveScanAnalyzer
 from app.services.scan_network import FetchError, HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_reporting import ScanReportService
@@ -52,6 +58,7 @@ class ScanPipeline:
         report_service: ScanReportService | None = None,
         redaction_service: RedactionService | None = None,
         context_service: ContextEstablishmentService | None = None,
+        context_collection_service: ContextCollectionService | None = None,
         clock=time.monotonic,
     ) -> None:
         self.policy = policy
@@ -60,6 +67,9 @@ class ScanPipeline:
         self.report_service = report_service or ScanReportService()
         self.redaction_service = redaction_service or RedactionService()
         self.context_service = context_service or ContextEstablishmentService()
+        self.context_collection_service = context_collection_service or ContextCollectionService(
+            gateway=DefaultContextCollectionGateway(http_gateway=gateway)
+        )
         self.clock = clock
 
     def establish_contexts(self, session: Session, scan_run_id: int) -> list[ScanContext]:
@@ -111,6 +121,77 @@ class ScanPipeline:
         stage.finished_at = datetime.now(timezone.utc)
         session.commit()
         return contexts
+
+    def collect_contexts(
+        self,
+        session: Session,
+        scan_run_id: int,
+    ) -> list[ContextCollectionSummary]:
+        """Execute context collection independently so one failure retains other results."""
+
+        run = session.get(ScanRun, scan_run_id)
+        if run is None:
+            raise InputValidationError(f"Scan run {scan_run_id} was not found.")
+        if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
+            raise InputValidationError("Only authenticated coverage runs collect three contexts.")
+        stage = self._stage(session, run.id, ScanStageName.COLLECT.value)
+        if stage is None:
+            raise RuntimeError("Missing persisted stage 'collect'.")
+        stage.status = "running"
+        stage.attempt += 1
+        stage.started_at = datetime.now(timezone.utc)
+        run.current_stage = ScanStageName.COLLECT.value
+        session.flush()
+
+        summaries: list[ContextCollectionSummary] = []
+        failed_kinds: set[str] = set()
+        contexts = list(
+            session.scalars(
+                select(ScanContext)
+                .where(ScanContext.scan_run_id == run.id)
+                .order_by(ScanContext.id)
+            )
+        )
+        for context in contexts:
+            if context.status == "failed":
+                failed_kinds.add(context.kind)
+                continue
+            try:
+                with session.begin_nested():
+                    summaries.append(self.context_collection_service.collect(session, run, context))
+            except Exception:  # noqa: BLE001 - context boundary persists only a safe diagnostic
+                context = session.get(ScanContext, context.id)
+                context.status = "failed"
+                context.collection_status = "failed"
+                context.completeness = CompletenessStatus.INCOMPLETE.value
+                context.failure_count += 1
+                context.error_code = "context_collection_failed"
+                context.error_message = "Collection failed for this context."
+                context.finished_at = datetime.now(timezone.utc)
+                failed_kinds.add(context.kind)
+
+        if failed_kinds:
+            run.status = ScanRunStatus.INCOMPLETE.value
+            if failed_kinds == {ContextKind.USER.value}:
+                run.completeness = CompletenessStatus.MISSING_USER_CONTEXT.value
+            elif failed_kinds == {ContextKind.ADMIN.value}:
+                run.completeness = CompletenessStatus.MISSING_ADMIN_CONTEXT.value
+            else:
+                run.completeness = CompletenessStatus.INCOMPLETE.value
+            run.error_code = "context_collection_incomplete"
+            run.error_message = "One or more contexts could not be collected completely."
+            stage.status = "completed_with_warnings"
+            stage.summary = (
+                f"Collected {len(summaries)} context(s); "
+                f"{len(failed_kinds)} context(s) were incomplete."
+            )
+        else:
+            stage.status = "completed"
+            stage.summary = f"Collected {len(summaries)} context(s)."
+            run.progress = PROGRESS_AFTER_STAGE[ScanStageName.COLLECT.value]
+        stage.finished_at = datetime.now(timezone.utc)
+        session.commit()
+        return summaries
 
     def execute(self, session: Session, scan_run_id: int) -> None:
         run = session.get(ScanRun, scan_run_id)
@@ -366,11 +447,20 @@ class ScanPipeline:
     def _persist_fetch(
         self, session: Session, run: ScanRun, result: FetchResult, *, depth: int
     ) -> None:
+        context = session.scalar(
+            select(ScanContext).where(
+                ScanContext.scan_run_id == run.id,
+                ScanContext.kind == ContextKind.ANONYMOUS.value,
+            )
+        )
+        if context is None:
+            raise RuntimeError("Missing persisted anonymous quick-scan context.")
+        identity_key = canonical_asset_identity("GET", result.final_url)
         asset = session.scalar(
             select(ScanAsset).where(
                 ScanAsset.scan_run_id == run.id,
-                ScanAsset.asset_type == "page",
-                ScanAsset.url == result.final_url,
+                ScanAsset.context_id == context.id,
+                ScanAsset.identity_key == identity_key,
             )
         )
         now = datetime.now(timezone.utc)
@@ -387,8 +477,10 @@ class ScanPipeline:
         if asset is None:
             asset = ScanAsset(
                 scan_run_id=run.id,
+                context_id=context.id,
+                identity_key=identity_key,
                 asset_type="page",
-                url=result.final_url,
+                url=redacted_observed_url(result.final_url),
                 method="GET",
                 status_code=result.status_code,
                 title=result.title,

--- a/app/services/session_storage.py
+++ b/app/services/session_storage.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from app.core.errors import InputValidationError
 
@@ -19,6 +21,20 @@ class SessionStorageService:
     def write_payload(self, session_id: int, payload: dict[str, Any]) -> str:
         storage_path = self.base_directory / f"session-{session_id}.json"
         storage_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return str(storage_path)
+
+    def write_request_payload(
+        self,
+        run_id: int,
+        context_id: int,
+        payload: dict[str, Any],
+    ) -> str:
+        storage_directory = self.base_directory / "requests" / f"run-{run_id}"
+        storage_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        storage_path = storage_directory / f"context-{context_id}-{uuid4().hex}.json"
+        descriptor = os.open(storage_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
         return str(storage_path)
 
     def read_payload(self, storage_ref: str) -> dict[str, Any]:

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -72,7 +72,10 @@ class AuthSessionService:
         candidates = list(
             session.scalars(
                 select(AuthSession)
-                .where(AuthSession.credential_profile_id == profile_id)
+                .where(
+                    AuthSession.credential_profile_id == profile_id,
+                    AuthSession.target_id == credential.target_id,
+                )
                 .order_by(AuthSession.id.desc())
             )
         )

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core.errors import ConflictError, ResourceNotFoundError
+from app.core.errors import ConflictError, GardenError, ResourceNotFoundError
 from app.integrations.auth.http_adapter import HttpLoginAdapter
 from app.integrations.auth.playwright_adapter import PlaywrightLoginAdapter
 from app.models.auth_session import AuthSession
@@ -62,6 +62,43 @@ class AuthSessionService:
         credential = self.credential_service.get_by_target_and_name(
             session, target.id, profile_name
         )
+        result, _auth_session = self._login_profile(session, credential)
+        return result
+
+    def ensure_valid_for_profile(self, session: Session, profile_id: int) -> AuthSession:
+        """Return a storage-backed session after adapter validation, logging in if needed."""
+
+        credential = self.credential_service.get(session, profile_id)
+        candidates = list(
+            session.scalars(
+                select(AuthSession)
+                .where(AuthSession.credential_profile_id == profile_id)
+                .order_by(AuthSession.id.desc())
+            )
+        )
+        for candidate in candidates:
+            try:
+                validation = self.validate(session, candidate.id)
+                if validation.valid:
+                    return candidate
+                if candidate.refresh_supported:
+                    refreshed = self.refresh(session, candidate.id)
+                    if refreshed.success and self.validate(session, candidate.id).valid:
+                        return candidate
+            except GardenError:
+                continue
+
+        login_result, auth_session = self._login_profile(session, credential)
+        if not login_result.success or auth_session is None:
+            raise ConflictError("Authentication login failed for the credential profile.")
+        if not self.validate(session, auth_session.id).valid:
+            raise ConflictError("The newly created authentication session was not valid.")
+        return auth_session
+
+    def _login_profile(
+        self, session: Session, credential: CredentialProfile
+    ) -> tuple[LoginExecutionResult, AuthSession | None]:
+        target = self.target_service.get(session, credential.target_id)
         config = self.login_config_service.load(credential.login_config_path)
         secret_value = self.secret_resolver.resolve(credential.secret_ref)
         adapter = self._get_adapter(config)
@@ -92,7 +129,7 @@ class AuthSessionService:
             credential_profile_id=credential.id,
             auth_session_id=auth_session.id if auth_session else None,
         )
-        return result
+        return result, auth_session
 
     def list(self, session: Session) -> list[AuthSession]:
         return list(session.scalars(select(AuthSession).order_by(AuthSession.id.desc())))

--- a/migrations/versions/0002_unified_assessment.py
+++ b/migrations/versions/0002_unified_assessment.py
@@ -211,7 +211,12 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["credential_profile_id"], ["credential_profiles.id"]),
         sa.ForeignKeyConstraint(["auth_session_id"], ["auth_sessions.id"]),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("scan_run_id", "kind"),
+        sa.CheckConstraint(
+            "kind IN ('anonymous', 'user', 'admin')",
+            name="ck_scan_contexts_kind",
+        ),
+        sa.UniqueConstraint("scan_run_id", "kind", name="uq_scan_contexts_run_kind"),
+        sa.UniqueConstraint("scan_run_id", "id", name="uq_scan_contexts_run_id_id"),
     )
     op.create_index("ix_scan_contexts_scan_run_id", "scan_contexts", ["scan_run_id"])
     op.create_index("ix_scan_contexts_kind", "scan_contexts", ["kind"])
@@ -233,8 +238,12 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column("context_id", sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column("identity_key", sa.String(length=1000), nullable=True))
         batch_op.create_foreign_key(
-            "fk_scan_assets_context_id_scan_contexts", "scan_contexts", ["context_id"], ["id"]
+            "fk_scan_assets_run_context",
+            "scan_contexts",
+            ["scan_run_id", "context_id"],
+            ["scan_run_id", "id"],
         )
+        batch_op.create_unique_constraint("uq_scan_assets_run_id_id", ["scan_run_id", "id"])
         batch_op.create_index("ix_scan_assets_context_id", ["context_id"], unique=False)
         batch_op.create_index("ix_scan_assets_identity_key", ["identity_key"], unique=False)
     _replace_scan_asset_unique_constraint()
@@ -247,8 +256,7 @@ def upgrade() -> None:
         sa.Column("source_context_id", sa.Integer(), nullable=False),
         sa.Column("asset_id", sa.Integer(), nullable=True),
         sa.Column("method", sa.String(length=16), nullable=False),
-        sa.Column("normalized_url", sa.String(length=1000), nullable=False),
-        sa.Column("redacted_url", sa.String(length=1000), nullable=False),
+        sa.Column("normalized_redacted_url", sa.String(length=1000), nullable=False),
         sa.Column("header_names", sa.JSON(), nullable=False),
         sa.Column("fingerprint", sa.String(length=128), nullable=False),
         sa.Column("replay_allowed", sa.Boolean(), nullable=False),
@@ -258,9 +266,23 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
-        sa.ForeignKeyConstraint(["source_context_id"], ["scan_contexts.id"]),
-        sa.ForeignKeyConstraint(["asset_id"], ["scan_assets.id"]),
+        sa.ForeignKeyConstraint(
+            ["scan_run_id", "source_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_scan_requests_run_source_context",
+        ),
+        sa.ForeignKeyConstraint(
+            ["scan_run_id", "asset_id"],
+            ["scan_assets.scan_run_id", "scan_assets.id"],
+            name="fk_scan_requests_run_asset",
+        ),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scan_run_id",
+            "id",
+            "source_context_id",
+            name="uq_scan_requests_run_id_source_context",
+        ),
     )
     for column in (
         "scan_run_id",
@@ -326,9 +348,25 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
-        sa.ForeignKeyConstraint(["source_request_id"], ["scan_requests.id"]),
-        sa.ForeignKeyConstraint(["source_context_id"], ["scan_contexts.id"]),
-        sa.ForeignKeyConstraint(["target_context_id"], ["scan_contexts.id"]),
+        sa.ForeignKeyConstraint(
+            ["scan_run_id", "source_request_id", "source_context_id"],
+            [
+                "scan_requests.scan_run_id",
+                "scan_requests.id",
+                "scan_requests.source_context_id",
+            ],
+            name="fk_replay_executions_run_source_request_context",
+        ),
+        sa.ForeignKeyConstraint(
+            ["scan_run_id", "source_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_replay_executions_run_source_context",
+        ),
+        sa.ForeignKeyConstraint(
+            ["scan_run_id", "target_context_id"],
+            ["scan_contexts.scan_run_id", "scan_contexts.id"],
+            name="fk_replay_executions_run_target_context",
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("scan_run_id", "source_request_id", "target_context_id", "policy_hash"),
     )
@@ -352,7 +390,8 @@ def downgrade() -> None:
     with op.batch_alter_table("scan_assets") as batch_op:
         batch_op.drop_index("ix_scan_assets_identity_key")
         batch_op.drop_index("ix_scan_assets_context_id")
-        batch_op.drop_constraint("fk_scan_assets_context_id_scan_contexts", type_="foreignkey")
+        batch_op.drop_constraint("fk_scan_assets_run_context", type_="foreignkey")
+        batch_op.drop_constraint("uq_scan_assets_run_id_id", type_="unique")
         batch_op.drop_column("identity_key")
         batch_op.drop_column("context_id")
 

--- a/migrations/versions/0002_unified_assessment.py
+++ b/migrations/versions/0002_unified_assessment.py
@@ -1,0 +1,373 @@
+"""建立统一验证运行模型。
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-08-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from urllib.parse import parse_qsl, urlsplit
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | Sequence[str] | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _legacy_asset_identity(method: str | None, url: str) -> str:
+    parsed = urlsplit(url)
+    path = parsed.path.rstrip("/") or "/"
+    parameter_names = sorted(
+        {name for name, _value in parse_qsl(parsed.query, keep_blank_values=True)}
+    )
+    query_suffix = f"?{'&'.join(parameter_names)}" if parameter_names else ""
+    return f"{(method or 'GET').upper()}:{path}{query_suffix}"
+
+
+def _replace_scan_asset_unique_constraint(*, restoring_legacy: bool = False) -> None:
+    bind = op.get_bind()
+    constraints = sa.inspect(bind).get_unique_constraints("scan_assets")
+    expected_columns = (
+        {"scan_run_id", "context_id", "asset_type", "url"}
+        if restoring_legacy
+        else {"scan_run_id", "asset_type", "url"}
+    )
+    old_constraint = next(
+        item for item in constraints if set(item.get("column_names") or ()) == expected_columns
+    )
+    old_name = old_constraint.get("name")
+    naming_convention = None
+    if old_name is None:
+        naming_convention = {"uq": "uq_%(table_name)s_%(column_0_N_name)s"}
+        old_name = "uq_scan_assets_" + "_".join(old_constraint["column_names"])
+
+    with op.batch_alter_table(
+        "scan_assets",
+        naming_convention=naming_convention,
+    ) as batch_op:
+        batch_op.drop_constraint(old_name, type_="unique")
+        if restoring_legacy:
+            batch_op.create_unique_constraint(
+                "uq_scan_assets_scan_run_id_asset_type_url",
+                ["scan_run_id", "asset_type", "url"],
+            )
+        else:
+            batch_op.create_unique_constraint(
+                "uq_scan_assets_run_context_type_url",
+                ["scan_run_id", "context_id", "asset_type", "url"],
+            )
+
+
+def _backfill_quick_contexts_and_asset_identity() -> None:
+    bind = op.get_bind()
+    metadata = sa.MetaData()
+    scan_runs = sa.Table("scan_runs", metadata, autoload_with=bind)
+    scan_contexts = sa.Table("scan_contexts", metadata, autoload_with=bind)
+    scan_assets = sa.Table("scan_assets", metadata, autoload_with=bind)
+
+    now = datetime.now(timezone.utc)
+    runs = bind.execute(sa.select(scan_runs)).mappings().all()
+    for run in runs:
+        context_status = str(run["status"])
+        collection_status = context_status if context_status != "queued" else "pending"
+        if context_status in {"completed", "completed_with_warnings"}:
+            completeness = "complete"
+        elif context_status == "failed":
+            completeness = "incomplete"
+        else:
+            completeness = "pending"
+        bind.execute(
+            scan_runs.update().where(scan_runs.c.id == run["id"]).values(completeness=completeness)
+        )
+        bind.execute(
+            scan_contexts.insert().values(
+                scan_run_id=run["id"],
+                kind="anonymous",
+                status=context_status,
+                login_status="skipped",
+                session_validation_status="skipped",
+                collection_status=collection_status,
+                completeness=completeness,
+                asset_count=0,
+                request_count=0,
+                failure_count=0,
+                created_at=run.get("created_at") or now,
+                updated_at=run.get("updated_at") or now,
+            )
+        )
+
+    context_by_run = dict(
+        bind.execute(
+            sa.select(scan_contexts.c.scan_run_id, scan_contexts.c.id).where(
+                scan_contexts.c.kind == "anonymous"
+            )
+        ).all()
+    )
+    assets = bind.execute(
+        sa.select(
+            scan_assets.c.id,
+            scan_assets.c.scan_run_id,
+            scan_assets.c.method,
+            scan_assets.c.url,
+        )
+    ).mappings()
+    for asset in assets:
+        bind.execute(
+            scan_assets.update()
+            .where(scan_assets.c.id == asset["id"])
+            .values(
+                context_id=context_by_run.get(asset["scan_run_id"]),
+                identity_key=_legacy_asset_identity(asset["method"], asset["url"]),
+            )
+        )
+
+    asset_counts = dict(
+        bind.execute(
+            sa.select(scan_assets.c.context_id, sa.func.count(scan_assets.c.id))
+            .where(scan_assets.c.context_id.is_not(None))
+            .group_by(scan_assets.c.context_id)
+        ).all()
+    )
+    for context_id, asset_count in asset_counts.items():
+        bind.execute(
+            scan_contexts.update()
+            .where(scan_contexts.c.id == context_id)
+            .values(asset_count=asset_count)
+        )
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("scan_runs") as batch_op:
+        batch_op.add_column(
+            sa.Column("mode", sa.String(length=40), server_default="quick", nullable=False)
+        )
+        batch_op.add_column(sa.Column("target_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("source_run_id", sa.Integer(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "active_checks_enabled",
+                sa.Boolean(),
+                server_default=sa.false(),
+                nullable=False,
+            )
+        )
+        batch_op.add_column(
+            sa.Column("authorization_confirmed_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("authorization_confirmed_by", sa.String(length=255), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "completeness", sa.String(length=64), server_default="pending", nullable=False
+            )
+        )
+        batch_op.create_foreign_key(
+            "fk_scan_runs_target_id_targets", "targets", ["target_id"], ["id"]
+        )
+        batch_op.create_foreign_key(
+            "fk_scan_runs_source_run_id_scan_runs", "scan_runs", ["source_run_id"], ["id"]
+        )
+        batch_op.create_index("ix_scan_runs_mode", ["mode"], unique=False)
+        batch_op.create_index("ix_scan_runs_target_id", ["target_id"], unique=False)
+        batch_op.create_index("ix_scan_runs_source_run_id", ["source_run_id"], unique=False)
+        batch_op.create_index("ix_scan_runs_completeness", ["completeness"], unique=False)
+
+    op.create_table(
+        "scan_contexts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scan_run_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("credential_profile_id", sa.Integer(), nullable=True),
+        sa.Column("auth_session_id", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=40), server_default="pending", nullable=False),
+        sa.Column("login_status", sa.String(length=40), server_default="pending", nullable=False),
+        sa.Column(
+            "session_validation_status",
+            sa.String(length=40),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column(
+            "collection_status", sa.String(length=40), server_default="pending", nullable=False
+        ),
+        sa.Column("completeness", sa.String(length=64), server_default="pending", nullable=False),
+        sa.Column("asset_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("request_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("failure_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_code", sa.String(length=120), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
+        sa.ForeignKeyConstraint(["credential_profile_id"], ["credential_profiles.id"]),
+        sa.ForeignKeyConstraint(["auth_session_id"], ["auth_sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scan_run_id", "kind"),
+    )
+    op.create_index("ix_scan_contexts_scan_run_id", "scan_contexts", ["scan_run_id"])
+    op.create_index("ix_scan_contexts_kind", "scan_contexts", ["kind"])
+    op.create_index(
+        "ix_scan_contexts_credential_profile_id", "scan_contexts", ["credential_profile_id"]
+    )
+    op.create_index("ix_scan_contexts_auth_session_id", "scan_contexts", ["auth_session_id"])
+    op.create_index("ix_scan_contexts_status", "scan_contexts", ["status"])
+    op.create_index("ix_scan_contexts_login_status", "scan_contexts", ["login_status"])
+    op.create_index(
+        "ix_scan_contexts_session_validation_status",
+        "scan_contexts",
+        ["session_validation_status"],
+    )
+    op.create_index("ix_scan_contexts_collection_status", "scan_contexts", ["collection_status"])
+    op.create_index("ix_scan_contexts_completeness", "scan_contexts", ["completeness"])
+
+    with op.batch_alter_table("scan_assets") as batch_op:
+        batch_op.add_column(sa.Column("context_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("identity_key", sa.String(length=1000), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_scan_assets_context_id_scan_contexts", "scan_contexts", ["context_id"], ["id"]
+        )
+        batch_op.create_index("ix_scan_assets_context_id", ["context_id"], unique=False)
+        batch_op.create_index("ix_scan_assets_identity_key", ["identity_key"], unique=False)
+    _replace_scan_asset_unique_constraint()
+    _backfill_quick_contexts_and_asset_identity()
+
+    op.create_table(
+        "scan_requests",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scan_run_id", sa.Integer(), nullable=False),
+        sa.Column("source_context_id", sa.Integer(), nullable=False),
+        sa.Column("asset_id", sa.Integer(), nullable=True),
+        sa.Column("method", sa.String(length=16), nullable=False),
+        sa.Column("normalized_url", sa.String(length=1000), nullable=False),
+        sa.Column("redacted_url", sa.String(length=1000), nullable=False),
+        sa.Column("header_names", sa.JSON(), nullable=False),
+        sa.Column("fingerprint", sa.String(length=128), nullable=False),
+        sa.Column("replay_allowed", sa.Boolean(), nullable=False),
+        sa.Column("replay_status", sa.String(length=40), nullable=False),
+        sa.Column("replay_reason", sa.Text(), nullable=True),
+        sa.Column("protected_storage_ref", sa.String(length=1000), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
+        sa.ForeignKeyConstraint(["source_context_id"], ["scan_contexts.id"]),
+        sa.ForeignKeyConstraint(["asset_id"], ["scan_assets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    for column in (
+        "scan_run_id",
+        "source_context_id",
+        "asset_id",
+        "method",
+        "fingerprint",
+        "replay_status",
+    ):
+        op.create_index(f"ix_scan_requests_{column}", "scan_requests", [column])
+
+    op.create_table(
+        "coverage_differences",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scan_run_id", sa.Integer(), nullable=False),
+        sa.Column("identity_key", sa.String(length=1000), nullable=False),
+        sa.Column("classification", sa.String(length=64), nullable=False),
+        sa.Column("anonymous_state", sa.String(length=32), nullable=False),
+        sa.Column("user_state", sa.String(length=32), nullable=False),
+        sa.Column("admin_state", sa.String(length=32), nullable=False),
+        sa.Column("anonymous_present", sa.Boolean(), nullable=True),
+        sa.Column("user_present", sa.Boolean(), nullable=True),
+        sa.Column("admin_present", sa.Boolean(), nullable=True),
+        sa.Column("context_summaries", sa.JSON(), nullable=False),
+        sa.Column("confidence", sa.String(length=32), nullable=False),
+        sa.Column("diagnostic", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scan_run_id", "identity_key"),
+    )
+    op.create_index("ix_coverage_differences_scan_run_id", "coverage_differences", ["scan_run_id"])
+    op.create_index(
+        "ix_coverage_differences_identity_key", "coverage_differences", ["identity_key"]
+    )
+    op.create_index(
+        "ix_coverage_differences_classification", "coverage_differences", ["classification"]
+    )
+    op.create_index("ix_coverage_differences_confidence", "coverage_differences", ["confidence"])
+
+    op.create_table(
+        "replay_executions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scan_run_id", sa.Integer(), nullable=False),
+        sa.Column("source_request_id", sa.Integer(), nullable=False),
+        sa.Column("source_context_id", sa.Integer(), nullable=False),
+        sa.Column("target_context_id", sa.Integer(), nullable=False),
+        sa.Column("policy_snapshot", sa.JSON(), nullable=False),
+        sa.Column("policy_hash", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=40), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("redirects", sa.JSON(), nullable=False),
+        sa.Column("response_status_code", sa.Integer(), nullable=True),
+        sa.Column("response_final_url_redacted", sa.String(length=1000), nullable=True),
+        sa.Column("response_fingerprint", sa.String(length=128), nullable=True),
+        sa.Column("response_summary_redacted", sa.JSON(), nullable=False),
+        sa.Column("verdict", sa.String(length=40), nullable=True),
+        sa.Column("verdict_reason", sa.Text(), nullable=True),
+        sa.Column("error_code", sa.String(length=120), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["scan_run_id"], ["scan_runs.id"]),
+        sa.ForeignKeyConstraint(["source_request_id"], ["scan_requests.id"]),
+        sa.ForeignKeyConstraint(["source_context_id"], ["scan_contexts.id"]),
+        sa.ForeignKeyConstraint(["target_context_id"], ["scan_contexts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scan_run_id", "source_request_id", "target_context_id", "policy_hash"),
+    )
+    for column in (
+        "scan_run_id",
+        "source_request_id",
+        "source_context_id",
+        "target_context_id",
+        "status",
+        "verdict",
+    ):
+        op.create_index(f"ix_replay_executions_{column}", "replay_executions", [column])
+
+
+def downgrade() -> None:
+    op.drop_table("replay_executions")
+    op.drop_table("coverage_differences")
+    op.drop_table("scan_requests")
+
+    _replace_scan_asset_unique_constraint(restoring_legacy=True)
+    with op.batch_alter_table("scan_assets") as batch_op:
+        batch_op.drop_index("ix_scan_assets_identity_key")
+        batch_op.drop_index("ix_scan_assets_context_id")
+        batch_op.drop_constraint("fk_scan_assets_context_id_scan_contexts", type_="foreignkey")
+        batch_op.drop_column("identity_key")
+        batch_op.drop_column("context_id")
+
+    op.drop_table("scan_contexts")
+    with op.batch_alter_table("scan_runs") as batch_op:
+        batch_op.drop_index("ix_scan_runs_completeness")
+        batch_op.drop_index("ix_scan_runs_source_run_id")
+        batch_op.drop_index("ix_scan_runs_target_id")
+        batch_op.drop_index("ix_scan_runs_mode")
+        batch_op.drop_constraint("fk_scan_runs_source_run_id_scan_runs", type_="foreignkey")
+        batch_op.drop_constraint("fk_scan_runs_target_id_targets", type_="foreignkey")
+        batch_op.drop_column("completeness")
+        batch_op.drop_column("authorization_confirmed_by")
+        batch_op.drop_column("authorization_confirmed_at")
+        batch_op.drop_column("active_checks_enabled")
+        batch_op.drop_column("source_run_id")
+        batch_op.drop_column("target_id")
+        batch_op.drop_column("mode")

--- a/tests/helpers/assessment.py
+++ b/tests/helpers/assessment.py
@@ -84,7 +84,7 @@ def add_request(
     session: Session,
     context: ScanContext,
     *,
-    redacted_url: str = "http://127.0.0.1:8000/items?token=[REDACTED]",
+    normalized_redacted_url: str = "http://127.0.0.1:8000/items?token=[REDACTED]",
     fingerprint: str = "request-fingerprint",
     protected_storage_ref: str = "vault://assessment/request/1",
 ) -> ScanRequest:
@@ -92,8 +92,7 @@ def add_request(
         scan_run_id=context.scan_run_id,
         source_context_id=context.id,
         method="GET",
-        normalized_url=redacted_url,
-        redacted_url=redacted_url,
+        normalized_redacted_url=normalized_redacted_url,
         fingerprint=fingerprint,
         protected_storage_ref=protected_storage_ref,
     )

--- a/tests/helpers/assessment.py
+++ b/tests/helpers/assessment.py
@@ -1,0 +1,102 @@
+"""统一验证运行测试数据工厂。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.scan_context import ScanContext
+from app.models.scan_request import ScanRequest
+from app.models.scan_run import ScanAsset, ScanRun
+
+
+def make_run(
+    session: Session,
+    *,
+    mode: str = "quick",
+    input_url: str = "http://127.0.0.1:8000",
+) -> ScanRun:
+    run = ScanRun(
+        input_url=input_url,
+        normalized_url=input_url,
+        mode=mode,
+        status="queued",
+        current_stage="queued",
+        options={},
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+def make_authenticated_run(
+    session: Session,
+    user_profile_id: int | None = None,
+    admin_profile_id: int | None = None,
+) -> ScanRun:
+    run = make_run(session, mode="authenticated_coverage")
+    session.add_all(
+        [
+            ScanContext(scan_run_id=run.id, kind="anonymous", status="pending"),
+            ScanContext(
+                scan_run_id=run.id,
+                kind="user",
+                credential_profile_id=user_profile_id,
+                status="pending",
+            ),
+            ScanContext(
+                scan_run_id=run.id,
+                kind="admin",
+                credential_profile_id=admin_profile_id,
+                status="pending",
+            ),
+        ]
+    )
+    session.flush()
+    return run
+
+
+def add_asset(
+    session: Session,
+    run: ScanRun,
+    *,
+    url: str = "http://127.0.0.1:8000/",
+    context_id: int | None = None,
+    identity_key: str = "GET:/",
+) -> ScanAsset:
+    asset = ScanAsset(
+        scan_run_id=run.id,
+        context_id=context_id,
+        identity_key=identity_key,
+        asset_type="page",
+        url=url,
+        method="GET",
+        attributes={},
+        discovered_at=datetime.now(timezone.utc),
+    )
+    session.add(asset)
+    session.flush()
+    return asset
+
+
+def add_request(
+    session: Session,
+    context: ScanContext,
+    *,
+    redacted_url: str = "http://127.0.0.1:8000/items?token=[REDACTED]",
+    fingerprint: str = "request-fingerprint",
+    protected_storage_ref: str = "vault://assessment/request/1",
+) -> ScanRequest:
+    request = ScanRequest(
+        scan_run_id=context.scan_run_id,
+        source_context_id=context.id,
+        method="GET",
+        normalized_url=redacted_url,
+        redacted_url=redacted_url,
+        fingerprint=fingerprint,
+        protected_storage_ref=protected_storage_ref,
+    )
+    session.add(request)
+    session.flush()
+    return request

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -189,6 +189,42 @@ def test_authenticated_assessment_can_reference_quick_source_run(
     assert view.asset_count == 0
 
 
+def test_authenticated_assessments_keep_distinct_quick_source_runs(
+    inline_service, completed_quick_run, assessment_profiles
+):
+    second_quick_run = inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="quick",
+            target_id=assessment_profiles.target_id,
+        )
+    )
+
+    first_upgrade = inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            source_run_id=completed_quick_run.id,
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    second_upgrade = inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            source_run_id=second_quick_run.id,
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+
+    assert completed_quick_run.id != second_quick_run.id
+    assert first_upgrade.id != second_upgrade.id
+    assert first_upgrade.source_run_id == completed_quick_run.id
+    assert second_upgrade.source_run_id == second_quick_run.id
+
+
 def test_source_run_must_be_terminal_quick_run_for_same_target(tmp_path, assessment_profiles):
     service, _dispatcher = build_holding_service(tmp_path)
     queued_quick = service.start_assessment(
@@ -327,8 +363,11 @@ def test_active_key_distinguishes_mode_profiles_active_flag_and_full_options(
     assert dispatcher.ids == [quick.id]
 
 
-@pytest.mark.parametrize("terminal_status", ["incomplete", "interrupted"])
-def test_wait_for_completion_accepts_new_terminal_status_and_clears_active_key(
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["completed", "completed_with_warnings", "failed", "incomplete", "interrupted"],
+)
+def test_committing_new_terminal_status_clears_active_key_and_allows_retry(
     tmp_path, terminal_status
 ):
     service, _dispatcher = build_holding_service(tmp_path)
@@ -339,8 +378,8 @@ def test_wait_for_completion_accepts_new_terminal_status_and_clears_active_key(
         run.finished_at = datetime.now(timezone.utc)
         session.commit()
 
-    terminal = service.wait_for_completion(view.id, timeout_seconds=0.2)
+    retry = service.start_scan("http://127.0.0.1:8080/")
 
-    assert terminal.status == terminal_status
+    assert retry.id != view.id
     with get_session() as session:
         assert session.get(ScanRun, view.id).active_key is None

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from app.core.errors import InputValidationError
+from app.core.settings import get_settings
+from app.db.bootstrap import get_session
+from app.models.credential_profile import CredentialProfile
+from app.models.scan_run import ScanRun
+from app.models.target import Target
+from app.schemas.assessment import AssessmentStartRequest
+from app.schemas.scan import ScanOptions
+from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
+from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_pipeline import ScanPipeline
+from app.services.scan_reporting import ScanReportService
+
+
+def _loopback_resolver(host, port, **kwargs):
+    return [(2, 1, 6, "", ("127.0.0.1", port))]
+
+
+def build_inline_service(tmp_path) -> ScanApplicationService:
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    gateway = HttpScanGateway(
+        policy,
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text="<html><title>Assessment fixture</title></html>",
+            )
+        ),
+    )
+    return ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=gateway,
+            report_service=ScanReportService(tmp_path / "reports"),
+        ),
+        dispatcher=InlineScanDispatcher(),
+    )
+
+
+class HoldingDispatcher:
+    def __init__(self) -> None:
+        self.ids: list[int] = []
+
+    def submit(self, scan_run_id: int, callback) -> None:
+        self.ids.append(scan_run_id)
+
+
+def build_holding_service(tmp_path) -> tuple[ScanApplicationService, HoldingDispatcher]:
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    dispatcher = HoldingDispatcher()
+    return (
+        ScanApplicationService(
+            settings=settings,
+            pipeline=ScanPipeline(
+                policy=policy,
+                gateway=HttpScanGateway(policy),
+                report_service=ScanReportService(tmp_path / "reports"),
+            ),
+            dispatcher=dispatcher,
+        ),
+        dispatcher,
+    )
+
+
+@dataclass(frozen=True)
+class AssessmentProfiles:
+    url: str
+    target_id: int
+    user_id: int
+    admin_id: int
+    alternate_user_id: int
+
+
+@pytest.fixture
+def assessment_profiles() -> AssessmentProfiles:
+    with get_session() as session:
+        target = Target(
+            name="assessment-target",
+            base_url="http://127.0.0.1:8080/",
+            type="web",
+            owner="security",
+            tags=[],
+            status="active",
+        )
+        session.add(target)
+        session.flush()
+        profiles = [
+            CredentialProfile(
+                target_id=target.id,
+                name=name,
+                role=role,
+                auth_type="password",
+                username=name,
+                secret_ref=f"env://{name}",
+                login_config_path=f"configs/{name}.yaml",
+            )
+            for name, role in [
+                ("user", "user"),
+                ("admin", "admin"),
+                ("alternate-user", "user"),
+            ]
+        ]
+        session.add_all(profiles)
+        session.commit()
+        return AssessmentProfiles(
+            url=target.base_url,
+            target_id=target.id,
+            user_id=profiles[0].id,
+            admin_id=profiles[1].id,
+            alternate_user_id=profiles[2].id,
+        )
+
+
+@pytest.fixture
+def inline_service(tmp_path) -> ScanApplicationService:
+    return build_inline_service(tmp_path)
+
+
+@pytest.fixture
+def completed_quick_run(inline_service, assessment_profiles):
+    return inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="quick",
+            target_id=assessment_profiles.target_id,
+        )
+    )
+
+
+def test_start_scan_delegates_to_quick_assessment(tmp_path):
+    service = build_inline_service(tmp_path)
+
+    view = service.start_scan("http://127.0.0.1:8080/")
+
+    assert view.mode == "quick"
+    assert [context.kind for context in view.contexts] == ["anonymous"]
+
+
+def test_start_assessment_creates_three_contexts(assessment_profiles, inline_service):
+    request = AssessmentStartRequest(
+        url=assessment_profiles.url,
+        mode="authenticated_coverage",
+        user_profile_id=assessment_profiles.user_id,
+        admin_profile_id=assessment_profiles.admin_id,
+    )
+
+    view = inline_service.start_assessment(request)
+
+    assert [item.kind for item in view.contexts] == ["anonymous", "user", "admin"]
+    assert [stage.name for stage in view.stages] == [
+        "validate",
+        "establish_contexts",
+        "collect",
+        "normalize",
+        "compare_coverage",
+        "replay_authorization",
+        "analyze",
+        "report",
+    ]
+    assert view.status == "queued"
+
+
+def test_authenticated_assessment_can_reference_quick_source_run(
+    inline_service, completed_quick_run, assessment_profiles
+):
+    view = inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=completed_quick_run.normalized_url,
+            mode="authenticated_coverage",
+            source_run_id=completed_quick_run.id,
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+
+    assert view.source_run_id == completed_quick_run.id
+    assert view.asset_count == 0
+
+
+def test_source_run_must_be_terminal_quick_run_for_same_target(tmp_path, assessment_profiles):
+    service, _dispatcher = build_holding_service(tmp_path)
+    queued_quick = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="quick",
+            target_id=assessment_profiles.target_id,
+        )
+    )
+
+    with pytest.raises(InputValidationError, match="终态 quick"):
+        service.start_assessment(
+            AssessmentStartRequest(
+                url=assessment_profiles.url,
+                mode="authenticated_coverage",
+                source_run_id=queued_quick.id,
+                user_profile_id=assessment_profiles.user_id,
+                admin_profile_id=assessment_profiles.admin_id,
+            )
+        )
+
+
+def test_source_run_rejects_terminal_quick_run_from_another_target(
+    inline_service, completed_quick_run, assessment_profiles
+):
+    with get_session() as session:
+        other_target = Target(
+            name="other-assessment-target",
+            base_url="http://127.0.0.1:9090/",
+            type="web",
+            owner="security",
+            tags=[],
+            status="active",
+        )
+        session.add(other_target)
+        session.flush()
+        source = session.get(ScanRun, completed_quick_run.id)
+        source.target_id = other_target.id
+        session.commit()
+
+    with pytest.raises(InputValidationError, match="同一 target"):
+        inline_service.start_assessment(
+            AssessmentStartRequest(
+                url=assessment_profiles.url,
+                mode="authenticated_coverage",
+                source_run_id=completed_quick_run.id,
+                user_profile_id=assessment_profiles.user_id,
+                admin_profile_id=assessment_profiles.admin_id,
+            )
+        )
+
+
+def test_source_run_rejects_terminal_authenticated_assessment(inline_service, assessment_profiles):
+    source = inline_service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    with get_session() as session:
+        run = session.get(ScanRun, source.id)
+        run.status = "incomplete"
+        run.active_key = None
+        session.commit()
+
+    with pytest.raises(InputValidationError, match="终态 quick"):
+        inline_service.start_assessment(
+            AssessmentStartRequest(
+                url=assessment_profiles.url,
+                mode="authenticated_coverage",
+                source_run_id=source.id,
+                user_profile_id=assessment_profiles.user_id,
+                admin_profile_id=assessment_profiles.admin_id,
+            )
+        )
+
+
+def test_active_key_distinguishes_mode_profiles_active_flag_and_full_options(
+    tmp_path, assessment_profiles
+):
+    service, dispatcher = build_holding_service(tmp_path)
+    base = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    duplicate = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    changed_profile = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.alternate_user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    changed_active_flag = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+            active_checks_enabled=True,
+            authorization_confirmed=True,
+        )
+    )
+    changed_options = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+            options=ScanOptions(max_depth=3),
+        )
+    )
+    quick = service.start_assessment(
+        AssessmentStartRequest(url=assessment_profiles.url, mode="quick")
+    )
+
+    assert duplicate.id == base.id
+    assert (
+        len({base.id, changed_profile.id, changed_active_flag.id, changed_options.id, quick.id})
+        == 5
+    )
+    assert dispatcher.ids == [quick.id]
+
+
+@pytest.mark.parametrize("terminal_status", ["incomplete", "interrupted"])
+def test_wait_for_completion_accepts_new_terminal_status_and_clears_active_key(
+    tmp_path, terminal_status
+):
+    service, _dispatcher = build_holding_service(tmp_path)
+    view = service.start_scan("http://127.0.0.1:8080/")
+    with get_session() as session:
+        run = session.get(ScanRun, view.id)
+        run.status = terminal_status
+        run.finished_at = datetime.now(timezone.utc)
+        session.commit()
+
+    terminal = service.wait_for_completion(view.id, timeout_seconds=0.2)
+
+    assert terminal.status == terminal_status
+    with get_session() as session:
+        assert session.get(ScanRun, view.id).active_key is None

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -5,12 +5,13 @@ from datetime import datetime, timezone
 
 import httpx
 import pytest
+from sqlalchemy import select
 
 from app.core.errors import InputValidationError
 from app.core.settings import get_settings
 from app.db.bootstrap import get_session
 from app.models.credential_profile import CredentialProfile
-from app.models.scan_run import ScanRun
+from app.models.scan_run import ScanAsset, ScanRun
 from app.models.target import Target
 from app.schemas.assessment import AssessmentStartRequest
 from app.schemas.scan import ScanOptions
@@ -158,6 +159,15 @@ def test_completed_quick_context_reflects_real_collection(completed_quick_run):
     assert context.asset_count == completed_quick_run.asset_count
     assert context.request_count == 0
     assert context.failure_count == len(completed_quick_run.failures)
+    with get_session() as session:
+        assets = list(
+            session.scalars(
+                select(ScanAsset).where(ScanAsset.scan_run_id == completed_quick_run.id)
+            )
+        )
+    assert assets
+    assert all(asset.context_id == context.id for asset in assets)
+    assert all(asset.identity_key for asset in assets)
 
 
 def test_start_assessment_creates_three_contexts(assessment_profiles, inline_service):

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -148,6 +148,18 @@ def test_start_scan_delegates_to_quick_assessment(tmp_path):
     assert [context.kind for context in view.contexts] == ["anonymous"]
 
 
+def test_completed_quick_context_reflects_real_collection(completed_quick_run):
+    context = completed_quick_run.contexts[0]
+
+    assert context.status == "completed"
+    assert context.login_status == "not_applicable"
+    assert context.session_validation_status == "not_applicable"
+    assert context.collection_status == "completed"
+    assert context.asset_count == completed_quick_run.asset_count
+    assert context.request_count == 0
+    assert context.failure_count == len(completed_quick_run.failures)
+
+
 def test_start_assessment_creates_three_contexts(assessment_profiles, inline_service):
     request = AssessmentStartRequest(
         url=assessment_profiles.url,

--- a/tests/test_assessment_models.py
+++ b/tests/test_assessment_models.py
@@ -1,0 +1,236 @@
+"""统一验证运行模型与请求协议行为测试。"""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from app.db.bootstrap import get_session
+from app.models.coverage_difference import CoverageDifference
+from app.models.enums import (
+    AssessmentMode,
+    CompletenessStatus,
+    ContextKind,
+    ReplayVerdict,
+)
+from app.models.replay_execution import ReplayExecution
+from app.models.scan_context import ScanContext
+from app.schemas.assessment import AssessmentRunView, AssessmentStartRequest
+from tests.helpers.assessment import add_asset, add_request, make_authenticated_run, make_run
+
+
+@pytest.fixture
+def db_session():
+    session = get_session()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def test_authenticated_assessment_has_exactly_three_contexts(db_session):
+    run = make_run(db_session, mode="authenticated_coverage")
+    db_session.add_all(
+        [
+            ScanContext(scan_run_id=run.id, kind="anonymous", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="admin", status="pending"),
+        ]
+    )
+
+    db_session.commit()
+
+    assert [item.kind for item in run.contexts] == ["anonymous", "user", "admin"]
+
+
+def test_context_kind_is_unique_per_run(db_session):
+    run = make_run(db_session)
+    db_session.add_all(
+        [
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+def test_assessment_enums_publish_protocol_values():
+    assert [item.value for item in AssessmentMode] == ["quick", "authenticated_coverage"]
+    assert [item.value for item in ContextKind] == ["anonymous", "user", "admin"]
+    assert [item.value for item in ReplayVerdict] == [
+        "blocked",
+        "equivalent_access",
+        "changed_response",
+        "inconclusive",
+    ]
+    assert CompletenessStatus.COMPLETE.value == "complete"
+
+
+def test_quick_assessment_rejects_credential_profiles():
+    with pytest.raises(ValidationError):
+        AssessmentStartRequest(
+            url="http://127.0.0.1:8000",
+            mode="quick",
+            user_profile_id=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("user_profile_id", "admin_profile_id"),
+    [(None, 2), (1, None), (None, None)],
+)
+def test_authenticated_assessment_requires_both_profiles(
+    user_profile_id,
+    admin_profile_id,
+):
+    with pytest.raises(ValidationError):
+        AssessmentStartRequest(
+            url="http://127.0.0.1:8000",
+            mode="authenticated_coverage",
+            user_profile_id=user_profile_id,
+            admin_profile_id=admin_profile_id,
+        )
+
+
+def test_active_replay_requires_authorization_confirmation():
+    with pytest.raises(ValidationError):
+        AssessmentStartRequest(
+            url="http://127.0.0.1:8000",
+            mode="authenticated_coverage",
+            user_profile_id=1,
+            admin_profile_id=2,
+            active_checks_enabled=True,
+        )
+
+
+def test_authorized_active_replay_is_accepted():
+    request = AssessmentStartRequest(
+        url="http://127.0.0.1:8000",
+        mode="authenticated_coverage",
+        user_profile_id=1,
+        admin_profile_id=2,
+        active_checks_enabled=True,
+        authorization_confirmed=True,
+    )
+
+    assert request.active_checks_enabled is True
+    assert request.authorization_confirmed is True
+
+
+def test_assessment_run_view_rejects_unknown_context_count_keys():
+    with pytest.raises(ValidationError):
+        AssessmentRunView(
+            id=1,
+            mode="authenticated_coverage",
+            completeness="complete",
+            active_checks_enabled=False,
+            contexts=[],
+            context_counts={"anonymous": 1, "user": 1, "admin": 1, "operator": 1},
+            difference_count=0,
+            replay_count=0,
+        )
+
+
+def test_unified_run_relationships_persist_without_mapper_ambiguity(db_session):
+    run = make_authenticated_run(db_session)
+    anonymous, user, admin = run.contexts
+    asset = add_asset(db_session, run, context_id=admin.id, identity_key="GET:/admin")
+    request = add_request(db_session, admin)
+    difference = CoverageDifference(
+        scan_run_id=run.id,
+        identity_key="GET:/admin",
+        classification="admin_only",
+        anonymous_state="absent",
+        user_state="absent",
+        admin_state="present",
+        anonymous_present=False,
+        user_present=False,
+        admin_present=True,
+        context_summaries={"admin": {"status_code": 200}},
+        confidence="high",
+        diagnostic="仅管理员上下文观察到该资产。",
+    )
+    replay = ReplayExecution(
+        scan_run_id=run.id,
+        source_request_id=request.id,
+        source_context_id=admin.id,
+        target_context_id=user.id,
+        policy_snapshot={"allowed_methods": ["GET"]},
+        policy_hash="policy-fingerprint",
+        status="completed",
+        redirects=[],
+        response_summary_redacted={"status_code": 403},
+        verdict="blocked",
+        verdict_reason="目标上下文被拒绝。",
+        started_at=datetime.now(timezone.utc),
+        finished_at=datetime.now(timezone.utc),
+    )
+    db_session.add_all([difference, replay])
+
+    db_session.commit()
+
+    assert [context.kind for context in run.contexts] == ["anonymous", "user", "admin"]
+    assert run.requests == [request]
+    assert run.coverage_differences == [difference]
+    assert run.replay_executions == [replay]
+    assert admin.assets == [asset]
+    assert admin.requests == [request]
+    assert replay.source_context is admin
+    assert replay.target_context is user
+    assert anonymous.assets == []
+
+
+def test_same_asset_url_can_be_persisted_once_per_context(db_session):
+    run = make_authenticated_run(db_session)
+    _anonymous, user, admin = run.contexts
+    user_asset = add_asset(
+        db_session,
+        run,
+        context_id=user.id,
+        url="http://127.0.0.1:8000/account",
+        identity_key="GET:/account",
+    )
+    admin_asset = add_asset(
+        db_session,
+        run,
+        context_id=admin.id,
+        url="http://127.0.0.1:8000/account",
+        identity_key="GET:/account",
+    )
+
+    db_session.commit()
+
+    assert user.assets == [user_asset]
+    assert admin.assets == [admin_asset]
+
+
+def test_source_run_relationship_is_unambiguous(db_session):
+    source = make_run(db_session)
+    derived = make_run(db_session, mode="authenticated_coverage")
+    derived.source_run_id = source.id
+
+    db_session.commit()
+
+    assert derived.source_run is source
+    assert source.derived_runs == [derived]
+
+
+def test_scan_request_stores_only_redacted_request_data(db_session):
+    run = make_authenticated_run(db_session)
+    request = add_request(
+        db_session,
+        run.contexts[2],
+        redacted_url="http://127.0.0.1:8000/items?token=[REDACTED]",
+        fingerprint="request-fingerprint",
+        protected_storage_ref="vault://assessment/request/42",
+    )
+
+    db_session.commit()
+
+    assert request.redacted_url.endswith("token=[REDACTED]")
+    assert request.fingerprint == "request-fingerprint"
+    assert request.protected_storage_ref == "vault://assessment/request/42"

--- a/tests/test_assessment_models.py
+++ b/tests/test_assessment_models.py
@@ -1,5 +1,6 @@
 """统一验证运行模型与请求协议行为测试。"""
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -16,6 +17,7 @@ from app.models.enums import (
 )
 from app.models.replay_execution import ReplayExecution
 from app.models.scan_context import ScanContext
+from app.models.scan_request import ScanRequest
 from app.schemas.assessment import AssessmentRunView, AssessmentStartRequest
 from tests.helpers.assessment import add_asset, add_request, make_authenticated_run, make_run
 
@@ -53,6 +55,15 @@ def test_context_kind_is_unique_per_run(db_session):
             ScanContext(scan_run_id=run.id, kind="user", status="pending"),
         ]
     )
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+@pytest.mark.parametrize("kind", ["operator", "auditor"])
+def test_context_kind_rejects_values_outside_fixed_protocol(db_session, kind):
+    run = make_run(db_session)
+    db_session.add(ScanContext(scan_run_id=run.id, kind=kind, status="pending"))
 
     with pytest.raises(IntegrityError):
         db_session.commit()
@@ -221,16 +232,96 @@ def test_source_run_relationship_is_unambiguous(db_session):
 
 def test_scan_request_stores_only_redacted_request_data(db_session):
     run = make_authenticated_run(db_session)
-    request = add_request(
-        db_session,
-        run.contexts[2],
-        redacted_url="http://127.0.0.1:8000/items?token=[REDACTED]",
+    secret = "real-session-secret-42"
+    request = ScanRequest.from_capture(
+        scan_run_id=run.id,
+        source_context_id=run.contexts[2].id,
+        method="GET",
+        raw_url=f"http://127.0.0.1:8000/items?token={secret}&id=7#fragment",
+        header_names=["Authorization", "Cookie"],
         fingerprint="request-fingerprint",
         protected_storage_ref="vault://assessment/request/42",
     )
+    db_session.add(request)
 
     db_session.commit()
 
-    assert request.redacted_url.endswith("token=[REDACTED]")
+    persisted = (
+        db_session.execute(ScanRequest.__table__.select().where(ScanRequest.id == request.id))
+        .mappings()
+        .one()
+    )
+    ordinary_values = {
+        key: value for key, value in persisted.items() if key != "protected_storage_ref"
+    }
+    assert request.normalized_redacted_url == (
+        "http://127.0.0.1:8000/items?id=[REDACTED]&token=[REDACTED]"
+    )
+    assert "normalized_url" not in persisted
+    assert "redacted_url" not in persisted
+    assert secret not in json.dumps(ordinary_values, default=str)
+    assert secret not in json.dumps(dict(persisted), default=str)
     assert request.fingerprint == "request-fingerprint"
     assert request.protected_storage_ref == "vault://assessment/request/42"
+
+
+def test_scan_request_rejects_unredacted_query_values():
+    with pytest.raises(ValueError, match="脱敏"):
+        ScanRequest(
+            scan_run_id=1,
+            source_context_id=1,
+            method="GET",
+            normalized_redacted_url="http://app/items?token=real-secret",
+            fingerprint="request-fingerprint",
+            protected_storage_ref="vault://assessment/request/1",
+        )
+
+
+def test_scan_request_rejects_source_context_from_another_run(db_session):
+    first = make_authenticated_run(db_session)
+    second = make_authenticated_run(db_session)
+    request = add_request(db_session, second.contexts[2])
+    request.scan_run_id = first.id
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+def test_scan_request_rejects_asset_from_another_run(db_session):
+    first = make_authenticated_run(db_session)
+    second = make_authenticated_run(db_session)
+    foreign_asset = add_asset(db_session, second, context_id=second.contexts[2].id)
+    request = add_request(db_session, first.contexts[2])
+    request.asset_id = foreign_asset.id
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+@pytest.mark.parametrize(
+    "mismatch",
+    ["source_request", "source_context", "target_context"],
+)
+def test_replay_execution_rejects_cross_run_links(db_session, mismatch):
+    first = make_authenticated_run(db_session)
+    second = make_authenticated_run(db_session)
+    first_request = add_request(db_session, first.contexts[2])
+    second_request = add_request(db_session, second.contexts[2])
+    source_request = second_request if mismatch == "source_request" else first_request
+    source_context = second.contexts[2] if mismatch == "source_context" else first.contexts[2]
+    target_context = second.contexts[1] if mismatch == "target_context" else first.contexts[1]
+    execution = ReplayExecution(
+        scan_run_id=first.id,
+        source_request_id=source_request.id,
+        source_context_id=source_context.id,
+        target_context_id=target_context.id,
+        policy_snapshot={},
+        policy_hash=f"policy-{mismatch}",
+        status="pending",
+        redirects=[],
+        response_summary_redacted={},
+    )
+    db_session.add(execution)
+
+    with pytest.raises(IntegrityError):
+        db_session.commit()

--- a/tests/test_context_collection.py
+++ b/tests/test_context_collection.py
@@ -1,0 +1,355 @@
+"""统一上下文采集和敏感请求持久化行为测试。"""
+
+from __future__ import annotations
+
+import json
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.db.bootstrap import get_session
+from app.integrations.inventory.playwright_gateway import (
+    InventoryCollectionResult,
+    ObservedEndpoint,
+    ObservedPage,
+)
+from app.models.scan_request import ScanRequest
+from app.models.scan_run import ScanAsset, ScanRunStage
+from app.schemas.scan import FetchResult, ScanOptions
+from app.services.context_collection import (
+    ContextCollectionService,
+    DefaultContextCollectionGateway,
+    ObservedRequest,
+    ObservedResource,
+)
+from app.services.scan_pipeline import ScanPipeline
+from app.services.session_storage import SessionStorageService
+from tests.helpers.assessment import make_authenticated_run
+
+
+@pytest.fixture
+def db_session():
+    session = get_session()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+class FakeCollectionGateway:
+    def collect(self, run, context):
+        resources = [
+            ObservedResource(
+                asset_type="page",
+                method="GET",
+                url="https://app.example/admin/?nonce=first",
+                status_code=200,
+                title="Admin",
+                attributes={
+                    "content_type": "text/html",
+                    "response_text": "generated=2026-08-11T01:02:03Z stable=admin",
+                },
+            ),
+            ObservedResource(
+                asset_type="endpoint",
+                method="GET",
+                url="https://app.example/api/users?id=1&sort=name",
+                status_code=200,
+                title=None,
+                attributes={
+                    "content_type": "application/json",
+                    "response_text": '{"traceId":"req-1","stable":"users"}',
+                },
+            ),
+            ObservedResource(
+                asset_type="endpoint",
+                method="GET",
+                url="https://app.example/api/users?sort=date&id=9",
+                status_code=200,
+                title=None,
+                attributes={
+                    "content_type": "application/json",
+                    "response_text": '{"traceId":"req-2","stable":"users"}',
+                },
+            ),
+        ]
+        requests = [
+            ObservedRequest(
+                method="GET",
+                url="https://app.example/api/users?id=top-secret&sort=name",
+                headers={
+                    "accept": "application/json",
+                    "authorization": "Bearer source-admin-secret",
+                    "cookie": "session=source-cookie-secret",
+                },
+                body=None,
+                status_code=200,
+                response_headers={"content-type": "application/json"},
+                response_text='{ "traceId": "req-1", "stable": "users" }',
+            )
+        ]
+        return resources, requests
+
+
+class FakeHttpGateway:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def fetch(self, url, options):
+        self.urls.append(url)
+        if url.endswith("/start"):
+            return FetchResult(
+                requested_url=url,
+                final_url=url,
+                status_code=200,
+                headers={"content-type": "text/html"},
+                content_type="text/html",
+                body_text="<title>Start</title>",
+                body_size_bytes=20,
+                title="Start",
+                discovered_urls=[
+                    "http://127.0.0.1:8080/next?id=1",
+                    "http://outside.example/ignored",
+                ],
+            )
+        return FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            headers={"content-type": "application/json"},
+            content_type="application/json",
+            body_text='{"stable":"next"}',
+            body_size_bytes=17,
+        )
+
+
+class FakeInventoryService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def collect(self, target, auth_session, controls):
+        self.calls.append((target, auth_session, controls))
+        return InventoryCollectionResult(
+            start_url=target.base_url,
+            pages=[
+                ObservedPage(
+                    url=f"{target.base_url.rstrip('/')}/home",
+                    title="Home",
+                    visited_at=admin_timestamp(),
+                    depth=0,
+                    discovered_urls=[],
+                    status_code=200,
+                    text_preview="stable home",
+                )
+            ],
+            endpoints=[
+                ObservedEndpoint(
+                    method="GET",
+                    url=f"{target.base_url.rstrip('/')}/api/users",
+                    request_url=f"{target.base_url.rstrip('/')}/api/users?id=42",
+                    path="/api/users",
+                    status_code=200,
+                    observed_at=admin_timestamp(),
+                    content_type="application/json",
+                    response_preview='{"stable":"users"}',
+                    request_headers={"authorization": "Bearer exact-source-token"},
+                    request_body=None,
+                    response_headers={"content-type": "application/json"},
+                )
+            ],
+        )
+
+
+def admin_timestamp():
+    return datetime.now(timezone.utc)
+
+
+class FailingOneContextCollectionService:
+    def __init__(self) -> None:
+        self.kinds: list[str] = []
+
+    def collect(self, session, run, context):
+        self.kinds.append(context.kind)
+        if context.kind == "user":
+            raise RuntimeError("raw-user-collection-secret")
+        context.status = "completed"
+        context.collection_status = "completed"
+        context.completeness = "complete"
+        context.asset_count = 1
+        return SimpleNamespace(
+            context_id=context.id,
+            asset_count=1,
+            request_count=0,
+            failure_count=0,
+        )
+
+
+def test_collection_persists_context_scoped_assets_and_protected_requests(
+    db_session,
+    tmp_path,
+) -> None:
+    run = make_authenticated_run(db_session)
+    admin = next(context for context in run.contexts if context.kind == "admin")
+    admin.status = "ready"
+    storage = SessionStorageService(tmp_path / "protected-captures")
+
+    summary = ContextCollectionService(
+        gateway=FakeCollectionGateway(),
+        storage_service=storage,
+    ).collect(db_session, run, admin)
+    db_session.flush()
+
+    assert summary.asset_count == 2
+    assert summary.request_count == 1
+    assert summary.failure_count == 0
+    assets = list(
+        db_session.scalars(
+            select(ScanAsset)
+            .where(ScanAsset.scan_run_id == run.id, ScanAsset.context_id == admin.id)
+            .order_by(ScanAsset.id)
+        )
+    )
+    assert all(asset.context_id == admin.id for asset in assets)
+    assert len({asset.identity_key for asset in assets}) == 2
+    assert all("response_text" not in asset.attributes for asset in assets)
+    requests = list(
+        db_session.scalars(select(ScanRequest).where(ScanRequest.source_context_id == admin.id))
+    )
+    assert {request.method for request in requests} == {"GET"}
+    assert requests[0].asset_id == next(
+        asset.id for asset in assets if asset.asset_type == "endpoint"
+    )
+    assert requests[0].normalized_redacted_url.endswith("/api/users?id=[REDACTED]&sort=[REDACTED]")
+    assert requests[0].protected_storage_ref
+    protected_payload = storage.read_payload(requests[0].protected_storage_ref)
+    assert stat.S_IMODE(Path(requests[0].protected_storage_ref).stat().st_mode) == 0o600
+    assert protected_payload["url"].endswith("id=top-secret&sort=name")
+    assert protected_payload["headers"]["authorization"] == "Bearer source-admin-secret"
+    assert protected_payload["headers"]["cookie"] == "session=source-cookie-secret"
+
+    ordinary_record = json.dumps(
+        {
+            "url": requests[0].normalized_redacted_url,
+            "header_names": requests[0].header_names,
+            "fingerprint": requests[0].fingerprint,
+            "asset_attributes": [asset.attributes for asset in assets],
+        },
+        sort_keys=True,
+    )
+    assert "top-secret" not in ordinary_record
+    assert "source-admin-secret" not in ordinary_record
+    assert "source-cookie-secret" not in ordinary_record
+
+
+def test_same_asset_is_persisted_independently_for_each_context(db_session, tmp_path) -> None:
+    run = make_authenticated_run(db_session)
+    storage = SessionStorageService(tmp_path / "protected-captures")
+    service = ContextCollectionService(
+        gateway=FakeCollectionGateway(),
+        storage_service=storage,
+    )
+    user = next(context for context in run.contexts if context.kind == "user")
+    admin = next(context for context in run.contexts if context.kind == "admin")
+    user.status = admin.status = "ready"
+
+    service.collect(db_session, run, user)
+    service.collect(db_session, run, admin)
+    db_session.flush()
+
+    user_identities = set(
+        db_session.scalars(select(ScanAsset.identity_key).where(ScanAsset.context_id == user.id))
+    )
+    admin_identities = set(
+        db_session.scalars(select(ScanAsset.identity_key).where(ScanAsset.context_id == admin.id))
+    )
+    assert user_identities == admin_identities
+    assert len(user_identities) == 2
+    assert user.asset_count == admin.asset_count == 2
+    assert user.request_count == admin.request_count == 1
+    assert user.collection_status == admin.collection_status == "completed"
+    assert user.status == admin.status == "completed"
+    assert all(Path(request.protected_storage_ref).is_file() for request in run.requests)
+
+
+def test_default_gateway_uses_bounded_http_collection_for_anonymous_context() -> None:
+    http_gateway = FakeHttpGateway()
+    gateway = DefaultContextCollectionGateway(http_gateway=http_gateway)
+    run = SimpleNamespace(
+        normalized_url="http://127.0.0.1:8080/start",
+        options=ScanOptions(max_pages=2, max_depth=1).model_dump(),
+    )
+    context = SimpleNamespace(kind="anonymous")
+
+    resources, requests = gateway.collect(run, context)
+
+    assert http_gateway.urls == [
+        "http://127.0.0.1:8080/start",
+        "http://127.0.0.1:8080/next?id=1",
+    ]
+    assert [resource.url for resource in resources] == http_gateway.urls
+    assert [request.url for request in requests] == http_gateway.urls
+
+
+def test_default_gateway_preserves_authenticated_request_only_in_observation() -> None:
+    inventory_service = FakeInventoryService()
+    gateway = DefaultContextCollectionGateway(
+        http_gateway=FakeHttpGateway(),
+        inventory_service=inventory_service,
+    )
+    target = SimpleNamespace(base_url="https://app.example/")
+    auth_session = SimpleNamespace(id=11)
+    run = SimpleNamespace(
+        target=target,
+        options=ScanOptions(max_pages=3, max_depth=2).model_dump(),
+    )
+    context = SimpleNamespace(kind="admin", auth_session=auth_session)
+
+    resources, requests = gateway.collect(run, context)
+
+    assert {resource.asset_type for resource in resources} == {"page", "endpoint"}
+    assert len(requests) == 1
+    assert requests[0].url.endswith("/api/users?id=42")
+    assert requests[0].headers == {"authorization": "Bearer exact-source-token"}
+    assert requests[0].response_headers == {"content-type": "application/json"}
+    controls = inventory_service.calls[0][2]
+    assert (controls.max_pages, controls.max_depth) == (3, 2)
+
+
+def test_pipeline_continues_other_contexts_after_one_collection_failure(db_session) -> None:
+    run = make_authenticated_run(db_session)
+    for context in run.contexts:
+        context.status = "ready"
+    db_session.add(
+        ScanRunStage(
+            scan_run_id=run.id,
+            name="collect",
+            position=3,
+            status="pending",
+        )
+    )
+    db_session.flush()
+    collection_service = FailingOneContextCollectionService()
+    pipeline = ScanPipeline(
+        policy=SimpleNamespace(),
+        gateway=SimpleNamespace(),
+        context_collection_service=collection_service,
+    )
+
+    summaries = pipeline.collect_contexts(db_session, run.id)
+
+    assert collection_service.kinds == ["anonymous", "user", "admin"]
+    assert len(summaries) == 2
+    failed_user = next(context for context in run.contexts if context.kind == "user")
+    assert failed_user.status == "failed"
+    assert failed_user.collection_status == "failed"
+    assert failed_user.error_code == "context_collection_failed"
+    assert "raw-user-collection-secret" not in (failed_user.error_message or "")
+    assert run.status == "incomplete"
+    assert run.completeness == "missing_user_context"
+    stage = next(stage for stage in run.stages if stage.name == "collect")
+    assert stage.status == "completed_with_warnings"

--- a/tests/test_context_establishment.py
+++ b/tests/test_context_establishment.py
@@ -1,0 +1,319 @@
+"""认证覆盖运行的上下文建立行为测试。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from sqlalchemy import select
+
+from app.core.errors import InputValidationError
+from app.db.bootstrap import get_session
+from app.models.audit_event import AuditEvent
+from app.models.auth_session import AuthSession
+from app.models.credential_profile import CredentialProfile
+from app.models.scan_context import ScanContext
+from app.models.scan_run import ScanRunStage
+from app.models.target import Target
+from app.schemas.auth import LoginExecutionResult, SessionValidationResult
+from app.services.context_establishment import ContextEstablishmentService
+from app.services.login_configs import encode_inline_login_config
+from app.services.scan_pipeline import ScanPipeline
+from app.services.session_storage import SessionStorageService
+from app.services.sessions import AuthSessionService
+from tests.helpers.assessment import make_authenticated_run
+
+
+@pytest.fixture
+def db_session():
+    session = get_session()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+@dataclass(frozen=True)
+class Profiles:
+    target_id: int
+    user_id: int
+    admin_id: int
+    other_target_admin_id: int
+    wrong_role_id: int
+
+
+@pytest.fixture
+def profiles(db_session) -> Profiles:
+    target = Target(
+        name="context-target",
+        base_url="http://127.0.0.1:8080/app",
+        type="web",
+        owner="appsec",
+        tags=[],
+        status="active",
+    )
+    other_target = Target(
+        name="other-context-target",
+        base_url="http://127.0.0.1:9090/app",
+        type="web",
+        owner="appsec",
+        tags=[],
+        status="active",
+    )
+    db_session.add_all([target, other_target])
+    db_session.flush()
+    inline_config = encode_inline_login_config(
+        {
+            "adapter": "http",
+            "login_request": {"method": "POST", "url": "/login"},
+            "validate_request": {"method": "GET", "url": "/me"},
+        }
+    )
+
+    def add_profile(*, target_id: int, name: str, role: str) -> CredentialProfile:
+        profile = CredentialProfile(
+            target_id=target_id,
+            name=name,
+            role=role,
+            auth_type="password",
+            username=f"{name}@example.local",
+            secret_ref="literal://never-audited-secret",
+            login_config_path=inline_config,
+        )
+        db_session.add(profile)
+        db_session.flush()
+        return profile
+
+    user = add_profile(target_id=target.id, name="context-user", role="user")
+    admin = add_profile(target_id=target.id, name="context-admin", role="admin")
+    other_admin = add_profile(
+        target_id=other_target.id,
+        name="other-context-admin",
+        role="admin",
+    )
+    wrong_role = add_profile(target_id=target.id, name="context-auditor", role="auditor")
+    return Profiles(
+        target_id=target.id,
+        user_id=user.id,
+        admin_id=admin.id,
+        other_target_admin_id=other_admin.id,
+        wrong_role_id=wrong_role.id,
+    )
+
+
+class SuccessfulAuthService:
+    def ensure_valid_for_profile(self, session, profile_id: int) -> AuthSession:
+        profile = session.get(CredentialProfile, profile_id)
+        auth_session = AuthSession(
+            target_id=profile.target_id,
+            credential_profile_id=profile.id,
+            status="active",
+            session_type="http_cookie_jar",
+            refresh_supported=False,
+            session_metadata_redacted={"adapter": "test"},
+            storage_ref=f"vault://session/{profile.id}",
+        )
+        session.add(auth_session)
+        session.flush()
+        return auth_session
+
+
+class FailingAuthService(SuccessfulAuthService):
+    def __init__(self, *failing_profile_ids: int) -> None:
+        self.failing_profile_ids = set(failing_profile_ids)
+
+    def ensure_valid_for_profile(self, session, profile_id: int) -> AuthSession:
+        if profile_id in self.failing_profile_ids:
+            raise InputValidationError("login rejected")
+        return super().ensure_valid_for_profile(session, profile_id)
+
+
+class RecordingHttpAdapter:
+    def __init__(self) -> None:
+        self.login_count = 0
+        self.validated_payloads: list[dict[str, object]] = []
+
+    def login(self, target, credential_profile, secret_value, config):
+        self.login_count += 1
+        assert secret_value == "never-audited-secret"
+        return LoginExecutionResult(
+            success=True,
+            adapter="http",
+            target_name=target.name,
+            profile_name=credential_profile.name,
+            status="active",
+            session_type="http_cookie_jar",
+            message="login succeeded",
+            storage_payload={"cookies": {"session": "raw-cookie-value"}},
+            session_metadata_redacted={"cookie_names": ["session"]},
+        )
+
+    def validate(self, target, credential_profile, config, stored_payload):
+        self.validated_payloads.append(stored_payload)
+        return SessionValidationResult(
+            valid=True,
+            status="active",
+            message="session valid",
+        )
+
+
+def context_by_kind(contexts: list[ScanContext], kind: str) -> ScanContext:
+    return next(context for context in contexts if context.kind == kind)
+
+
+def make_profile_run(db_session, profiles: Profiles, admin_profile_id: int | None = None):
+    run = make_authenticated_run(
+        db_session,
+        profiles.user_id,
+        admin_profile_id or profiles.admin_id,
+    )
+    run.target_id = profiles.target_id
+    run.input_url = "http://127.0.0.1:8080/start"
+    run.normalized_url = run.input_url
+    return run
+
+
+def test_profiles_must_share_target_and_expected_roles(db_session, profiles):
+    service = ContextEstablishmentService(auth_service=SuccessfulAuthService())
+    run = make_profile_run(db_session, profiles, profiles.other_target_admin_id)
+
+    with pytest.raises(InputValidationError, match="同一目标"):
+        service.establish(db_session, run)
+
+    role_run = make_profile_run(db_session, profiles, profiles.wrong_role_id)
+    with pytest.raises(InputValidationError, match="admin"):
+        service.establish(db_session, role_run)
+
+
+def test_run_url_must_share_target_origin(db_session, profiles):
+    run = make_profile_run(db_session, profiles)
+    run.normalized_url = "http://127.0.0.1:8081/start"
+
+    with pytest.raises(InputValidationError, match="同源"):
+        ContextEstablishmentService(auth_service=SuccessfulAuthService()).establish(db_session, run)
+
+
+def test_establish_updates_existing_contexts_and_writes_redacted_audit(db_session, profiles):
+    run = make_profile_run(db_session, profiles)
+    existing_ids = {context.kind: context.id for context in run.contexts}
+
+    contexts = ContextEstablishmentService(auth_service=SuccessfulAuthService()).establish(
+        db_session, run
+    )
+    db_session.flush()
+
+    assert {context.kind: context.id for context in contexts} == existing_ids
+    assert len(db_session.scalars(select(ScanContext)).all()) == 3
+    anonymous = context_by_kind(contexts, "anonymous")
+    assert (anonymous.status, anonymous.login_status) == ("ready", "not_applicable")
+    for kind in ("user", "admin"):
+        context = context_by_kind(contexts, kind)
+        assert context.status == "ready"
+        assert context.login_status == "succeeded"
+        assert context.session_validation_status == "valid"
+        assert context.auth_session_id is not None
+
+    events = list(
+        db_session.scalars(
+            select(AuditEvent).where(AuditEvent.event_type == "context_establishment")
+        )
+    )
+    assert len(events) == 3
+    assert {event.detail_redacted["context_kind"] for event in events} == {
+        "anonymous",
+        "user",
+        "admin",
+    }
+    serialized = repr([event.detail_redacted for event in events]).lower()
+    assert "secret" not in serialized
+    assert "cookie" not in serialized
+    assert "authorization" not in serialized
+    assert "payload" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("failed_kind", "expected_completeness"),
+    [
+        ("user", "missing_user_context"),
+        ("admin", "missing_admin_context"),
+    ],
+)
+def test_single_login_failure_marks_run_incomplete(
+    db_session, profiles, failed_kind, expected_completeness
+):
+    run = make_profile_run(db_session, profiles)
+    run.active_key = "context-establishment-active-key"
+    failed_profile_id = getattr(profiles, f"{failed_kind}_id")
+    service = ContextEstablishmentService(auth_service=FailingAuthService(failed_profile_id))
+
+    contexts = service.establish(db_session, run)
+
+    failed = context_by_kind(contexts, failed_kind)
+    assert failed.status == "failed"
+    assert failed.login_status == "failed"
+    assert failed.failure_count == 1
+    assert run.status == "incomplete"
+    assert run.completeness == expected_completeness
+    assert run.error_code == "context_establishment_failed"
+    assert run.active_key is None
+
+
+def test_both_login_failures_use_general_incomplete_completeness(db_session, profiles):
+    run = make_profile_run(db_session, profiles)
+    service = ContextEstablishmentService(
+        auth_service=FailingAuthService(profiles.user_id, profiles.admin_id)
+    )
+
+    contexts = service.establish(db_session, run)
+
+    assert context_by_kind(contexts, "user").status == "failed"
+    assert context_by_kind(contexts, "admin").status == "failed"
+    assert run.status == "incomplete"
+    assert run.completeness == "incomplete"
+
+
+def test_pipeline_runs_only_context_stage_for_authenticated_run(db_session, profiles):
+    run = make_profile_run(db_session, profiles)
+    stage = ScanRunStage(
+        scan_run_id=run.id,
+        name="establish_contexts",
+        position=2,
+        status="pending",
+    )
+    db_session.add(stage)
+    db_session.flush()
+    pipeline = ScanPipeline(
+        policy=object(),
+        gateway=object(),
+        context_service=ContextEstablishmentService(auth_service=SuccessfulAuthService()),
+    )
+
+    contexts = pipeline.establish_contexts(db_session, run.id)
+
+    assert [context.kind for context in contexts] == ["anonymous", "user", "admin"]
+    assert stage.status == "completed"
+    assert stage.attempt == 1
+    assert run.status == "queued"
+    assert run.current_stage == "establish_contexts"
+    assert run.progress > 0
+
+
+def test_ensure_valid_for_profile_reuses_storage_backed_session(db_session, profiles, tmp_path):
+    adapter = RecordingHttpAdapter()
+    service = AuthSessionService(
+        storage_service=SessionStorageService(tmp_path / "session-payloads"),
+        http_adapter=adapter,
+    )
+
+    created = service.ensure_valid_for_profile(db_session, profiles.user_id)
+    reused = service.ensure_valid_for_profile(db_session, profiles.user_id)
+
+    assert reused.id == created.id
+    assert adapter.login_count == 1
+    assert adapter.validated_payloads == [
+        {"cookies": {"session": "raw-cookie-value"}},
+        {"cookies": {"session": "raw-cookie-value"}},
+    ]
+    details = repr(db_session.scalars(select(AuditEvent.detail_redacted)).all()).lower()
+    assert "raw-cookie-value" not in details

--- a/tests/test_context_establishment.py
+++ b/tests/test_context_establishment.py
@@ -158,6 +158,59 @@ class RecordingHttpAdapter:
         )
 
 
+class StatefulHttpAdapter:
+    def __init__(self) -> None:
+        self.login_count = 0
+        self.refresh_count = 0
+        self.validated_payloads: list[dict[str, object]] = []
+
+    def login(self, target, credential_profile, secret_value, config):
+        self.login_count += 1
+        assert secret_value == "never-audited-secret"
+        return LoginExecutionResult(
+            success=True,
+            adapter="http",
+            target_name=target.name,
+            profile_name=credential_profile.name,
+            status="active",
+            session_type="http_cookie_jar",
+            message="login succeeded",
+            storage_payload={"state": "fresh", "cookies": {"session": "raw-cookie-value"}},
+            session_metadata_redacted={"cookie_names": ["session"]},
+        )
+
+    def validate(self, target, credential_profile, config, stored_payload):
+        self.validated_payloads.append(stored_payload)
+        valid = stored_payload.get("state") in {"valid", "fresh", "refreshed"}
+        return SessionValidationResult(
+            valid=valid,
+            status="active" if valid else "invalid",
+            message="session valid" if valid else "session invalid",
+        )
+
+    def refresh(self, target, credential_profile, secret_value, config, stored_payload):
+        self.refresh_count += 1
+        return LoginExecutionResult(
+            success=True,
+            adapter="http",
+            target_name=target.name,
+            profile_name=credential_profile.name,
+            status="refreshed",
+            session_type="http_cookie_jar",
+            message="session refreshed",
+            storage_payload={"state": "refreshed"},
+            session_metadata_redacted={"cookie_names": ["session"]},
+        )
+
+
+class FailingAfterFlushStorage:
+    def write_payload(self, session_id: int, payload: dict[str, object]) -> str:
+        raise OSError("storage failure: adapter-secret raw-cookie-value")
+
+    def read_payload(self, storage_ref: str) -> dict[str, object]:
+        raise AssertionError("no persisted payload should be read")
+
+
 def context_by_kind(contexts: list[ScanContext], kind: str) -> ScanContext:
     return next(context for context in contexts if context.kind == kind)
 
@@ -172,6 +225,31 @@ def make_profile_run(db_session, profiles: Profiles, admin_profile_id: int | Non
     run.input_url = "http://127.0.0.1:8080/start"
     run.normalized_url = run.input_url
     return run
+
+
+def add_stored_auth_session(
+    db_session,
+    storage_service,
+    *,
+    profile_id: int,
+    target_id: int,
+    payload: dict[str, object],
+    refresh_supported: bool = False,
+) -> AuthSession:
+    auth_session = AuthSession(
+        target_id=target_id,
+        credential_profile_id=profile_id,
+        status="active",
+        session_type="http_cookie_jar",
+        refresh_supported=refresh_supported,
+        session_metadata_redacted={},
+        storage_ref="",
+    )
+    db_session.add(auth_session)
+    db_session.flush()
+    auth_session.storage_ref = storage_service.write_payload(auth_session.id, payload)
+    db_session.flush()
+    return auth_session
 
 
 def test_profiles_must_share_target_and_expected_roles(db_session, profiles):
@@ -273,6 +351,38 @@ def test_both_login_failures_use_general_incomplete_completeness(db_session, pro
     assert run.completeness == "incomplete"
 
 
+def test_non_domain_storage_failure_is_persisted_as_redacted_context_failure(db_session, profiles):
+    run = make_profile_run(db_session, profiles)
+    service = ContextEstablishmentService(
+        auth_service=AuthSessionService(
+            storage_service=FailingAfterFlushStorage(),
+            http_adapter=RecordingHttpAdapter(),
+        )
+    )
+
+    contexts = service.establish(db_session, run)
+    db_session.flush()
+
+    for kind in ("user", "admin"):
+        context = context_by_kind(contexts, kind)
+        assert context.status == "failed"
+        assert context.auth_session_id is None
+    assert run.status == "incomplete"
+    assert db_session.scalars(select(AuthSession)).all() == []
+    failure_events = list(
+        db_session.scalars(
+            select(AuditEvent).where(
+                AuditEvent.event_type == "context_establishment",
+                AuditEvent.status == "failure",
+            )
+        )
+    )
+    assert len(failure_events) == 2
+    serialized = repr([event.detail_redacted for event in failure_events]).lower()
+    assert "adapter-secret" not in serialized
+    assert "raw-cookie-value" not in serialized
+
+
 def test_pipeline_runs_only_context_stage_for_authenticated_run(db_session, profiles):
     run = make_profile_run(db_session, profiles)
     stage = ScanRunStage(
@@ -317,3 +427,107 @@ def test_ensure_valid_for_profile_reuses_storage_backed_session(db_session, prof
     ]
     details = repr(db_session.scalars(select(AuditEvent.detail_redacted)).all()).lower()
     assert "raw-cookie-value" not in details
+
+
+def test_ensure_valid_skips_newer_session_with_mismatched_target(db_session, profiles, tmp_path):
+    storage = SessionStorageService(tmp_path / "session-payloads")
+    adapter = StatefulHttpAdapter()
+    profile = db_session.get(CredentialProfile, profiles.user_id)
+    other_target_id = db_session.get(CredentialProfile, profiles.other_target_admin_id).target_id
+    correct = add_stored_auth_session(
+        db_session,
+        storage,
+        profile_id=profile.id,
+        target_id=profile.target_id,
+        payload={"state": "valid", "marker": "correct"},
+    )
+    add_stored_auth_session(
+        db_session,
+        storage,
+        profile_id=profile.id,
+        target_id=other_target_id,
+        payload={"state": "valid", "marker": "mismatched"},
+    )
+    service = AuthSessionService(storage_service=storage, http_adapter=adapter)
+
+    selected = service.ensure_valid_for_profile(db_session, profile.id)
+
+    assert selected.id == correct.id
+    assert adapter.login_count == 0
+    assert adapter.validated_payloads == [{"state": "valid", "marker": "correct"}]
+
+
+def test_ensure_valid_relogs_when_only_session_has_mismatched_target(
+    db_session, profiles, tmp_path
+):
+    storage = SessionStorageService(tmp_path / "session-payloads")
+    adapter = StatefulHttpAdapter()
+    profile = db_session.get(CredentialProfile, profiles.user_id)
+    other_target_id = db_session.get(CredentialProfile, profiles.other_target_admin_id).target_id
+    mismatched = add_stored_auth_session(
+        db_session,
+        storage,
+        profile_id=profile.id,
+        target_id=other_target_id,
+        payload={"state": "valid", "marker": "mismatched"},
+    )
+    service = AuthSessionService(storage_service=storage, http_adapter=adapter)
+
+    selected = service.ensure_valid_for_profile(db_session, profile.id)
+
+    assert selected.id != mismatched.id
+    assert selected.target_id == profile.target_id
+    assert adapter.login_count == 1
+    assert adapter.validated_payloads == [
+        {"state": "fresh", "cookies": {"session": "raw-cookie-value"}}
+    ]
+
+
+def test_ensure_valid_refreshes_then_revalidates_existing_session(db_session, profiles, tmp_path):
+    storage = SessionStorageService(tmp_path / "session-payloads")
+    adapter = StatefulHttpAdapter()
+    profile = db_session.get(CredentialProfile, profiles.user_id)
+    existing = add_stored_auth_session(
+        db_session,
+        storage,
+        profile_id=profile.id,
+        target_id=profile.target_id,
+        payload={"state": "invalid"},
+        refresh_supported=True,
+    )
+    service = AuthSessionService(storage_service=storage, http_adapter=adapter)
+
+    selected = service.ensure_valid_for_profile(db_session, profile.id)
+
+    assert selected.id == existing.id
+    assert adapter.login_count == 0
+    assert adapter.refresh_count == 1
+    assert adapter.validated_payloads == [
+        {"state": "invalid"},
+        {"state": "refreshed"},
+    ]
+
+
+def test_ensure_valid_relogs_after_invalid_non_refreshable_session(db_session, profiles, tmp_path):
+    storage = SessionStorageService(tmp_path / "session-payloads")
+    adapter = StatefulHttpAdapter()
+    profile = db_session.get(CredentialProfile, profiles.user_id)
+    existing = add_stored_auth_session(
+        db_session,
+        storage,
+        profile_id=profile.id,
+        target_id=profile.target_id,
+        payload={"state": "invalid"},
+    )
+    service = AuthSessionService(storage_service=storage, http_adapter=adapter)
+
+    selected = service.ensure_valid_for_profile(db_session, profile.id)
+
+    assert selected.id != existing.id
+    assert selected.target_id == profile.target_id
+    assert adapter.login_count == 1
+    assert adapter.refresh_count == 0
+    assert adapter.validated_payloads == [
+        {"state": "invalid"},
+        {"state": "fresh", "cookies": {"session": "raw-cookie-value"}},
+    ]

--- a/tests/test_coverage_identity.py
+++ b/tests/test_coverage_identity.py
@@ -1,0 +1,77 @@
+"""资产身份和稳定响应指纹行为测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.coverage_identity import (
+    canonical_asset_identity,
+    stable_response_signature,
+)
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("https://app/a?id=1&sort=name", "https://app/a?sort=date&id=9"),
+        ("https://app:443/a/", "https://app/a"),
+        ("http://APP:80/a#first", "http://app/a#second"),
+        ("https://app/a?id=1&id=2", "https://app/a?id=9"),
+    ],
+)
+def test_asset_identity_ignores_values_default_port_fragment_and_duplicate_names(
+    left: str,
+    right: str,
+) -> None:
+    assert canonical_asset_identity("GET", left) == canonical_asset_identity("GET", right)
+
+
+@pytest.mark.parametrize(
+    ("method", "url"),
+    [
+        ("POST", "https://app/a?id=1&sort=name"),
+        ("GET", "https://app/b?id=1&sort=name"),
+        ("GET", "https://app/a?id=1&filter=name"),
+    ],
+)
+def test_asset_identity_distinguishes_method_path_and_parameter_names(
+    method: str,
+    url: str,
+) -> None:
+    baseline = canonical_asset_identity("GET", "https://app/a?id=1&sort=name")
+
+    assert canonical_asset_identity(method, url) != baseline
+
+
+def test_asset_identity_preserves_encoded_path_separators() -> None:
+    encoded = canonical_asset_identity("GET", "https://app/reports%2F2026")
+    separated = canonical_asset_identity("GET", "https://app/reports/2026")
+
+    assert encoded != separated
+
+
+def test_signature_ignores_timestamp_nonce_and_trace_id() -> None:
+    first = "generated=2026-08-11T01:02:03Z nonce=abc trace_id=req-1 stable=users"
+    second = "generated=2026-08-11T02:03:04Z nonce=xyz trace_id=req-2 stable=users"
+
+    assert stable_response_signature(first, "text/plain") == stable_response_signature(
+        second,
+        "text/plain",
+    )
+
+
+def test_json_signature_ignores_dynamic_fields_and_object_order() -> None:
+    first = '{"traceId":"req-1","users":["alice","bob"],"generatedAt":"2026-08-11T01:02:03Z"}'
+    second = '{"generatedAt":"2026-08-11T02:03:04Z","users":["alice","bob"],"traceId":"req-2"}'
+
+    assert stable_response_signature(first, "application/json") == stable_response_signature(
+        second,
+        "application/json; charset=utf-8",
+    )
+
+
+def test_signature_retains_stable_business_content() -> None:
+    users = stable_response_signature('{"role":"user"}', "application/json")
+    admins = stable_response_signature('{"role":"admin"}', "application/json")
+
+    assert users != admins

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,6 +5,8 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from alembic import command
+from alembic.config import Config
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import NoSuchModuleError
@@ -14,7 +16,6 @@ from typer.testing import CliRunner
 import app.models  # noqa: F401
 from app.cli.main import app as cli_app
 from app.core.settings import clear_settings_cache, get_settings
-from app.db.base import Base
 from app.db.bootstrap import (
     reset_database_state,
     stamp_existing_database,
@@ -27,19 +28,42 @@ runner = CliRunner()
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
+def create_unversioned_legacy_database(url: str):
+    """构造仅包含 0001 schema、但尚未登记 Alembic 版本的历史数据库。"""
+    upgrade_database(url, "0001")
+    engine = create_engine(url)
+    with engine.begin() as connection:
+        connection.execute(text("drop table alembic_version"))
+    return engine
+
+
+def downgrade_database(url: str, revision: str) -> None:
+    config = Config(str(PROJECT_ROOT / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    command.downgrade(config, revision)
+
+
 def test_upgrade_database_creates_current_schema(tmp_path):
     url = f"sqlite+pysqlite:///{tmp_path / 'fresh.db'}"
 
     upgrade_database(url)
 
     tables = set(inspect(create_engine(url)).get_table_names())
-    assert {"alembic_version", "scan_runs", "scan_jobs", "inventory_runs"} <= tables
+    assert {
+        "alembic_version",
+        "scan_runs",
+        "scan_contexts",
+        "scan_requests",
+        "coverage_differences",
+        "replay_executions",
+        "scan_jobs",
+        "inventory_runs",
+    } <= tables
 
 
 def test_stamp_existing_database_preserves_rows(tmp_path):
     url = f"sqlite+pysqlite:///{tmp_path / 'legacy.db'}"
-    engine = create_engine(url)
-    Base.metadata.create_all(engine)
+    engine = create_unversioned_legacy_database(url)
     with Session(engine) as session:
         session.add(
             Target(
@@ -58,12 +82,106 @@ def test_stamp_existing_database_preserves_rows(tmp_path):
 
     with engine.connect() as connection:
         assert connection.scalar(text("select count(*) from targets")) == 1
-        assert connection.scalar(text("select version_num from alembic_version")) == "0001"
+        assert connection.scalar(text("select version_num from alembic_version")) == "0002"
+
+
+def test_legacy_scan_assets_are_backfilled_into_anonymous_context(tmp_path):
+    url = f"sqlite+pysqlite:///{tmp_path / 'legacy-assets.db'}"
+    engine = create_unversioned_legacy_database(url)
+    with engine.begin() as connection:
+        run_id = connection.execute(
+            text(
+                """
+                insert into scan_runs (
+                    input_url, normalized_url, active_key, status, current_stage,
+                    progress, options, retry_count, report_path, error_code,
+                    error_message, started_at, finished_at, report_generated_at,
+                    created_at, updated_at
+                ) values (
+                    :input_url, :normalized_url, null, 'completed', 'report',
+                    100, '{}', 0, null, null, null, null, null, null,
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {
+                "input_url": "http://localhost:8080/items?token=secret&id=7",
+                "normalized_url": "http://localhost:8080/items?id=7&token=secret",
+            },
+        ).lastrowid
+        asset_id = connection.execute(
+            text(
+                """
+                insert into scan_assets (
+                    scan_run_id, asset_type, url, method, status_code, title,
+                    attributes, discovered_at
+                ) values (
+                    :run_id, 'page', :url, 'GET', 200, 'Items', '{}', CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {
+                "run_id": run_id,
+                "url": "http://localhost:8080/items?token=secret&id=7",
+            },
+        ).lastrowid
+
+    stamp_existing_database(url)
+    upgrade_database(url)
+
+    with engine.connect() as connection:
+        run = (
+            connection.execute(
+                text("select mode, completeness from scan_runs where id = :run_id"),
+                {"run_id": run_id},
+            )
+            .mappings()
+            .one()
+        )
+        context = (
+            connection.execute(
+                text("select id, kind, asset_count from scan_contexts where scan_run_id = :run_id"),
+                {"run_id": run_id},
+            )
+            .mappings()
+            .one()
+        )
+        asset = (
+            connection.execute(
+                text("select context_id, identity_key from scan_assets where id = :asset_id"),
+                {"asset_id": asset_id},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert run == {"mode": "quick", "completeness": "complete"}
+    assert context["kind"] == "anonymous"
+    assert context["asset_count"] == 1
+    assert asset["context_id"] == context["id"]
+    assert asset["identity_key"] == "GET:/items?id&token"
+
+
+def test_unified_assessment_migration_round_trip(tmp_path):
+    url = f"sqlite+pysqlite:///{tmp_path / 'round-trip.db'}"
+    upgrade_database(url)
+
+    downgrade_database(url, "0001")
+
+    downgraded_tables = set(inspect(create_engine(url)).get_table_names())
+    assert "scan_contexts" not in downgraded_tables
+    assert "scan_requests" not in downgraded_tables
+    assert "coverage_differences" not in downgraded_tables
+    assert "replay_executions" not in downgraded_tables
+
+    upgrade_database(url)
+    with create_engine(url).connect() as connection:
+        assert connection.scalar(text("select version_num from alembic_version")) == "0002"
 
 
 def test_application_requires_explicit_stamp_for_unversioned_legacy_database(tmp_path, monkeypatch):
     url = f"sqlite+pysqlite:///{tmp_path / 'legacy-app.db'}"
-    Base.metadata.create_all(create_engine(url))
+    create_unversioned_legacy_database(url)
     monkeypatch.setenv("GARDEN_DATABASE_URL", url)
     monkeypatch.setenv("GARDEN_DATABASE_AUTO_MIGRATE", "false")
     clear_settings_cache()
@@ -112,7 +230,7 @@ def test_application_auto_migrates_fresh_database_in_development(tmp_path, monke
         assert client.get("/healthz").status_code == 200
 
     with create_engine(url).connect() as connection:
-        assert connection.scalar(text("select version_num from alembic_version")) == "0001"
+        assert connection.scalar(text("select version_num from alembic_version")) == "0002"
 
 
 def test_database_cli_upgrade_and_current(tmp_path, monkeypatch):
@@ -125,13 +243,12 @@ def test_database_cli_upgrade_and_current(tmp_path, monkeypatch):
     current_result = runner.invoke(cli_app, ["db", "current"])
 
     assert upgrade_result.exit_code == 0
-    assert "0001" in current_result.stdout
+    assert "0002" in current_result.stdout
 
 
 def test_database_cli_stamp_existing_preserves_legacy_rows(tmp_path, monkeypatch):
     url = f"sqlite+pysqlite:///{tmp_path / 'cli-legacy.db'}"
-    engine = create_engine(url)
-    Base.metadata.create_all(engine)
+    engine = create_unversioned_legacy_database(url)
     with Session(engine) as session:
         session.add(
             Target(
@@ -190,6 +307,7 @@ def test_built_wheel_installs_with_loadable_migration_assets(tmp_path):
         "app/db/migration_assets/migrations/env.py",
         "app/db/migration_assets/migrations/script.py.mako",
         "app/db/migration_assets/migrations/versions/0001_existing_schema_baseline.py",
+        "app/db/migration_assets/migrations/versions/0002_unified_assessment.py",
     }
     assert expected_paths <= packaged_paths
 
@@ -242,9 +360,7 @@ assert "alembic_version" in inspect(create_engine(database_url)).get_table_names
 
 def test_percent_encoded_non_sqlite_url_fails_without_leaking_credentials(capsys):
     encoded_password = "encoded-secret%40value%2Fpart"
-    database_url = (
-        f"postgresql+gardenmissing://garden:{encoded_password}@db.example.invalid/garden"
-    )
+    database_url = f"postgresql+gardenmissing://garden:{encoded_password}@db.example.invalid/garden"
 
     with pytest.raises(NoSuchModuleError) as exc_info:
         upgrade_database(database_url)

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -135,7 +135,26 @@ def test_complete_pipeline_persists_structured_data_and_report(tmp_path) -> None
     assert scan.asset_count == 2
     assert scan.evidence_count == 2
     assert scan.finding_count >= 1
-    assert [stage.status for stage in scan.stages] == ["completed"] * 6
+    assert [stage.name for stage in scan.stages] == [
+        "validate",
+        "establish_contexts",
+        "collect",
+        "normalize",
+        "compare_coverage",
+        "replay_authorization",
+        "analyze",
+        "report",
+    ]
+    assert [stage.status for stage in scan.stages] == [
+        "completed",
+        "completed",
+        "completed",
+        "completed",
+        "skipped",
+        "skipped",
+        "completed",
+        "completed",
+    ]
     report = service.read_report(scan.id)
     for heading in [
         "执行摘要",


### PR DESCRIPTION
## 变更内容

- 建立统一验证运行模型和 assessment 协议，固定 anonymous、user、admin 三上下文。
- 统一应用入口，同时保留 quick scan 兼容路径与来源运行关联。
- 建立认证上下文和会话有效性校验，隔离并脱敏上下文失败。
- 实现三上下文统一采集、资产身份规范化和稳定响应指纹。
- 捕获可重放请求，将精确 URL、认证头和 Cookie 外置到 owner-only 受保护文件；普通数据库字段只保留脱敏 URL、header 名称与 fingerprint。
- 将 quick scan 资产绑定到 anonymous context，保持原有 URL pipeline 行为。

## 为什么需要

Garden 的产品主线已经确定为认证后应用面验证，同时继续保留单 URL quick scan 作为低门槛入口。本 PR 补齐统一运行、三角色上下文和 context-scoped 采集基础，为后续覆盖差异计算和显式授权重放提供数据边界。

## 影响

- 新增 Alembic 统一模型迁移后的 assessment 数据与三上下文采集能力。
- 现有 quick scan API、CLI 和报告路径继续兼容。
- 单个认证上下文失败会产生 incomplete/unknown 语义，不会伪装成资产缺失。
- 精确请求材料不会进入普通数据库视图、日志或报告。

## 验证

- `.venv/bin/ruff check .`
- 任务涉及文件通过 `.venv/bin/ruff format --check`
- `.venv/bin/pytest -q`
- `git diff --check`

以上检查在任务 5 提交前通过；工作区当前干净，远端 head 为 `b68aa1a`。
