### PR TITLE
修复 CI 格式检查与 Docker 打包

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY pyproject.toml README.md ./
+COPY alembic.ini ./alembic.ini
+COPY migrations ./migrations
 COPY app ./app
 COPY docs ./docs
 COPY examples ./examples
@@ -15,4 +17,3 @@ RUN pip install --no-cache-dir .
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
-

--- a/docs/superpowers/plans/2026-08-11-authenticated-coverage-platform-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-11-authenticated-coverage-platform-implementation-plan.md
@@ -222,11 +222,13 @@ git commit -m "引入数据库迁移基线"
 ```python
 def test_authenticated_assessment_has_exactly_three_contexts(db_session):
     run = make_run(db_session, mode="authenticated_coverage")
-    db_session.add_all([
-        ScanContext(scan_run_id=run.id, kind="anonymous", status="pending"),
-        ScanContext(scan_run_id=run.id, kind="user", status="pending"),
-        ScanContext(scan_run_id=run.id, kind="admin", status="pending"),
-    ])
+    db_session.add_all(
+        [
+            ScanContext(scan_run_id=run.id, kind="anonymous", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="admin", status="pending"),
+        ]
+    )
     db_session.commit()
     assert [item.kind for item in run.contexts] == ["anonymous", "user", "admin"]
 ```
@@ -236,18 +238,25 @@ def test_authenticated_assessment_has_exactly_three_contexts(db_session):
 ```python
 def test_context_kind_is_unique_per_run(db_session):
     run = make_run(db_session)
-    db_session.add_all([
-        ScanContext(scan_run_id=run.id, kind="user", status="pending"),
-        ScanContext(scan_run_id=run.id, kind="user", status="pending"),
-    ])
+    db_session.add_all(
+        [
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+            ScanContext(scan_run_id=run.id, kind="user", status="pending"),
+        ]
+    )
     with pytest.raises(IntegrityError):
         db_session.commit()
 
 
 def test_active_replay_requires_authorization_confirmation():
     with pytest.raises(ValidationError):
-        AssessmentStartRequest(url="http://127.0.0.1:8000", mode="authenticated_coverage",
-            user_profile_id=1, admin_profile_id=2, active_checks_enabled=True)
+        AssessmentStartRequest(
+            url="http://127.0.0.1:8000",
+            mode="authenticated_coverage",
+            user_profile_id=1,
+            admin_profile_id=2,
+            active_checks_enabled=True,
+        )
 ```
 
 - [ ] **步骤 3：运行测试并确认模型不存在**
@@ -343,15 +352,23 @@ def test_start_assessment_creates_three_contexts(assessment_profiles, inline_ser
     view = inline_service.start_assessment(request)
     assert [item.kind for item in view.contexts] == ["anonymous", "user", "admin"]
     assert [stage.name for stage in view.stages] == [
-        "validate", "establish_contexts", "collect", "normalize",
-        "compare_coverage", "replay_authorization", "analyze", "report",
+        "validate",
+        "establish_contexts",
+        "collect",
+        "normalize",
+        "compare_coverage",
+        "replay_authorization",
+        "analyze",
+        "report",
     ]
 ```
 
 - [ ] **步骤 3：写 quick 运行升级关联测试**
 
 ```python
-def test_authenticated_assessment_can_reference_quick_source_run(inline_service, completed_quick_run, assessment_profiles):
+def test_authenticated_assessment_can_reference_quick_source_run(
+    inline_service, completed_quick_run, assessment_profiles
+):
     view = inline_service.start_assessment(
         AssessmentStartRequest(
             url=completed_quick_run.url,
@@ -497,10 +514,13 @@ git commit -m "建立三角色验证上下文"
 - [ ] **步骤 1：写身份规范化测试**
 
 ```python
-@pytest.mark.parametrize(("left", "right"), [
-    ("https://app/a?id=1&sort=name", "https://app/a?sort=date&id=9"),
-    ("https://app:443/a/", "https://app/a"),
-])
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("https://app/a?id=1&sort=name", "https://app/a?sort=date&id=9"),
+        ("https://app:443/a/", "https://app/a"),
+    ],
+)
 def test_asset_identity_ignores_values_and_default_port(left, right):
     assert canonical_asset_identity("GET", left) == canonical_asset_identity("GET", right)
 ```
@@ -511,7 +531,9 @@ def test_asset_identity_ignores_values_and_default_port(left, right):
 def test_signature_ignores_timestamp_nonce_and_trace_id():
     first = "generated=2026-08-11T01:02:03Z nonce=abc trace_id=req-1 stable=users"
     second = "generated=2026-08-11T02:03:04Z nonce=xyz trace_id=req-2 stable=users"
-    assert stable_response_signature(first, "text/plain") == stable_response_signature(second, "text/plain")
+    assert stable_response_signature(first, "text/plain") == stable_response_signature(
+        second, "text/plain"
+    )
 ```
 
 - [ ] **步骤 3：写 context-scoped 持久化测试**
@@ -693,7 +715,9 @@ def test_protected_payload_can_be_deleted_and_expired_payloads_are_purged(tmp_pa
 def test_policy_only_selects_approved_downward_gets(run_with_requests):
     candidates = ReplayPolicy(max_candidates=50).candidates(run_with_requests)
     assert {(c.source_kind, c.target_kind) for c in candidates} == {
-        ("user", "anonymous"), ("admin", "user"), ("admin", "anonymous")
+        ("user", "anonymous"),
+        ("admin", "user"),
+        ("admin", "anonymous"),
     }
     assert all(c.method in {"GET", "HEAD", "OPTIONS"} for c in candidates)
 ```
@@ -787,14 +811,19 @@ def test_replay_replaces_source_authentication(fake_http_transport, replay_candi
 - [ ] **步骤 2：写四种判定测试**
 
 ```python
-@pytest.mark.parametrize(("status", "login_redirect", "similarity", "expected"), [
-    (403, False, 0.0, "blocked"),
-    (302, True, 0.0, "blocked"),
-    (200, False, 0.95, "equivalent_access"),
-    (200, False, 0.35, "changed_response"),
-])
+@pytest.mark.parametrize(
+    ("status", "login_redirect", "similarity", "expected"),
+    [
+        (403, False, 0.0, "blocked"),
+        (302, True, 0.0, "blocked"),
+        (200, False, 0.95, "equivalent_access"),
+        (200, False, 0.35, "changed_response"),
+    ],
+)
 def test_classify_replay(status, login_redirect, similarity, expected):
-    assert classify_replay(make_source(), make_replay(status, login_redirect, similarity)) == expected
+    assert (
+        classify_replay(make_source(), make_replay(status, login_redirect, similarity)) == expected
+    )
 ```
 
 - [ ] **步骤 3：写超时、跨源重定向和会话失效测试**
@@ -902,7 +931,13 @@ def test_non_equivalent_verdict_does_not_create_vulnerability_finding(verdict):
 
 ```python
 def test_authenticated_report_contains_coverage_and_replay_sections(report_text):
-    for heading in ["三角色会话有效性", "覆盖矩阵", "主动权限重放", "疑似授权缺陷", "完整性与未覆盖原因"]:
+    for heading in [
+        "三角色会话有效性",
+        "覆盖矩阵",
+        "主动权限重放",
+        "疑似授权缺陷",
+        "完整性与未覆盖原因",
+    ]:
         assert f"## {heading}" in report_text
 ```
 
@@ -978,9 +1013,22 @@ def test_operator_can_start_active_assessment(operator_client, assessment_payloa
 
 ```python
 def test_cli_rejects_active_replay_without_confirmation(runner):
-    result = runner.invoke(app, ["assess", "start", "--url", LOCAL_URL,
-        "--mode", "authenticated-coverage", "--user-profile", "user",
-        "--admin-profile", "admin", "--enable-active-replay"])
+    result = runner.invoke(
+        app,
+        [
+            "assess",
+            "start",
+            "--url",
+            LOCAL_URL,
+            "--mode",
+            "authenticated-coverage",
+            "--user-profile",
+            "user",
+            "--admin-profile",
+            "admin",
+            "--enable-active-replay",
+        ],
+    )
     assert result.exit_code == 2
     assert "--confirm-authorized" in result.stdout
 ```
@@ -1106,8 +1154,12 @@ def test_worker_requeues_expired_running_assessment(db_session, frozen_time):
 
 ```python
 def test_worker_marks_repeated_crash_interrupted(db_session, frozen_time):
-    run = make_run(db_session, status="running", recovery_count=3,
-        lease_expires_at=frozen_time.minus(minutes=5))
+    run = make_run(
+        db_session,
+        status="running",
+        recovery_count=3,
+        lease_expires_at=frozen_time.minus(minutes=5),
+    )
     AssessmentWorker(max_recoveries=3).recover_interrupted(frozen_time.now)
     db_session.refresh(run)
     assert run.status == "interrupted"

--- a/docs/superpowers/plans/2026-08-12-ci-repair.md
+++ b/docs/superpowers/plans/2026-08-12-ci-repair.md
@@ -2,9 +2,9 @@
 
 > **供智能代理执行：** 必须逐项执行 RED、GREEN、完整验证和发布检查；本计划采用内联执行，不分派子代理。
 
-**目标：** 修复主分支的 Ruff 格式门禁和 Docker 迁移资产打包失败，并让 GitHub Actions 恢复绿色。
+**目标：** 修复主分支的 Ruff 格式门禁、Docker 迁移资产打包和测试环境构建后端缺失，并让 GitHub Actions 恢复绿色。
 
-**架构：** 保留现有 CI 工作流和测试矩阵。格式问题直接修正被检查的中文实施计划；Docker 问题通过补齐镜像构建上下文解决，使 Hatch wheel 的强制包含来源在 `pip install .` 时真实存在。
+**架构：** 保留现有 CI 工作流和测试矩阵。格式问题直接修正被检查的中文实施计划；Docker 问题通过补齐镜像构建上下文解决，使 Hatch wheel 的强制包含来源在 `pip install .` 时真实存在；非隔离 wheel 测试所需的 Hatchling 明确归入开发依赖。
 
 **技术栈：** GitHub Actions、Ruff、pytest、Docker、Hatchling、Alembic。
 
@@ -92,7 +92,36 @@
 
   暂存 `Dockerfile` 并使用中文提交信息 `修复 Docker 迁移资产打包`。
 
-### 任务 3：完整验证和远端交付
+### 任务 3：补全非隔离 wheel 测试环境
+
+**文件：**
+
+- 修改：`pyproject.toml`
+
+**接口：**
+
+- 输入：`tests/test_migrations.py` 使用 `pip wheel --no-build-isolation`
+- 输出：安装 `.[dev]` 后可以导入 `hatchling.build`
+
+- [ ] **步骤 1：确认远端 RED**
+
+  读取 PR 首轮 Python 3.10 和 3.12 日志。
+
+  预期：两个版本都只有 `test_built_wheel_installs_with_loadable_migration_assets` 失败，并报告 `Cannot import 'hatchling.build'`。
+
+- [ ] **步骤 2：实施最小依赖修复**
+
+  在 `dev` 可选依赖中加入 `hatchling>=1.27.0,<2.0.0`，不修改生产依赖或测试逻辑。
+
+- [ ] **步骤 3：确认 GREEN**
+
+  本地运行迁移测试和完整测试，并推送后确认 Python 3.10、3.12 矩阵均成功。
+
+- [ ] **步骤 4：提交依赖修复**
+
+  暂存 `pyproject.toml` 和更新后的中文设计/计划，使用中文提交信息 `补全 CI wheel 构建依赖`。
+
+### 任务 4：完整验证和远端交付
 
 **文件：**
 
@@ -101,7 +130,7 @@
 
 **接口：**
 
-- 输入：任务 1、2 的提交
+- 输入：任务 1、2、3 的提交
 - 输出：本地验证证据和 GitHub Actions 绿色结果
 
 - [ ] **步骤 1：运行完整本地验证**
@@ -116,7 +145,7 @@
 
 - [ ] **步骤 3：推送并创建拉取请求**
 
-  推送 `fix/ci-packaging-and-format`，创建以 `main` 为基线的拉取请求，并在说明中列出两个根因及本地验证结果。
+  推送 `fix/ci-packaging-and-format`，创建以 `main` 为基线的拉取请求，并在说明中列出三个根因及本地验证结果。
 
 - [ ] **步骤 4：确认 GitHub Actions**
 

--- a/docs/superpowers/plans/2026-08-12-ci-repair.md
+++ b/docs/superpowers/plans/2026-08-12-ci-repair.md
@@ -1,0 +1,125 @@
+# CI 修复实施计划
+
+> **供智能代理执行：** 必须逐项执行 RED、GREEN、完整验证和发布检查；本计划采用内联执行，不分派子代理。
+
+**目标：** 修复主分支的 Ruff 格式门禁和 Docker 迁移资产打包失败，并让 GitHub Actions 恢复绿色。
+
+**架构：** 保留现有 CI 工作流和测试矩阵。格式问题直接修正被检查的中文实施计划；Docker 问题通过补齐镜像构建上下文解决，使 Hatch wheel 的强制包含来源在 `pip install .` 时真实存在。
+
+**技术栈：** GitHub Actions、Ruff、pytest、Docker、Hatchling、Alembic。
+
+## 全局约束
+
+- 不修改认证覆盖平台业务逻辑、数据库模型或迁移内容。
+- 不缩小 Ruff 检查范围，不跳过 Python 3.10 或 3.12。
+- 不开始认证覆盖平台任务 6。
+- 所有设计文档、执行计划、开发日志和提交信息使用中文。
+- 主目录现有未提交文件不得进入本任务分支。
+
+---
+
+### 任务 1：恢复全仓 Ruff 格式门禁
+
+**文件：**
+
+- 修改：`docs/superpowers/plans/2026-08-11-authenticated-coverage-platform-implementation-plan.md`
+- 修改：`docs/superpowers/plans/2026-08-12-ci-repair.md`（仅当 Ruff 规范化本文代码块时）
+
+**接口：**
+
+- 输入：CI 命令 `ruff format --check .`
+- 输出：整个仓库无待格式化文件
+
+- [ ] **步骤 1：运行失败检查并确认 RED**
+
+  运行：`python -m ruff format --check .`
+
+  预期：命令失败，并只报告现有中文实施计划需要重新格式化。
+
+- [ ] **步骤 2：执行最小格式修复**
+
+  运行：`python -m ruff format docs/superpowers/plans/2026-08-11-authenticated-coverage-platform-implementation-plan.md docs/superpowers/plans/2026-08-12-ci-repair.md`
+
+- [ ] **步骤 3：确认 GREEN**
+
+  运行：`python -m ruff check .` 和 `python -m ruff format --check .`
+
+  预期：两个命令退出码均为零。
+
+- [ ] **步骤 4：提交格式修复**
+
+  暂存上述两个计划文件并使用中文提交信息 `修复全仓 Ruff 格式检查`。
+
+### 任务 2：恢复 Docker wheel 打包
+
+**文件：**
+
+- 修改：`Dockerfile`
+
+**接口：**
+
+- 输入：`pyproject.toml` 中 `alembic.ini` 和 `migrations` 的 wheel `force-include` 来源
+- 输出：镜像 `/app/alembic.ini` 与 `/app/migrations/` 在 `pip install .` 前存在
+
+- [ ] **步骤 1：运行失败构建并确认 RED**
+
+  运行：`docker build -t garden:ci-red .`
+
+  预期：命令在 `pip install --no-cache-dir .` 失败，并报告 `/app/alembic.ini` 不存在。
+
+- [ ] **步骤 2：实施最小修复**
+
+  在 `Dockerfile` 的项目安装步骤之前增加：
+
+  ```dockerfile
+  COPY alembic.ini ./alembic.ini
+  COPY migrations ./migrations
+  ```
+
+- [ ] **步骤 3：确认 GREEN**
+
+  运行：`docker build -t garden:ci .`
+
+  预期：镜像成功构建，`pip install .` 完成。
+
+- [ ] **步骤 4：验证镜像中的迁移资产**
+
+  运行：`docker run --rm garden:ci python -c "from importlib.resources import files; root = files('app.db.migration_assets'); assert root.joinpath('alembic.ini').is_file(); assert root.joinpath('migrations/env.py').is_file()"`
+
+  预期：命令退出码为零。
+
+- [ ] **步骤 5：提交 Docker 修复**
+
+  暂存 `Dockerfile` 并使用中文提交信息 `修复 Docker 迁移资产打包`。
+
+### 任务 3：完整验证和远端交付
+
+**文件：**
+
+- 不新增生产文件
+- 检查：当前分支相对 `origin/main` 的完整差异
+
+**接口：**
+
+- 输入：任务 1、2 的提交
+- 输出：本地验证证据和 GitHub Actions 绿色结果
+
+- [ ] **步骤 1：运行完整本地验证**
+
+  依次运行：`python -m ruff check .`、`python -m ruff format --check .`、`python -m pytest -o addopts='' -q -ra`、`docker build -t garden:ci .` 和任务 2 的镜像迁移资产检查。
+
+- [ ] **步骤 2：自审差异和范围**
+
+  运行：`git diff --check origin/main...HEAD`、`git diff --stat origin/main...HEAD` 和 `git status --short --branch`。
+
+  预期：没有空白错误、没有业务逻辑变更、工作区干净。
+
+- [ ] **步骤 3：推送并创建拉取请求**
+
+  推送 `fix/ci-packaging-and-format`，创建以 `main` 为基线的拉取请求，并在说明中列出两个根因及本地验证结果。
+
+- [ ] **步骤 4：确认 GitHub Actions**
+
+  等待拉取请求的 `Lint & Test (3.10)`、`Lint & Test (3.12)`、`Docker build` 和 `CLI smoke` 全部结束。
+
+  预期：全部检查成功；若失败，读取失败日志并仅在本任务边界内继续修复。

--- a/docs/superpowers/specs/2026-08-12-ci-repair-design.md
+++ b/docs/superpowers/specs/2026-08-12-ci-repair-design.md
@@ -1,0 +1,35 @@
+# CI 修复设计
+
+## 背景
+
+合并提交 `3069fce` 的 GitHub Actions 同时暴露了两个交付问题：Ruff 全仓格式检查因认证覆盖平台实施计划中的 Python 代码块未格式化而中止，Docker 镜像在安装项目 wheel 时因构建上下文缺少 `alembic.ini` 和 `migrations/` 而失败。因此 Python 3.10 和 3.12 的测试步骤没有实际执行，主分支保持红色。
+
+## 目标
+
+- 保留 CI 对整个仓库执行 Ruff 格式检查的现有约束，并修正唯一不符合格式的文档。
+- 让 Docker 构建上下文包含 Hatch wheel 强制打包所需的 Alembic 配置和迁移脚本。
+- 在本地重新验证 Ruff、完整测试、wheel 打包和 Docker 构建，并通过拉取请求触发 GitHub Actions。
+
+## 非目标
+
+- 不修改认证覆盖平台的业务逻辑、数据库模型或迁移内容。
+- 不调整 CI 的测试矩阵、跳过规则或分支保护策略。
+- 不开始实施认证覆盖平台任务 6。
+
+## 方案
+
+格式问题采用“修正文档”方案：继续保留 `ruff format --check .`，对现有实施计划执行 Ruff formatter。相比缩小检查目录或添加排除规则，这能维持单一本地与 CI 格式标准，不隐藏未来文档代码块中的格式问题。
+
+Docker 问题采用“补全构建上下文”方案：在安装项目之前，将仓库根目录的 `alembic.ini` 和 `migrations/` 复制到镜像 `/app`。这与 `pyproject.toml` 中的 wheel `force-include` 来源路径一致，不改变运行时迁移资产的包内位置。
+
+## 验收标准
+
+- `ruff check .` 和 `ruff format --check .` 均成功。
+- 完整 pytest 套件成功；GitHub Actions 实际覆盖 Python 3.10 和 3.12。
+- 本地 wheel 构建能够包含迁移资产。
+- `docker build -t garden:ci .` 成功。
+- 修复分支推送后，拉取请求的 CI、Docker build 和 CLI smoke 全部成功。
+
+## 风险控制
+
+本任务只修改 Dockerfile、格式化目标文档及本设计/计划文档。主目录的未提交文件不会被复制、暂存或提交；所有工作在独立 worktree 中完成。如果本地缺少某个 Python 版本或 Docker 服务，则以能够执行的本地检查为证据，并以 GitHub Actions 矩阵作为最终远端验证。

--- a/docs/superpowers/specs/2026-08-12-ci-repair-design.md
+++ b/docs/superpowers/specs/2026-08-12-ci-repair-design.md
@@ -2,12 +2,13 @@
 
 ## 背景
 
-合并提交 `3069fce` 的 GitHub Actions 同时暴露了两个交付问题：Ruff 全仓格式检查因认证覆盖平台实施计划中的 Python 代码块未格式化而中止，Docker 镜像在安装项目 wheel 时因构建上下文缺少 `alembic.ini` 和 `migrations/` 而失败。因此 Python 3.10 和 3.12 的测试步骤没有实际执行，主分支保持红色。
+合并提交 `3069fce` 的 GitHub Actions 同时暴露了两个交付问题：Ruff 全仓格式检查因认证覆盖平台实施计划中的 Python 代码块未格式化而中止，Docker 镜像在安装项目 wheel 时因构建上下文缺少 `alembic.ini` 和 `migrations/` 而失败。因此 Python 3.10 和 3.12 的测试步骤没有实际执行，主分支保持红色。前两个问题修复后，首次完整执行的测试矩阵又暴露了第三个问题：迁移 wheel 测试使用 `--no-build-isolation`，但开发依赖没有安装 Hatchling 构建后端。
 
 ## 目标
 
 - 保留 CI 对整个仓库执行 Ruff 格式检查的现有约束，并修正唯一不符合格式的文档。
 - 让 Docker 构建上下文包含 Hatch wheel 强制打包所需的 Alembic 配置和迁移脚本。
+- 让通过 `.[dev]` 建立的测试环境具备非隔离 wheel 构建所需的 Hatchling。
 - 在本地重新验证 Ruff、完整测试、wheel 打包和 Docker 构建，并通过拉取请求触发 GitHub Actions。
 
 ## 非目标
@@ -22,6 +23,8 @@
 
 Docker 问题采用“补全构建上下文”方案：在安装项目之前，将仓库根目录的 `alembic.ini` 和 `migrations/` 复制到镜像 `/app`。这与 `pyproject.toml` 中的 wheel `force-include` 来源路径一致，不改变运行时迁移资产的包内位置。
 
+测试环境问题采用“显式开发依赖”方案：在 `dev` 可选依赖中加入与构建系统下限一致的 Hatchling。测试继续使用 `--no-build-isolation`，避免每次验证 wheel 时创建联网构建环境，同时让本地和 CI 的依赖契约一致。
+
 ## 验收标准
 
 - `ruff check .` 和 `ruff format --check .` 均成功。
@@ -32,4 +35,4 @@ Docker 问题采用“补全构建上下文”方案：在安装项目之前，�
 
 ## 风险控制
 
-本任务只修改 Dockerfile、格式化目标文档及本设计/计划文档。主目录的未提交文件不会被复制、暂存或提交；所有工作在独立 worktree 中完成。如果本地缺少某个 Python 版本或 Docker 服务，则以能够执行的本地检查为证据，并以 GitHub Actions 矩阵作为最终远端验证。
+本任务只修改 Dockerfile、开发依赖声明、格式化目标文档及本设计/计划文档。主目录的未提交文件不会被复制、暂存或提交；所有工作在独立 worktree 中完成。如果本地缺少某个 Python 版本或 Docker 服务，则以能够执行的本地检查为证据，并以 GitHub Actions 矩阵作为最终远端验证。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "hatchling>=1.27.0,<2.0.0",
   "pre-commit>=4.2.0,<5.0.0",
   "pytest>=8.3.0,<9.0.0",
   "pytest-cov>=6.1.0,<7.0.0",


### PR DESCRIPTION
## 修复内容

- 保留全仓 `ruff format --check .`，格式化认证覆盖平台实施计划中的 Python 代码块。
- 在 Docker 安装项目之前复制 `alembic.ini` 和 `migrations/`，满足 Hatch wheel 的 `force-include` 来源要求。
- 将 Hatchling 明确列入开发依赖，满足迁移 wheel 测试的 `--no-build-isolation` 契约。
- 增加中文 CI 修复设计和实施计划，明确本任务不进入认证覆盖平台任务 6。

## 根因

Python 3.10/3.12 作业最初在 pytest 之前被未格式化文档阻断；Docker 作业在构建 wheel 元数据时因 `/app/alembic.ini` 不存在而失败。前两项修复后，测试矩阵进一步暴露开发环境缺少 Hatchling，导致非隔离 wheel 构建无法导入 `hatchling.build`。

## 本地验证

- `ruff check .`：通过
- `ruff format --check .`：178 个文件均已格式化
- `pytest -o addopts='' -q -ra`：164 passed，1 个既有弃用警告
- wheel 构建：通过，并确认包含 `app/db/migration_assets/alembic.ini` 与 `migrations/env.py`
- GitHub Actions：Python 3.10、Python 3.12、Docker build、CLI smoke 全部通过
- 本地完整 Docker 构建在下载 Playwright 依赖时网络停滞；远端 Docker build 已完成最终验证
