### PR TITLE
正式 CLI 与自动 Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,26 @@ URL
   → Markdown 报告
 ```
 
-## 快速开始
+## 正式 CLI 快速开始
+
+macOS、Linux 或 WSL（Python 3.10+）可直接在仓库根目录安装用户级 CLI；不需要 `sudo`，也不需要手动激活虚拟环境：
+
+```bash
+./install.sh
+garden --version
+garden scan http://127.0.0.1:13000/
+```
+
+首次运行会自动启动或复用仅监听本机回环地址的 Web UI，并输出首页和本次扫描详情地址；默认前台显示进度，但不会自动打开浏览器。用户数据默认保存于 `~/.garden`，可用 `GARDEN_HOME` 覆盖。若安装后找不到命令，请按安装器输出将 `~/.local/bin` 加入 PATH。
+
+```bash
+garden scan http://127.0.0.1:13000/ --detach  # 仅提交，立即返回
+garden stop                                   # 中断活动扫描并停止本机 UI
+```
+
+`gardenctl` 是兼容别名，既有命令组和 `gardenctl scan --url URL` 均继续可用。
+
+## 仓库开发快速开始
 
 环境要求：Python 3.10+。
 
@@ -57,14 +76,14 @@ docker compose up --build
 ### CLI
 
 ```bash
-gardenctl scan --url http://127.0.0.1:13000/
+garden scan http://127.0.0.1:13000/
+gardenctl scan --url http://127.0.0.1:13000/  # 兼容写法
 ```
 
 可以用边界参数控制扫描规模：
 
 ```bash
-gardenctl scan \
-  --url http://127.0.0.1:13000/ \
+garden scan http://127.0.0.1:13000/ \
   --max-pages 10 \
   --max-depth 2 \
   --request-timeout 5 \
@@ -84,6 +103,7 @@ curl -X POST http://127.0.0.1:8000/api/scans \
 
 - `POST /api/scans`：提交 URL
 - `GET /api/scans/{id}`：读取进度、阶段和失败信息
+- `POST /api/scans/{id}/cancel`：中断尚未结束的扫描并保留已写入结果
 - `GET /api/scans/{id}/report`：阅读或下载报告
 
 ## 报告内容

--- a/app/api/routes/scans.py
+++ b/app/api/routes/scans.py
@@ -24,6 +24,11 @@ def scan_status_api(request: Request, scan_run_id: int) -> ScanRunView:
     return request.app.state.scan_service.get_scan(scan_run_id)
 
 
+@router.post("/api/scans/{scan_run_id}/cancel", response_model=ScanRunView)
+def cancel_scan_api(request: Request, scan_run_id: int) -> ScanRunView:
+    return request.app.state.scan_service.cancel_scan(scan_run_id)
+
+
 @router.get("/api/scans/{scan_run_id}/report")
 def scan_report_api(
     request: Request,

--- a/app/cli/local_api.py
+++ b/app/cli/local_api.py
@@ -1,0 +1,49 @@
+"""正式 CLI 与本机 Garden Web UI 之间的最小 HTTP 适配。"""
+
+from __future__ import annotations
+
+import json
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from app.core.errors import GardenError
+from app.schemas.scan import ScanOptions, ScanRunView
+
+
+class LocalApiError(GardenError):
+    """本机 Web UI 未就绪或返回不可用响应。"""
+
+
+class LocalScanApi:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def start_scan(self, url: str, options: ScanOptions) -> ScanRunView:
+        return self._scan_request(
+            "POST", "/api/scans", {"url": url, "options": options.model_dump()}
+        )
+
+    def get_scan(self, scan_run_id: int) -> ScanRunView:
+        return self._scan_request("GET", f"/api/scans/{scan_run_id}")
+
+    def cancel_scan(self, scan_run_id: int) -> ScanRunView:
+        return self._scan_request("POST", f"/api/scans/{scan_run_id}/cancel")
+
+    def _scan_request(
+        self, method: str, path: str, payload: dict[str, object] | None = None
+    ) -> ScanRunView:
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = Request(
+            f"{self.base_url}{path}",
+            data=data,
+            method=method,
+            headers={"content-type": "application/json"} if data else {},
+        )
+        try:
+            with urlopen(request, timeout=5) as response:  # noqa: S310 - loopback URL only
+                return ScanRunView.model_validate(json.loads(response.read()))
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise LocalApiError(f"本机 Garden Web UI 返回 HTTP {error.code}: {detail}") from error
+        except (URLError, OSError, ValueError) as error:
+            raise LocalApiError(f"无法连接本机 Garden Web UI：{error}") from error

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -15,6 +15,7 @@ from app.cli.report import app as report_app
 from app.cli.retest import app as retest_app
 from app.cli.scan import scan as scan_command
 from app.cli.sessions import app as session_app
+from app.cli.stop import stop as stop_command
 from app.cli.targets import app as target_app
 from app.cli.utils import console, render_json
 from app.core.logging import configure_logging
@@ -23,7 +24,7 @@ from app.db.bootstrap import init_database
 from app.services.health import build_health_response
 
 app = typer.Typer(
-    name="gardenctl",
+    name="garden",
     help=(
         "CLI for Garden's one-URL automatic asset reports and advanced authenticated "
         "verification workflows."
@@ -54,6 +55,7 @@ def healthcheck() -> None:
 
 
 app.command("scan")(scan_command)
+app.command("stop")(stop_command)
 app.add_typer(target_app, name="target")
 app.add_typer(credential_app, name="cred")
 app.add_typer(job_app, name="job")

--- a/app/cli/paths.py
+++ b/app/cli/paths.py
@@ -52,6 +52,10 @@ class GardenPaths:
         return self.runtime_dir / "server.json"
 
     @property
+    def server_pid_file(self) -> Path:
+        return self.runtime_dir / "server.pid"
+
+    @property
     def web_log_file(self) -> Path:
         return self.logs_dir / "web.log"
 

--- a/app/cli/paths.py
+++ b/app/cli/paths.py
@@ -1,0 +1,58 @@
+"""用户级 Garden CLI 的运行目录约定。"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GardenPaths:
+    """集中解析正式 CLI 的用户数据目录。"""
+
+    home: Path
+
+    @classmethod
+    def from_environment(cls) -> GardenPaths:
+        configured = os.environ.get("GARDEN_HOME")
+        home = Path(configured).expanduser() if configured else Path.home() / ".garden"
+        return cls(home=home)
+
+    @property
+    def config_file(self) -> Path:
+        return self.home / "config.env"
+
+    @property
+    def database_file(self) -> Path:
+        return self.home / "garden.db"
+
+    @property
+    def database_url(self) -> str:
+        return f"sqlite+pysqlite:///{self.database_file}"
+
+    @property
+    def reports_dir(self) -> Path:
+        return self.home / "reports"
+
+    @property
+    def storage_dir(self) -> Path:
+        return self.home / "storage"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.home / "logs"
+
+    @property
+    def runtime_dir(self) -> Path:
+        return self.home / "runtime"
+
+    def ensure_directories(self) -> None:
+        for directory in (
+            self.home,
+            self.reports_dir,
+            self.storage_dir,
+            self.logs_dir,
+            self.runtime_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)

--- a/app/cli/paths.py
+++ b/app/cli/paths.py
@@ -47,6 +47,14 @@ class GardenPaths:
     def runtime_dir(self) -> Path:
         return self.home / "runtime"
 
+    @property
+    def server_state_file(self) -> Path:
+        return self.runtime_dir / "server.json"
+
+    @property
+    def web_log_file(self) -> Path:
+        return self.logs_dir / "web.log"
+
     def ensure_directories(self) -> None:
         for directory in (
             self.home,

--- a/app/cli/scan.py
+++ b/app/cli/scan.py
@@ -1,60 +1,120 @@
-"""Thin one-URL CLI adapter over the core scan application service."""
+"""正式 `garden scan` 命令：通过本机 Web UI 提交并观察扫描。"""
 
 from __future__ import annotations
 
+import time
 from typing import Annotated
 
 import typer
 
+from app.cli.local_api import LocalScanApi
+from app.cli.paths import GardenPaths
 from app.cli.utils import console, handle_cli_error, render_key_value
+from app.cli.web_runtime import WebRuntimeError, WebRuntimeManager
 from app.core.errors import GardenError, InputValidationError
-from app.schemas.scan import ScanOptions
-from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
+from app.core.settings import get_settings
+from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES
+from app.schemas.scan import ScanOptions, ScanRunView
 
 
 def scan(
-    url: Annotated[str | None, typer.Option("--url", help="Authorized HTTP(S) entry URL.")] = None,
+    entry_url: Annotated[str | None, typer.Argument(help="已授权的 HTTP(S) 入口 URL。")] = None,
+    legacy_url: Annotated[str | None, typer.Option("--url", help="兼容旧版 URL 参数。")] = None,
     max_pages: Annotated[int, typer.Option("--max-pages")] = 10,
     max_depth: Annotated[int, typer.Option("--max-depth")] = 2,
     request_timeout_seconds: Annotated[float | None, typer.Option("--request-timeout")] = None,
     overall_timeout_seconds: Annotated[float | None, typer.Option("--overall-timeout")] = None,
     retry_attempts: Annotated[int | None, typer.Option("--retries")] = None,
+    detach: Annotated[bool, typer.Option("--detach", help="提交后立即返回。")] = False,
+    ui_port: Annotated[int | None, typer.Option("--ui-port", min=1, max=65535)] = None,
 ) -> None:
-    """Submit one URL and automatically produce the final structured report."""
+    """扫描一个已授权 URL；默认前台显示进度。"""
+
+    manager = None
+    api = None
+    result = None
     try:
-        if url is None:
-            url = typer.prompt("Authorized entry URL")
-        if not url.strip():
-            raise InputValidationError("URL cannot be blank.")
-        service = ScanApplicationService(dispatcher=InlineScanDispatcher())
-        result = service.start_scan(
-            url,
-            ScanOptions(
-                max_pages=max_pages,
-                max_depth=max_depth,
-                request_timeout_seconds=request_timeout_seconds,
-                overall_timeout_seconds=overall_timeout_seconds,
-                retry_attempts=retry_attempts,
-            ),
+        url = _resolve_url(entry_url, legacy_url)
+        options = ScanOptions(
+            max_pages=max_pages,
+            max_depth=max_depth,
+            request_timeout_seconds=request_timeout_seconds,
+            overall_timeout_seconds=overall_timeout_seconds,
+            retry_attempts=retry_attempts,
         )
-        render_key_value(
-            [
-                ("Scan", str(result.id)),
-                ("Status", result.status),
-                ("Progress", f"{result.progress}%"),
-                ("Stage", result.current_stage),
-                ("Assets", str(result.asset_count)),
-                ("Evidence", str(result.evidence_count)),
-                ("Findings", str(result.finding_count)),
-                ("Retries", str(result.retry_count)),
-                ("Report", result.report_path or "not generated"),
-            ],
-            title="Automatic URL Scan Result",
+        manager = WebRuntimeManager(
+            paths=GardenPaths.from_environment(), default_port=get_settings().api_port
         )
-        if result.failures:
-            for failure in result.failures:
-                console.print(f"[yellow]{failure.stage}/{failure.code}:[/yellow] {failure.message}")
+        runtime = manager.ensure(ui_port=ui_port)
+        api = LocalScanApi(runtime.base_url)
+        result = api.start_scan(url, options)
+        _print_locations(runtime.base_url, result.id)
+        if detach:
+            console.print(f"扫描 {result.id} 已后台提交。")
+            return
+        result = _wait_for_scan(api, result)
+        _print_result(result)
         if result.status == "failed":
             raise typer.Exit(code=1)
-    except GardenError as error:
+    except KeyboardInterrupt:
+        if api is not None and result is not None and manager is not None:
+            _cancel_from_interrupt(api, result.id, manager)
+        raise typer.Exit(code=130) from None
+    except (GardenError, WebRuntimeError) as error:
         handle_cli_error(error)
+
+
+def _resolve_url(entry_url: str | None, legacy_url: str | None) -> str:
+    if entry_url is not None and legacy_url is not None:
+        raise InputValidationError("请只使用位置 URL 或 --url 之一，不能同时提供。")
+    url = entry_url or legacy_url
+    if url is None:
+        url = typer.prompt("已授权的入口 URL")
+    if not url.strip():
+        raise InputValidationError("URL cannot be blank.")
+    return url
+
+
+def _wait_for_scan(api: LocalScanApi, initial: ScanRunView) -> ScanRunView:
+    result = initial
+    shown: tuple[str, int] | None = None
+    while result.status not in TERMINAL_SCAN_RUN_STATUSES:
+        progress = (result.current_stage, result.progress)
+        if progress != shown:
+            console.print(f"扫描 {result.id}：{result.current_stage}，{result.progress}%")
+            shown = progress
+        time.sleep(0.2)
+        result = api.get_scan(result.id)
+    return result
+
+
+def _print_locations(base_url: str, scan_run_id: int) -> None:
+    console.print(f"Web UI：{base_url}")
+    console.print(f"扫描详情：{base_url}/scans/{scan_run_id}")
+
+
+def _print_result(result: ScanRunView) -> None:
+    render_key_value(
+        [
+            ("扫描", str(result.id)),
+            ("状态", result.status),
+            ("进度", f"{result.progress}%"),
+            ("阶段", result.current_stage),
+            ("资产", str(result.asset_count)),
+            ("证据", str(result.evidence_count)),
+            ("关注项", str(result.finding_count)),
+            ("报告", result.report_path or "未生成"),
+        ],
+        title="Garden 扫描结果",
+    )
+
+
+def _cancel_from_interrupt(api, scan_run_id, manager) -> None:
+    try:
+        api.cancel_scan(scan_run_id)
+    except Exception:  # noqa: BLE001 - Ctrl+C 必须在有限时间内退出
+        pass
+    if manager.started_by_this_command:
+        manager.stop()
+    console.print("扫描已中断。")
+    raise typer.Exit(code=130)

--- a/app/cli/stop.py
+++ b/app/cli/stop.py
@@ -1,0 +1,18 @@
+"""停止本机 Web UI 并中断尚未结束的扫描。"""
+
+from __future__ import annotations
+
+from app.cli.paths import GardenPaths
+from app.cli.utils import console
+from app.cli.web_runtime import WebRuntimeManager
+from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
+
+
+def stop() -> None:
+    """中断全部活动扫描并停止本机 Garden Web UI。"""
+
+    interrupted = ScanApplicationService(dispatcher=InlineScanDispatcher()).interrupt_active_scans()
+    manager = WebRuntimeManager(paths=GardenPaths.from_environment())
+    stopped = manager.stop()
+    console.print(f"已中断 {interrupted} 个活动扫描。")
+    console.print("本机 Garden Web UI 已停止。" if stopped else "本机 Garden Web UI 未运行。")

--- a/app/cli/web_runtime.py
+++ b/app/cli/web_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -45,6 +46,7 @@ class WebRuntimeManager:
         self.paths = paths
         self.default_port = default_port
         self.startup_timeout_seconds = startup_timeout_seconds
+        self.started_by_this_command = False
 
     def ensure(self, *, ui_port: int | None = None) -> WebRuntime:
         existing = self._load_state()
@@ -55,6 +57,7 @@ class WebRuntimeManager:
                         f"Garden Web UI 已在端口 {existing.port} 运行；"
                         "请使用相同端口或先执行 garden stop。"
                     )
+                self.started_by_this_command = False
                 return existing
             self._remove_state()
 
@@ -78,6 +81,7 @@ class WebRuntimeManager:
                     started_at=datetime.now(timezone.utc).isoformat(),
                 )
                 self._write_state(runtime)
+                self.started_by_this_command = True
                 return runtime
             self._terminate_process(process)
             last_error = WebRuntimeError(
@@ -112,9 +116,37 @@ class WebRuntimeManager:
         temp_path.write_text(json.dumps(asdict(runtime), sort_keys=True), encoding="utf-8")
         temp_path.chmod(0o600)
         temp_path.replace(self.paths.server_state_file)
+        self.paths.server_pid_file.write_text(f"{runtime.pid}\n", encoding="utf-8")
+        self.paths.server_pid_file.chmod(0o600)
 
     def _remove_state(self) -> None:
         self.paths.server_state_file.unlink(missing_ok=True)
+        self.paths.server_pid_file.unlink(missing_ok=True)
+
+    def stop(self) -> bool:
+        """只终止状态文件确认的健康 Garden UI；不触碰不确定的外部进程。"""
+
+        runtime = self._load_state()
+        if runtime is None or not self._is_healthy(runtime):
+            self._remove_state()
+            return False
+        try:
+            os.killpg(runtime.pid, signal.SIGTERM)
+        except (AttributeError, OSError):
+            self._remove_state()
+            return False
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            if not self._is_process_alive(runtime.pid):
+                self._remove_state()
+                return True
+            time.sleep(0.05)
+        try:
+            os.killpg(runtime.pid, signal.SIGKILL)
+        except OSError:
+            pass
+        self._remove_state()
+        return True
 
     def _is_healthy(self, runtime: WebRuntime) -> bool:
         if not self._is_process_alive(runtime.pid):

--- a/app/cli/web_runtime.py
+++ b/app/cli/web_runtime.py
@@ -1,0 +1,204 @@
+"""正式 CLI 使用的本地 Garden Web UI 进程管理。"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from app.cli.paths import GardenPaths
+
+
+class WebRuntimeError(RuntimeError):
+    """本地 Web UI 无法安全复用或启动。"""
+
+
+@dataclass(frozen=True)
+class WebRuntime:
+    pid: int
+    port: int
+    home: str
+    started_at: str
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+class WebRuntimeManager:
+    """复用或启动只监听回环地址的 Uvicorn 进程。"""
+
+    def __init__(
+        self,
+        *,
+        paths: GardenPaths,
+        default_port: int = 8000,
+        startup_timeout_seconds: float = 10.0,
+    ) -> None:
+        self.paths = paths
+        self.default_port = default_port
+        self.startup_timeout_seconds = startup_timeout_seconds
+
+    def ensure(self, *, ui_port: int | None = None) -> WebRuntime:
+        existing = self._load_state()
+        if existing is not None:
+            if self._is_healthy(existing):
+                if ui_port is not None and existing.port != ui_port:
+                    raise WebRuntimeError(
+                        f"Garden Web UI 已在端口 {existing.port} 运行；"
+                        "请使用相同端口或先执行 garden stop。"
+                    )
+                return existing
+            self._remove_state()
+
+        if ui_port is not None:
+            if not self._is_port_available(ui_port):
+                raise WebRuntimeError(f"指定的 Web UI 端口 {ui_port} 已被占用。")
+            candidate_ports = [ui_port]
+        elif self._is_port_available(self.default_port):
+            candidate_ports = [self.default_port]
+        else:
+            candidate_ports = [self._reserve_free_port() for _ in range(3)]
+
+        last_error: WebRuntimeError | None = None
+        for port in candidate_ports:
+            process = self._start_process(port)
+            if self._wait_for_health(port):
+                runtime = WebRuntime(
+                    pid=process.pid,
+                    port=port,
+                    home=str(self.paths.home),
+                    started_at=datetime.now(timezone.utc).isoformat(),
+                )
+                self._write_state(runtime)
+                return runtime
+            self._terminate_process(process)
+            last_error = WebRuntimeError(
+                f"Garden Web UI 未能在 {self.startup_timeout_seconds:g} 秒内就绪。"
+            )
+            if ui_port is not None:
+                break
+
+        raise last_error or WebRuntimeError("Garden Web UI 启动失败。")
+
+    def _load_state(self) -> WebRuntime | None:
+        path = self.paths.server_state_file
+        if not path.is_file():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            runtime = WebRuntime(
+                pid=int(payload["pid"]),
+                port=int(payload["port"]),
+                home=str(payload["home"]),
+                started_at=str(payload["started_at"]),
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if runtime.home != str(self.paths.home):
+            return None
+        return runtime
+
+    def _write_state(self, runtime: WebRuntime) -> None:
+        self.paths.ensure_directories()
+        temp_path = self.paths.runtime_dir / ".server.json.tmp"
+        temp_path.write_text(json.dumps(asdict(runtime), sort_keys=True), encoding="utf-8")
+        temp_path.chmod(0o600)
+        temp_path.replace(self.paths.server_state_file)
+
+    def _remove_state(self) -> None:
+        self.paths.server_state_file.unlink(missing_ok=True)
+
+    def _is_healthy(self, runtime: WebRuntime) -> bool:
+        if not self._is_process_alive(runtime.pid):
+            return False
+        try:
+            with urlopen(f"{runtime.base_url}/healthz", timeout=0.5) as response:  # noqa: S310
+                return response.status == 200
+        except (URLError, TimeoutError, OSError):
+            return False
+
+    def _wait_for_health(self, port: int) -> bool:
+        runtime = WebRuntime(
+            pid=0,
+            port=port,
+            home=str(self.paths.home),
+            started_at="",
+        )
+        deadline = time.monotonic() + self.startup_timeout_seconds
+        while time.monotonic() < deadline:
+            try:
+                with urlopen(f"{runtime.base_url}/healthz", timeout=0.5) as response:  # noqa: S310
+                    if response.status == 200:
+                        return True
+            except (URLError, TimeoutError, OSError):
+                time.sleep(0.1)
+        return False
+
+    @staticmethod
+    def _is_process_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
+
+    @staticmethod
+    def _is_port_available(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                probe.bind(("127.0.0.1", port))
+            except OSError:
+                return False
+        return True
+
+    @staticmethod
+    def _reserve_free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            return int(probe.getsockname()[1])
+
+    def _start_process(self, port: int) -> subprocess.Popen:
+        self.paths.ensure_directories()
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GARDEN_CLI_RUNTIME": "1",
+                "GARDEN_HOME": str(self.paths.home),
+            }
+        )
+        with self.paths.web_log_file.open("a", encoding="utf-8") as log_file:
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "uvicorn",
+                    "app.main:app",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                ],
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+
+    @staticmethod
+    def _terminate_process(process: subprocess.Popen) -> None:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                process.kill()

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,9 +1,22 @@
 """Central settings loader for Garden."""
 
+import os
 from functools import lru_cache
 
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, DotEnvSettingsSource, SettingsConfigDict
+
+from app.cli.paths import GardenPaths
+
+
+def _is_formal_cli_runtime() -> bool:
+    return os.environ.get("GARDEN_CLI_RUNTIME") == "1"
+
+
+def _default_database_url() -> str:
+    if _is_formal_cli_runtime():
+        return GardenPaths.from_environment().database_url
+    return "sqlite+pysqlite:///./data/garden.db"
 
 
 class Settings(BaseSettings):
@@ -13,10 +26,7 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", alias="GARDEN_LOG_LEVEL")
     api_host: str = Field(default="127.0.0.1", alias="GARDEN_API_HOST")
     api_port: int = Field(default=8000, alias="GARDEN_API_PORT")
-    database_url: str = Field(
-        default="sqlite+pysqlite:///./data/garden.db",
-        alias="GARDEN_DATABASE_URL",
-    )
+    database_url: str = Field(default_factory=_default_database_url, alias="GARDEN_DATABASE_URL")
     database_auto_migrate: bool = Field(
         default=False,
         alias="GARDEN_DATABASE_AUTO_MIGRATE",
@@ -73,6 +83,25 @@ class Settings(BaseSettings):
         case_sensitive=False,
         extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls,
+        init_settings,
+        env_settings,
+        dotenv_settings,
+        file_secret_settings,
+    ):
+        if _is_formal_cli_runtime():
+            formal_dotenv = DotEnvSettingsSource(
+                settings_cls,
+                env_file=GardenPaths.from_environment().config_file,
+                env_file_encoding="utf-8",
+                case_sensitive=False,
+            )
+            return init_settings, env_settings, formal_dotenv, file_secret_settings
+        return init_settings, env_settings, dotenv_settings, file_secret_settings
 
 
 @lru_cache(maxsize=1)

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,9 @@ async def lifespan(app: FastAPI):
     )
     init_database(settings.database_url)
     app.state.scan_service = ScanApplicationService(settings=settings)
+    interrupted = app.state.scan_service.interrupt_active_scans()
+    if interrupted:
+        logger.warning("Interrupted stale active scans", extra={"count": interrupted})
     try:
         yield
     finally:

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -176,6 +176,32 @@ class ScanApplicationService:
         with session_scope() as session:
             self.pipeline.execute(session, scan_run_id)
 
+    def cancel_scan(self, scan_run_id: int) -> ScanRunView:
+        """立即标记一个尚未结束的扫描为已中断，保留已写入的证据。"""
+
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            if run.status not in TERMINAL_SCAN_RUN_STATUSES:
+                self._mark_interrupted(run)
+            return self._view(run)
+
+    def interrupt_active_scans(self) -> int:
+        """在服务启动时收敛上次异常退出遗留的活动扫描。"""
+
+        with session_scope() as session:
+            active_ids = list(
+                session.scalars(
+                    select(ScanRun.id).where(
+                        ScanRun.status.in_(
+                            [ScanRunStatus.QUEUED.value, ScanRunStatus.RUNNING.value]
+                        )
+                    )
+                )
+            )
+            for scan_run_id in active_ids:
+                self._mark_interrupted(self._get(session, scan_run_id))
+            return len(active_ids)
+
     def get_scan(self, scan_run_id: int) -> ScanRunView:
         with session_scope() as session:
             run = self._get(session, scan_run_id)
@@ -252,6 +278,33 @@ class ScanApplicationService:
         if run is None:
             raise ResourceNotFoundError(f"Scan run {scan_run_id} was not found.")
         return run
+
+    def _mark_interrupted(self, run: ScanRun) -> None:
+        now = datetime.now(timezone.utc)
+        run.status = ScanRunStatus.INTERRUPTED.value
+        run.current_stage = ScanRunStatus.INTERRUPTED.value
+        run.error_code = "scan_cancelled"
+        run.error_message = "Scan was cancelled before completion."
+        run.finished_at = now
+        run.active_key = None
+        for stage in run.stages:
+            if stage.status == "running":
+                stage.status = "interrupted"
+                stage.summary = "Interrupted before this stage completed."
+                stage.finished_at = now
+            elif stage.status == "pending":
+                stage.status = "skipped"
+                stage.summary = "Skipped because the scan was cancelled."
+                stage.finished_at = now
+        if run.mode == AssessmentMode.QUICK.value:
+            for context in run.contexts:
+                if context.kind != ContextKind.ANONYMOUS.value:
+                    continue
+                context.status = ScanRunStatus.INTERRUPTED.value
+                context.collection_status = ScanRunStatus.INTERRUPTED.value
+                context.error_code = "scan_cancelled"
+                context.error_message = "Scan was cancelled before collection completed."
+                context.finished_at = now
 
     def _view(self, run: ScanRun) -> ScanRunView:
         return ScanRunView(**self._view_data(run))

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -48,6 +48,10 @@ class OverallScanTimeout(RuntimeError):
     pass
 
 
+class ScanInterrupted(RuntimeError):
+    """A persisted cancellation signal observed at a safe pipeline boundary."""
+
+
 class ScanPipeline:
     def __init__(
         self,
@@ -241,6 +245,7 @@ class ScanPipeline:
                 deadline,
                 lambda: self._report(session, run),
             )
+            self._check_interrupted(session, run.id)
             session.refresh(run)
             run.status = (
                 ScanRunStatus.COMPLETED_WITH_WARNINGS.value
@@ -253,6 +258,9 @@ class ScanPipeline:
             run.active_key = None
             self._finalize_quick_context(session, run)
             session.commit()
+        except ScanInterrupted:
+            session.rollback()
+            return
         except Exception as error:  # noqa: BLE001 - stage boundary records diagnostics
             session.rollback()
             run = session.get(ScanRun, scan_run_id)
@@ -285,6 +293,7 @@ class ScanPipeline:
             self._try_failure_report(session, run)
 
     def _run_stage(self, session, run, name, deadline, operation):
+        self._check_interrupted(session, run.id)
         self._check_deadline(deadline)
         stage = self._stage(session, run.id, name)
         if stage is None:
@@ -295,6 +304,7 @@ class ScanPipeline:
         run.current_stage = name
         session.commit()
         result, summary = operation()
+        self._check_interrupted(session, run.id)
         self._check_deadline(deadline)
         stage = self._stage(session, run.id, name)
         stage.status = "completed"
@@ -316,7 +326,9 @@ class ScanPipeline:
         return result, summary
 
     def _discover(self, session: Session, run: ScanRun, options: ScanOptions):
+        self._check_interrupted(session, run.id)
         result = self.gateway.fetch(run.normalized_url, options)
+        self._check_interrupted(session, run.id)
         self._persist_fetch(session, run, result, depth=0)
         return result, (
             f"Fetched entry URL with HTTP {result.status_code}; "
@@ -348,6 +360,7 @@ class ScanPipeline:
         collected = 1
         skipped_external = 0
         while queue and collected < options.max_pages:
+            self._check_interrupted(session, run.id)
             self._check_deadline(deadline)
             url, depth = queue.pop(0)
             if url in seen:
@@ -360,6 +373,7 @@ class ScanPipeline:
                 continue
             try:
                 result = self.gateway.fetch(url, options)
+                self._check_interrupted(session, run.id)
             except (FetchError, InputValidationError, TargetPolicyError) as error:
                 code, retryable, attempts, failed_url = self._error_details(error, url)
                 self._record_failure(
@@ -590,6 +604,14 @@ class ScanPipeline:
     def _check_deadline(self, deadline: float) -> None:
         if self.clock() > deadline:
             raise OverallScanTimeout("The overall scan timeout was exceeded.")
+
+    def _check_interrupted(self, session: Session, scan_run_id: int) -> None:
+        status = session.scalar(
+            select(ScanRun.status).where(ScanRun.id == scan_run_id),
+            execution_options={"autoflush": False},
+        )
+        if status == ScanRunStatus.INTERRUPTED.value:
+            raise ScanInterrupted("Scan was cancelled.")
 
     def _origin(self, url: str) -> tuple[str, str, int | None]:
         parsed = urlparse(url)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,40 @@
 - `make`
 - Chromium / Playwright 运行时
 
-## 二、本地开发部署
+## 二、用户级正式 CLI（推荐）
+
+适用于 macOS、Linux 和 WSL，要求 Python 3.10+。在仓库根目录执行：
+
+```bash
+./install.sh
+garden --version
+garden scan http://127.0.0.1:8080/
+```
+
+安装器不使用 `sudo`，也不会修改 shell 配置。运行环境位于 `~/.local/share/garden/runtime/`，命令入口是 `~/.local/bin/garden` 与兼容入口 `~/.local/bin/gardenctl`。若 `~/.local/bin` 不在 PATH，按安装器输出的命令配置后重新打开终端。
+
+用户数据默认位于 `~/.garden`，可通过 `GARDEN_HOME` 覆盖：
+
+```text
+~/.garden/
+├── config.env
+├── garden.db
+├── reports/
+├── storage/
+├── logs/web.log
+└── runtime/server.json
+```
+
+`garden scan URL` 自动启动或复用仅监听 `127.0.0.1` 的 Web UI，终端会输出首页和本次详情地址。默认前台等待并显示进度；`--detach` 仅提交任务并立即返回。不要在同一条命令中同时使用位置 URL 和 `--url`。
+
+```bash
+garden scan http://127.0.0.1:8080/ --detach
+garden stop
+```
+
+`garden stop` 会把全部 queued/running 扫描标记为 `interrupted` 并停止本机 UI，已写入的资产和证据会保留。安装器升级前会自动备份 SQLite 数据库；如果服务仍在运行，先执行 `garden stop`。正式 CLI 只读取 `$GARDEN_HOME/config.env`，不读取当前目录 `.env`，而当前 shell 环境变量优先。
+
+## 三、本地开发部署
 
 ### 1. 克隆仓库
 
@@ -105,18 +138,18 @@ curl -s -X POST http://127.0.0.1:8000/api/scans \
 
 响应中的 `id` 可用于 Web/API 查看进度；不需要执行 inventory、checks 或 report 命令。
 
-## 三、CLI 基础验证
+## 四、CLI 基础验证
 
 激活虚拟环境后执行：
 
 ```bash
-gardenctl --help
-gardenctl version
-gardenctl healthcheck
-gardenctl scan --url http://127.0.0.1:8080/
+garden --help
+garden version
+garden healthcheck
+garden scan http://127.0.0.1:8080/
 ```
 
-## 四、Docker 方式运行
+## 五、Docker 方式运行
 
 ### 1. 构建镜像
 
@@ -155,7 +188,7 @@ docker run --rm -it \
 docker compose up --build
 ```
 
-## 五、旧版登录后高级工作流（可选）
+## 六、旧版登录后高级工作流（可选）
 
 下面这些命令只用于需要登录态、人工 triage 或 retest 的高级流程；它们不是 URL 自动扫描的前置或后置步骤。
 
@@ -203,7 +236,7 @@ gardenctl findings list
 gardenctl evidence list
 ```
 
-## 六、DVWA 联调步骤
+## 七、DVWA 联调步骤
 
 如果你想拿一个真实登录后靶场做演示，可以使用 DVWA。
 

--- a/docs/legacy-cli-migration.md
+++ b/docs/legacy-cli-migration.md
@@ -1,30 +1,27 @@
-# Legacy CLI Migration
+# CLI 迁移说明
 
-## What changed
+## 当前入口
 
-Before this refactor, `gardenctl scan` required a username/password and created a
-target, credential profile, login session, inventory job, checks job, and report
-inside the command handler. The command was the business orchestrator.
+`garden` 是正式的用户级命令入口，`gardenctl` 是同一应用的兼容别名。所有既有命令组保持不变。
 
-`gardenctl scan` now accepts one URL and calls `ScanApplicationService.start_scan`.
-It automatically waits for the persisted six-stage run and prints the final
-report location. Removed scan-specific authentication/selector flags are not
-required for the anonymous asset-report product flow.
+单 URL 被动扫描的推荐写法是：
+
+```bash
+garden scan http://127.0.0.1:8080/
+```
+
+旧写法继续兼容：
 
 ```bash
 gardenctl scan --url http://127.0.0.1:8080/
 ```
 
-Use `--max-pages`, `--max-depth`, `--request-timeout`, `--overall-timeout`, and
-`--retries` to adjust safe bounds. `--retries` means retries after the first
-request and is capped at two.
+位置 URL 与 `--url` 不能同时使用。默认扫描在前台显示阶段和进度；`--detach` 只提交后台任务。CLI 会自动启动或复用本机 Web UI，并输出可访问的详情地址。`Ctrl+C` 会中断本次扫描；`garden stop` 会中断全部活动扫描并停止本机 UI。
 
-## Advanced authenticated workflow
+## 与旧行为的差异
 
-Existing target, credential, login, session, inventory, checks, findings,
-evidence, retest, and legacy job-report commands remain available. Use those
-explicit commands only when authenticated exploration or lifecycle triage is the
-actual task. They do not need to be run before or after `gardenctl scan`.
+`scan` 不再在 CLI 进程内承担业务编排或等待线程池，而是通过本机 Web UI 的 API 创建持久化 `ScanRun` 并读取状态。这使 Web、HTTP API 与 CLI 共享同一个任务、报告和取消状态。已中断扫描保留已写入的资产、证据和失败记录，不生成伪造完整报告。
 
-No old data tables are removed. `ScanJob` remains the advanced workflow step
-record; `ScanRun` is the new URL-to-report parent task.
+## 高级认证工作流
+
+target、credential、login、session、inventory、checks、findings、evidence、retest 和历史 job/report 命令均继续存在。它们用于需要登录态、人工 triage 或 retest 的显式高级流程，不是 `garden scan` 的前置步骤。

--- a/docs/superpowers/plans/2026-08-13-formal-cli-web-ui.md
+++ b/docs/superpowers/plans/2026-08-13-formal-cli-web-ui.md
@@ -1,0 +1,92 @@
+# 正式 CLI 与自动 Web UI 实施计划
+
+> **供智能代理执行：** 必须按任务执行 RED、GREEN、回归验证和中文提交；实现方式为内联执行。
+
+**目标：** 将 Garden 发布为可从任意目录运行的正式 CLI，并让现有 scan 自动管理本地 Web UI 与可取消的扫描生命周期。
+
+**架构：** 新增轻量用户级启动器、路径/运行管理模块和最小取消接口；保留现有 Typer 命令、FastAPI API、ScanApplicationService 和八阶段 pipeline。CLI 通过本地 API 创建扫描，不再在 CLI 进程内同步执行 pipeline。
+
+**技术栈：** Python 3.10+、Typer、FastAPI、Uvicorn、SQLAlchemy、Alembic、pytest、Ruff、POSIX shell。
+
+## 全局约束
+
+- 所有新增文档、日志和提交信息使用中文。
+- 不更改既有命令分组，不增加 `start`、`status`、`logs` 或 `--json`。
+- `gardenctl scan --url URL` 必须兼容；`garden scan URL` 是新主入口。
+- 正式 CLI 用户数据默认在 `~/.garden`，仅由 `GARDEN_HOME` 覆盖。
+- 本任务不进入认证覆盖任务 6，也不重构 ScanApplicationService 或 pipeline 阶段。
+
+---
+
+### 任务 1：路径和正式启动器
+
+**文件：**
+
+- 新建：`app/cli/paths.py`
+- 新建：`install.sh`
+- 修改：`app/core/settings.py`
+- 新建：`tests/test_cli_paths.py`
+- 新建：`tests/test_install_script.py`
+
+- [ ] 写失败测试：正式模式从 `GARDEN_HOME` 解析配置、数据库、报告、日志和运行目录；安装器生成 `garden` 与 `gardenctl` 启动器且不覆盖用户数据。
+- [ ] 运行定向测试，确认当前缺少路径/安装器实现而失败。
+- [ ] 实现最小路径解析、正式启动模式与幂等安装器；首次安装创建数据目录、复制缺失配置、安装 runtime，升级前拒绝运行中的实例并执行备份/迁移。
+- [ ] 重新运行定向测试并提交中文变更。
+
+### 任务 2：本地 Web UI 运行管理
+
+**文件：**
+
+- 新建：`app/cli/web_runtime.py`
+- 修改：`app/cli/main.py`
+- 新建：`tests/test_web_runtime.py`
+
+- [ ] 写失败测试：优先 8000、占用时空闲端口、显式端口冲突、状态复用、过期状态清理和 10 秒就绪失败。
+- [ ] 运行定向测试确认 RED。
+- [ ] 实现 Uvicorn 后台进程管理、状态文件、日志重定向和现有健康接口检查。
+- [ ] 重新运行定向测试并提交中文变更。
+
+### 任务 3：扫描取消与异常状态收敛
+
+**文件：**
+
+- 修改：`app/services/scan_application.py`
+- 修改：`app/services/scan_pipeline.py`
+- 修改：`app/api/routes/scans.py`
+- 修改：`app/main.py`
+- 新建：`tests/test_scan_cancellation.py`
+
+- [ ] 写失败测试：活动扫描可取消、终态取消幂等、取消不生成报告、启动时遗留活动扫描收敛为 interrupted。
+- [ ] 运行定向测试确认 RED。
+- [ ] 在现有服务边界实现 cancel、pipeline 安全检查点、API 取消路由和启动收敛。
+- [ ] 重新运行定向测试并提交中文变更。
+
+### 任务 4：对齐现有 scan 与 garden stop
+
+**文件：**
+
+- 修改：`app/cli/scan.py`
+- 修改：`app/cli/main.py`
+- 新建：`app/cli/stop.py`
+- 修改：`tests/test_quick_scan_cli.py`
+- 新建：`tests/test_formal_scan_cli.py`
+
+- [ ] 写失败测试：位置 URL、旧 `--url`、混用拒绝、`--detach`、API 提交、前台轮询、Ctrl+C 取消/退出码 130 和 stop 取消活动扫描。
+- [ ] 运行定向测试确认 RED。
+- [ ] 以本地 API 适配现有 scan，按规则输出地址和进度，增加最小 stop 命令。
+- [ ] 重新运行定向测试并提交中文变更。
+
+### 任务 5：中文文档、完整验收与交付
+
+**文件：**
+
+- 修改：`README.md`
+- 修改：`docs/deployment.md`
+- 修改：`docs/legacy-cli-migration.md`
+- 修改：`docs/superpowers/specs/2026-08-13-formal-cli-web-ui-design.md`
+- 修改：`docs/superpowers/plans/2026-08-13-formal-cli-web-ui.md`
+
+- [ ] 更新中文安装、扫描、后台模式、停止和迁移说明。
+- [ ] 在临时 HOME 和 GARDEN_HOME 运行真实安装/启动/扫描/停止 smoke。
+- [ ] 运行完整 pytest、Ruff、wheel 资产验证、Docker build 和差异自审。
+- [ ] 推送分支、创建草稿 PR、确认 GitHub Actions 的 Python 3.10、3.12、Docker 与 CLI smoke 成功。

--- a/docs/superpowers/specs/2026-08-13-formal-cli-web-ui-design.md
+++ b/docs/superpowers/specs/2026-08-13-formal-cli-web-ui-design.md
@@ -1,0 +1,67 @@
+# 正式 CLI 与自动 Web UI 设计
+
+## 目标
+
+Garden 安装后应像正常用户级 CLI 一样从任意目录运行，不要求激活 Python 虚拟环境。单条命令 `garden scan URL` 自动确保本机 Web UI 可用、提交扫描并在前台显示进度与可点击本地地址；不会自动打开浏览器。
+
+## 命令兼容
+
+保留所有既有 Typer 命令组和行为。正式入口新增为 `garden`，`gardenctl` 是同一应用的兼容入口。仅扩展现有 `scan` 命令：URL 位置参数为主入口，`--url` 保持兼容；二者同时出现时拒绝执行。
+
+```bash
+garden scan http://127.0.0.1:3000/
+garden scan http://127.0.0.1:3000/ --detach
+gardenctl scan --url http://127.0.0.1:3000/
+garden stop
+```
+
+默认扫描保持前台。`Ctrl+C` 优先取消本次扫描并在本命令启动服务时停止该服务，安全收尾上限为 3 秒，退出码为 130。`--detach` 明确转为后台提交；`garden stop` 取消该实例全部活动扫描并停止 Web UI。
+
+## 用户级安装和目录
+
+`install.sh` 支持 macOS、Linux 和 WSL，要求 Python 3.10+，不使用 `sudo`。它把可替换运行环境安装到 `~/.local/share/garden/runtime/`，把两个轻量启动器放到 `~/.local/bin/garden` 与 `~/.local/bin/gardenctl`。PATH 不包含 `~/.local/bin` 时只打印当前 shell 的精确配置命令，不修改 shell 配置。
+
+默认用户数据根是 `~/.garden`，可由 `GARDEN_HOME` 覆盖：
+
+```text
+$GARDEN_HOME/
+├── config.env
+├── garden.db
+├── reports/
+├── storage/
+├── logs/web.log
+└── runtime/server.json
+```
+
+正式启动器只读取 `$GARDEN_HOME/config.env`，不读取当前目录的 `.env`；当前 shell 环境变量优先。仓库开发模式保持读取项目 `.env`。
+
+## 数据库规则
+
+安装器首次安装和升级时备份 SQLite 数据库后运行现有 `garden db upgrade`。若 Garden 正在运行，安装器拒绝升级并提示先执行 `garden stop`。扫描命令不自动迁移；发现 schema 落后时 fail-closed 并提示 `garden db upgrade`。
+
+## Web UI 运行规则
+
+扫描先复用健康的本地 Garden UI。否则后台运行既有 FastAPI/Uvicorn：优先 `127.0.0.1:8000`，占用时由系统选择空闲端口，竞争最多重试 3 次；`--ui-port` 指定端口被占用时明确失败。启动最多等待 10 秒，日志写入 `$GARDEN_HOME/logs/web.log`，状态文件仅记录 PID、端口、启动时间和数据根。运行管理不添加令牌或新的公开认证接口。
+
+CLI 通过既有 `POST /api/scans` 提交任务，并使用既有状态 API 显示前台进度。输出只展示首页、详情页、进度和报告路径。
+
+## 取消与停止
+
+新增幂等 `POST /api/scans/{id}/cancel`。`queued` 和 `running` 扫描收敛到 `interrupted`，保留已提交资产、失败和阶段记录，不生成伪造的完整报告。pipeline 在阶段和请求边界检查取消状态。应用启动时将异常退出遗留的活动扫描收敛为 `interrupted`。
+
+`garden stop` 通过运行状态文件停止本地实例：先取消全部活动扫描，再停止 Uvicorn 并清理状态文件。状态文件失效时只清理过期记录，不尝试终止不确定的外部进程。
+
+## 非目标
+
+- 不重构既有命令分组、应用服务、八阶段 pipeline 或认证覆盖能力。
+- 不自动打开浏览器、不增加 `--json`、`start`、`status` 或 `logs` 命令。
+- 不增加自动更新、运行时令牌或 Windows 原生安装器。
+- 不让 `scan` 隐式迁移数据库，也不开始认证覆盖任务 6。
+
+## 验收
+
+- 临时 HOME 下安装后，未激活 venv 也能从任意目录执行 `garden --version` 和 `gardenctl --version`。
+- `garden scan URL` 自动启动/复用 UI，输出本地首页和扫描详情，默认前台；`--detach` 立即返回。
+- URL 位置参数和 `--url` 均可用，混用被拒绝。
+- Ctrl+C、取消 API 和 `garden stop` 都使活动扫描进入 `interrupted`，且不影响无关实例。
+- 迁移、现有 quick 兼容入口、完整 pytest、Ruff、Docker build 与 GitHub CI 均通过。

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+用法：./install.sh
+
+在当前用户目录安装 Garden，不需要 sudo：
+  命令入口：~/.local/bin/garden 和 ~/.local/bin/gardenctl
+  运行环境：~/.local/share/garden/runtime
+  用户数据：~/.garden
+
+安装不会修改 shell 配置。若 ~/.local/bin 不在 PATH 中，脚本会输出对应的配置命令。
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -ne 0 ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$(uname -s)" in
+  Darwin | Linux) ;;
+  *)
+    echo "不支持的系统：$(uname -s)。当前仅支持 macOS、Linux 和 WSL。" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64 | aarch64 | x86_64 | amd64) ;;
+  *)
+    echo "不支持的 CPU 架构：$(uname -m)。" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "未找到 python3。请先安装 Python 3.10 或更高版本。" >&2
+  exit 1
+fi
+
+if ! python3 - <<'PY'
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+PY
+then
+  echo "Garden 需要 Python 3.10 或更高版本。" >&2
+  exit 1
+fi
+
+GARDEN_SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+GARDEN_USER_HOME="${HOME:?HOME 未设置，无法执行用户级安装。}"
+GARDEN_HOME="${GARDEN_HOME:-$GARDEN_USER_HOME/.garden}"
+GARDEN_INSTALL_ROOT="${GARDEN_INSTALL_ROOT:-$GARDEN_USER_HOME/.local/share/garden}"
+GARDEN_BIN_DIR="${GARDEN_BIN_DIR:-$GARDEN_USER_HOME/.local/bin}"
+GARDEN_RUNTIME_DIR="$GARDEN_INSTALL_ROOT/runtime"
+GARDEN_RUNTIME_STATE_DIR="$GARDEN_HOME/runtime"
+
+if [ -f "$GARDEN_RUNTIME_STATE_DIR/server.pid" ]; then
+  GARDEN_RUNNING_PID="$(tr -d '[:space:]' < "$GARDEN_RUNTIME_STATE_DIR/server.pid")"
+  if [ -n "$GARDEN_RUNNING_PID" ] && kill -0 "$GARDEN_RUNNING_PID" 2>/dev/null; then
+    cat >&2 <<EOF
+Garden 当前正在运行，无法安全升级。
+
+请先执行：
+garden stop
+
+然后重新执行：
+./install.sh
+EOF
+    exit 1
+  fi
+fi
+
+mkdir -p "$GARDEN_HOME" "$GARDEN_HOME/reports" "$GARDEN_HOME/storage" \
+  "$GARDEN_HOME/logs" "$GARDEN_RUNTIME_STATE_DIR" "$GARDEN_INSTALL_ROOT" "$GARDEN_BIN_DIR"
+
+if [ ! -f "$GARDEN_HOME/config.env" ]; then
+  grep -v '^GARDEN_DATABASE_URL=' "$GARDEN_SOURCE_ROOT/.env.example" \
+    > "$GARDEN_HOME/config.env"
+fi
+
+if [ -f "$GARDEN_HOME/garden.db" ]; then
+  GARDEN_BACKUP_DIR="$GARDEN_HOME/backups"
+  mkdir -p "$GARDEN_BACKUP_DIR"
+  GARDEN_BACKUP_FILE="$GARDEN_BACKUP_DIR/garden-$(date +%Y%m%d%H%M%S).db"
+  cp -p "$GARDEN_HOME/garden.db" "$GARDEN_BACKUP_FILE"
+  echo "已备份数据库：$GARDEN_BACKUP_FILE"
+fi
+
+GARDEN_STAGE_DIR="$(mktemp -d "$GARDEN_INSTALL_ROOT/.runtime.XXXXXX")"
+GARDEN_OLD_RUNTIME_DIR="$GARDEN_INSTALL_ROOT/.runtime.previous.$$"
+cleanup_stage() {
+  if [ -d "$GARDEN_STAGE_DIR" ]; then
+    rm -rf "$GARDEN_STAGE_DIR"
+  fi
+}
+trap cleanup_stage EXIT
+
+python3 -m venv "$GARDEN_STAGE_DIR/venv"
+"$GARDEN_STAGE_DIR/venv/bin/python" -m pip install --upgrade pip
+"$GARDEN_STAGE_DIR/venv/bin/python" -m pip install "$GARDEN_SOURCE_ROOT"
+
+GARDEN_CLI_RUNTIME=1 GARDEN_HOME="$GARDEN_HOME" \
+  "$GARDEN_STAGE_DIR/venv/bin/gardenctl" db upgrade
+
+if [ -d "$GARDEN_RUNTIME_DIR" ]; then
+  mv "$GARDEN_RUNTIME_DIR" "$GARDEN_OLD_RUNTIME_DIR"
+fi
+mv "$GARDEN_STAGE_DIR" "$GARDEN_RUNTIME_DIR"
+if [ -d "$GARDEN_OLD_RUNTIME_DIR" ]; then
+  rm -rf "$GARDEN_OLD_RUNTIME_DIR"
+fi
+
+write_launcher() {
+  local launcher_path="$1"
+  cat > "$launcher_path" <<EOF
+#!/usr/bin/env sh
+set -eu
+export GARDEN_CLI_RUNTIME=1
+export GARDEN_HOME="\${GARDEN_HOME:-$GARDEN_HOME}"
+exec "$GARDEN_RUNTIME_DIR/venv/bin/gardenctl" "\$@"
+EOF
+  chmod 0755 "$launcher_path"
+}
+
+write_launcher "$GARDEN_BIN_DIR/garden"
+write_launcher "$GARDEN_BIN_DIR/gardenctl"
+
+echo "Garden 已安装。"
+echo "命令入口：$GARDEN_BIN_DIR/garden"
+
+case ":${PATH}:" in
+  *":${GARDEN_BIN_DIR}:"*)
+    echo "验证安装：garden --version"
+    ;;
+  *)
+    GARDEN_SHELL_NAME="$(basename "${SHELL:-sh}")"
+    case "$GARDEN_SHELL_NAME" in
+      zsh) GARDEN_SHELL_CONFIG="~/.zprofile" ;;
+      bash) GARDEN_SHELL_CONFIG="~/.bash_profile" ;;
+      *) GARDEN_SHELL_CONFIG="当前 shell 的启动配置文件" ;;
+    esac
+    cat <<EOF
+请将 ~/.local/bin 加入 PATH 后重新打开终端：
+export PATH="\$HOME/.local/bin:\$PATH"
+
+可写入：$GARDEN_SHELL_CONFIG
+验证安装：garden --version
+EOF
+    ;;
+esac

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,0 +1,46 @@
+from app.core.settings import clear_settings_cache, get_settings
+
+
+def test_formal_runtime_paths_use_garden_home(monkeypatch, tmp_path):
+    from app.cli.paths import GardenPaths
+
+    home = tmp_path / "garden-home"
+    monkeypatch.setenv("GARDEN_HOME", str(home))
+
+    paths = GardenPaths.from_environment()
+
+    assert paths.home == home
+    assert paths.config_file == home / "config.env"
+    assert paths.database_file == home / "garden.db"
+    assert paths.reports_dir == home / "reports"
+    assert paths.logs_dir == home / "logs"
+    assert paths.runtime_dir == home / "runtime"
+
+
+def test_formal_runtime_reads_home_config_not_working_directory_dotenv(monkeypatch, tmp_path):
+    home = tmp_path / "garden-home"
+    home.mkdir()
+    (home / "config.env").write_text("GARDEN_API_PORT=8123\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("GARDEN_API_PORT=9999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GARDEN_HOME", str(home))
+    monkeypatch.setenv("GARDEN_CLI_RUNTIME", "1")
+    monkeypatch.delenv("GARDEN_DATABASE_URL", raising=False)
+    clear_settings_cache()
+
+    settings = get_settings()
+
+    assert settings.api_port == 8123
+    assert settings.database_url == f"sqlite+pysqlite:///{home / 'garden.db'}"
+    clear_settings_cache()
+
+
+def test_development_mode_keeps_current_directory_dotenv(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("GARDEN_API_PORT=9999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GARDEN_HOME", raising=False)
+    monkeypatch.delenv("GARDEN_CLI_RUNTIME", raising=False)
+    clear_settings_cache()
+
+    assert get_settings().api_port == 9999
+    clear_settings_cache()

--- a/tests/test_formal_scan_cli.py
+++ b/tests/test_formal_scan_cli.py
@@ -1,0 +1,147 @@
+"""正式 scan 命令的兼容参数、前台/后台和中断语义。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+import app.cli.scan as scan_cli
+import app.cli.stop as stop_cli
+from app.cli.main import app
+from app.schemas.scan import ScanRunView
+
+runner = CliRunner()
+
+
+def _view(*, status="queued", stage="queued", progress=0):
+    return ScanRunView(
+        id=7,
+        input_url="http://127.0.0.1:3000/",
+        normalized_url="http://127.0.0.1:3000/",
+        status=status,
+        current_stage=stage,
+        progress=progress,
+        retry_count=0,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_position_url_is_foreground_and_detach_returns_immediately(monkeypatch):
+    calls = []
+
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class Manager:
+        started_by_this_command = False
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            calls.append(("ensure", ui_port))
+            return Runtime()
+
+    class Api:
+        def __init__(self, base_url):
+            assert base_url == Runtime.base_url
+
+        def start_scan(self, url, options):
+            calls.append(("start", url, options.max_pages))
+            return _view()
+
+        def get_scan(self, scan_run_id):
+            calls.append(("get", scan_run_id))
+            return _view(status="completed", stage="finished", progress=100)
+
+    monkeypatch.setattr(scan_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(scan_cli, "LocalScanApi", Api)
+    foreground = runner.invoke(app, ["scan", "http://127.0.0.1:3000/", "--max-pages", "3"])
+    detached = runner.invoke(app, ["scan", "http://127.0.0.1:3000/", "--detach"])
+
+    assert foreground.exit_code == 0
+    assert "扫描详情：http://127.0.0.1:8000/scans/7" in foreground.stdout
+    assert ("get", 7) in calls
+    assert detached.exit_code == 0
+    assert "已后台提交" in detached.stdout
+    assert calls.count(("get", 7)) == 1
+
+
+def test_position_url_and_legacy_url_cannot_be_mixed():
+    result = runner.invoke(
+        app,
+        ["scan", "http://127.0.0.1:3000/", "--url", "http://127.0.0.1:3001/"],
+    )
+
+    assert result.exit_code == 1
+    assert "不能同时提供" in result.stdout
+
+
+def test_ctrl_c_cancels_scan_stops_only_owned_ui_and_exits_130(monkeypatch):
+    calls = []
+
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class Manager:
+        started_by_this_command = True
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            return Runtime()
+
+        def stop(self):
+            calls.append("stop")
+            return True
+
+    class Api:
+        def __init__(self, base_url):
+            pass
+
+        def start_scan(self, url, options):
+            return _view()
+
+        def get_scan(self, scan_run_id):
+            raise KeyboardInterrupt
+
+        def cancel_scan(self, scan_run_id):
+            calls.append(("cancel", scan_run_id))
+            return _view(status="interrupted", stage="interrupted")
+
+    monkeypatch.setattr(scan_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(scan_cli, "LocalScanApi", Api)
+    result = runner.invoke(app, ["scan", "http://127.0.0.1:3000/"])
+
+    assert result.exit_code == 130
+    assert calls == [("cancel", 7), "stop"]
+
+
+def test_stop_interrupts_active_scans_and_stops_ui(monkeypatch):
+    calls = []
+
+    class Service:
+        def __init__(self, **kwargs):
+            pass
+
+        def interrupt_active_scans(self):
+            calls.append("interrupt")
+            return 2
+
+    class Manager:
+        def __init__(self, **kwargs):
+            pass
+
+        def stop(self):
+            calls.append("stop")
+            return True
+
+    monkeypatch.setattr(stop_cli, "ScanApplicationService", Service)
+    monkeypatch.setattr(stop_cli, "WebRuntimeManager", Manager)
+    result = runner.invoke(app, ["stop"])
+
+    assert result.exit_code == 0
+    assert calls == ["interrupt", "stop"]
+    assert "已中断 2 个活动扫描" in result.stdout

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,30 @@
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_install_script_explains_user_level_installation():
+    script = PROJECT_ROOT / "install.sh"
+
+    result = subprocess.run(
+        ["bash", str(script), "--help"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "~/.local/bin/garden" in result.stdout
+    assert "~/.local/share/garden/runtime" in result.stdout
+    assert "sudo" in result.stdout
+
+
+def test_install_script_uses_launchers_without_mutating_shell_configuration():
+    script = (PROJECT_ROOT / "install.sh").read_text(encoding="utf-8")
+
+    assert "GARDEN_CLI_RUNTIME=1" in script
+    assert "gardenctl" in script
+    assert ">>" not in script
+    assert 'source "$GARDEN_SHELL_CONFIG"' not in script

--- a/tests/test_quick_scan_cli.py
+++ b/tests/test_quick_scan_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 import app.cli.scan as scan_cli
 from app.cli.main import app
-from app.schemas.scan import ScanRunView
+from app.schemas.scan import ScanOptions, ScanRunView
 from app.services.login_configs import LoginConfigService, encode_inline_login_config
 
 runner = CliRunner()
@@ -25,12 +25,25 @@ def test_inline_playwright_config_round_trip_for_legacy_commands() -> None:
     assert config.auto_detect_selectors is True
 
 
-def test_scan_command_is_thin_adapter_over_core_service(monkeypatch) -> None:
+def test_legacy_scan_url_option_submits_through_local_web_ui(monkeypatch) -> None:
     calls = []
 
-    class FakeScanService:
-        def __init__(self, *, dispatcher):
-            assert dispatcher.__class__.__name__ == "InlineScanDispatcher"
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class FakeRuntimeManager:
+        started_by_this_command = False
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            assert ui_port is None
+            return Runtime()
+
+    class FakeLocalScanApi:
+        def __init__(self, base_url):
+            assert base_url == Runtime.base_url
 
         def start_scan(self, url, options):
             calls.append((url, options.max_pages, options.max_depth, options.retry_attempts))
@@ -49,7 +62,12 @@ def test_scan_command_is_thin_adapter_over_core_service(monkeypatch) -> None:
                 finding_count=1,
             )
 
-    monkeypatch.setattr(scan_cli, "ScanApplicationService", FakeScanService)
+        def get_scan(self, scan_run_id):
+            assert scan_run_id == 41
+            return self.start_scan("http://127.0.0.1:8888/", ScanOptions())
+
+    monkeypatch.setattr(scan_cli, "WebRuntimeManager", FakeRuntimeManager)
+    monkeypatch.setattr(scan_cli, "LocalScanApi", FakeLocalScanApi)
     result = runner.invoke(
         app,
         [
@@ -67,5 +85,6 @@ def test_scan_command_is_thin_adapter_over_core_service(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert calls == [("http://127.0.0.1:8888/", 3, 1, 0)]
-    assert "Automatic URL Scan Result" in result.stdout
+    assert "Web UI：http://127.0.0.1:8000" in result.stdout
+    assert "Garden 扫描结果" in result.stdout
     assert "exports/scan-reports/scan-41.md" in result.stdout

--- a/tests/test_scan_cancellation.py
+++ b/tests/test_scan_cancellation.py
@@ -1,0 +1,101 @@
+"""扫描取消与服务重启后的中断收敛。"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.errors import ResourceNotFoundError
+from app.db.bootstrap import get_session
+from app.main import create_app
+from app.models.scan_run import ScanRun
+from app.schemas.scan import ScanOptions
+from tests.test_assessment_application import build_holding_service
+
+
+def test_cancel_queued_scan_is_idempotent_and_releases_duplicate_key(tmp_path) -> None:
+    service, dispatcher = build_holding_service(tmp_path)
+    queued = service.start_scan("http://127.0.0.1:8080/", ScanOptions())
+
+    cancelled = service.cancel_scan(queued.id)
+    repeated = service.cancel_scan(queued.id)
+    replacement = service.start_scan("http://127.0.0.1:8080/", ScanOptions())
+
+    assert dispatcher.ids == [queued.id, replacement.id]
+    assert cancelled.status == "interrupted"
+    assert cancelled.current_stage == "interrupted"
+    assert cancelled.error_code == "scan_cancelled"
+    assert cancelled.report_path is None
+    assert repeated.status == cancelled.status
+    assert repeated.finished_at.replace(tzinfo=None) == cancelled.finished_at.replace(tzinfo=None)
+    assert repeated.error_code == cancelled.error_code
+    assert replacement.id != queued.id
+    assert {stage.status for stage in cancelled.stages if stage.name == "report"} == {"skipped"}
+
+
+def test_cancel_missing_scan_raises_not_found(tmp_path) -> None:
+    service, _ = build_holding_service(tmp_path)
+
+    try:
+        service.cancel_scan(404)
+    except ResourceNotFoundError:
+        pass
+    else:
+        raise AssertionError("Expected a missing scan to return a not-found error.")
+
+
+def test_cancelled_pipeline_does_not_create_a_failure_report(tmp_path) -> None:
+    service, _ = build_holding_service(tmp_path)
+    def cancel_during_validation(run):
+        service.cancel_scan(run.id)
+        return None, "Cancelled while validating."
+
+    service.pipeline._validate = cancel_during_validation
+    queued = service.start_scan("http://127.0.0.1:8080/", ScanOptions())
+
+    service.execute_scan(queued.id)
+    final = service.get_scan(queued.id)
+
+    assert final.status == "interrupted"
+    assert final.report_path is None
+    assert final.finding_count == 0
+    assert not final.failures
+    assert next(stage for stage in final.stages if stage.name == "validate").status == "interrupted"
+
+
+def test_application_startup_interrupts_stale_active_scans() -> None:
+    with get_session() as session:
+        session.add(
+            ScanRun(
+                input_url="http://127.0.0.1:8080/",
+                normalized_url="http://127.0.0.1:8080/",
+                status="running",
+                current_stage="collect",
+                active_key="stale-active-run",
+                options={},
+            )
+        )
+        session.commit()
+
+    with TestClient(create_app()) as client:
+        assert client.get("/healthz").status_code == 200
+
+    with get_session() as session:
+        run = session.query(ScanRun).one()
+        assert run.status == "interrupted"
+        assert run.current_stage == "interrupted"
+        assert run.active_key is None
+
+
+def test_cancel_api_is_idempotent(app, monkeypatch, tmp_path) -> None:
+    service, _ = build_holding_service(tmp_path)
+    monkeypatch.setattr("app.main.ScanApplicationService", lambda settings: service)
+    with TestClient(app) as client:
+        queued = service.start_scan("http://127.0.0.1:8080/", ScanOptions())
+        first = client.post(f"/api/scans/{queued.id}/cancel")
+        second = client.post(f"/api/scans/{queued.id}/cancel")
+        missing = client.post("/api/scans/404/cancel")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["status"] == second.json()["status"] == "interrupted"
+    assert missing.status_code == 404

--- a/tests/test_scan_cancellation.py
+++ b/tests/test_scan_cancellation.py
@@ -45,6 +45,7 @@ def test_cancel_missing_scan_raises_not_found(tmp_path) -> None:
 
 def test_cancelled_pipeline_does_not_create_a_failure_report(tmp_path) -> None:
     service, _ = build_holding_service(tmp_path)
+
     def cancel_during_validation(run):
         service.cancel_scan(run.id)
         return None, "Cancelled while validating."

--- a/tests/test_web_runtime.py
+++ b/tests/test_web_runtime.py
@@ -31,6 +31,7 @@ def test_ensure_prefers_default_port_and_records_started_server(monkeypatch, tmp
     assert state["port"] == 8000
     assert state["home"] == str(paths.home)
     assert state["started_at"]
+    assert paths.server_pid_file.read_text(encoding="utf-8") == "4210\n"
 
 
 def test_ensure_uses_system_free_port_when_default_is_occupied(monkeypatch, tmp_path):
@@ -110,3 +111,31 @@ def test_ensure_removes_stale_state_before_starting(monkeypatch, tmp_path):
 
     assert runtime.port == 8000
     assert json.loads(paths.server_state_file.read_text(encoding="utf-8"))["pid"] == 4213
+
+
+def test_stop_only_terminates_a_healthy_recorded_server(monkeypatch, tmp_path):
+    from app.cli.web_runtime import WebRuntimeManager
+
+    paths = GardenPaths(tmp_path / "garden-home")
+    paths.ensure_directories()
+    paths.server_state_file.write_text(
+        json.dumps(
+            {
+                "pid": 4214,
+                "port": 8000,
+                "home": str(paths.home),
+                "started_at": "2026-08-13T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = WebRuntimeManager(paths=paths)
+    killed = []
+    alive = iter([True, False])
+    monkeypatch.setattr(manager, "_is_healthy", lambda runtime: True)
+    monkeypatch.setattr(manager, "_is_process_alive", lambda pid: next(alive))
+    monkeypatch.setattr("app.cli.web_runtime.os.killpg", lambda pid, signal: killed.append(pid))
+
+    assert manager.stop() is True
+    assert killed == [4214]
+    assert not paths.server_state_file.exists()

--- a/tests/test_web_runtime.py
+++ b/tests/test_web_runtime.py
@@ -1,0 +1,112 @@
+import json
+
+import pytest
+
+from app.cli.paths import GardenPaths
+
+
+def test_ensure_prefers_default_port_and_records_started_server(monkeypatch, tmp_path):
+    from app.cli.web_runtime import WebRuntimeManager
+
+    started = []
+
+    class Process:
+        pid = 4210
+
+        def poll(self):
+            return None
+
+    paths = GardenPaths(tmp_path / "garden-home")
+    manager = WebRuntimeManager(paths=paths, default_port=8000)
+    monkeypatch.setattr(manager, "_is_port_available", lambda port: port == 8000)
+    monkeypatch.setattr(manager, "_start_process", lambda port: started.append(port) or Process())
+    monkeypatch.setattr(manager, "_wait_for_health", lambda port: True)
+
+    runtime = manager.ensure()
+
+    assert runtime.base_url == "http://127.0.0.1:8000"
+    assert started == [8000]
+    state = json.loads(paths.server_state_file.read_text(encoding="utf-8"))
+    assert state["pid"] == 4210
+    assert state["port"] == 8000
+    assert state["home"] == str(paths.home)
+    assert state["started_at"]
+
+
+def test_ensure_uses_system_free_port_when_default_is_occupied(monkeypatch, tmp_path):
+    from app.cli.web_runtime import WebRuntimeManager
+
+    class Process:
+        pid = 4211
+
+        def poll(self):
+            return None
+
+    paths = GardenPaths(tmp_path / "garden-home")
+    manager = WebRuntimeManager(paths=paths, default_port=8000)
+    monkeypatch.setattr(manager, "_is_port_available", lambda port: False)
+    monkeypatch.setattr(manager, "_reserve_free_port", lambda: 51843)
+    monkeypatch.setattr(manager, "_start_process", lambda port: Process())
+    monkeypatch.setattr(manager, "_wait_for_health", lambda port: True)
+
+    runtime = manager.ensure()
+
+    assert runtime.port == 51843
+
+
+def test_ensure_reuses_healthy_server_and_rejects_different_explicit_port(monkeypatch, tmp_path):
+    from app.cli.web_runtime import WebRuntimeError, WebRuntimeManager
+
+    paths = GardenPaths(tmp_path / "garden-home")
+    paths.ensure_directories()
+    paths.server_state_file.write_text(
+        json.dumps(
+            {
+                "pid": 4212,
+                "port": 8123,
+                "home": str(paths.home),
+                "started_at": "2026-08-13T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = WebRuntimeManager(paths=paths, default_port=8000)
+    monkeypatch.setattr(manager, "_is_healthy", lambda runtime: True)
+
+    assert manager.ensure().port == 8123
+    with pytest.raises(WebRuntimeError, match="8123"):
+        manager.ensure(ui_port=9000)
+
+
+def test_ensure_removes_stale_state_before_starting(monkeypatch, tmp_path):
+    from app.cli.web_runtime import WebRuntimeManager
+
+    class Process:
+        pid = 4213
+
+        def poll(self):
+            return None
+
+    paths = GardenPaths(tmp_path / "garden-home")
+    paths.ensure_directories()
+    paths.server_state_file.write_text(
+        json.dumps(
+            {
+                "pid": 4212,
+                "port": 8123,
+                "home": str(paths.home),
+                "started_at": "2026-08-13T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = WebRuntimeManager(paths=paths, default_port=8000)
+    monkeypatch.setattr(manager, "_is_healthy", lambda runtime: False)
+    monkeypatch.setattr(manager, "_is_port_available", lambda port: port == 8000)
+    monkeypatch.setattr(manager, "_start_process", lambda port: Process())
+    monkeypatch.setattr(manager, "_wait_for_health", lambda port: True)
+
+    runtime = manager.ensure()
+
+    assert runtime.port == 8000
+    assert json.loads(paths.server_state_file.read_text(encoding="utf-8"))["pid"] == 4213


### PR DESCRIPTION
## 概要

- 新增 `garden` 正式入口，保留 `gardenctl` 兼容入口与既有命令组
- `garden scan URL` 自动启动或复用本机 Web UI，支持前台进度、`--detach`、Ctrl+C 取消
- 新增 `garden stop`、幂等取消 API、启动时遗留活动扫描收敛
- 增加用户级安装器、`GARDEN_HOME` 目录约定和中文文档

## 验证

- `pytest -q`
- `ruff check .`
- `ruff format --check .`
- 临时 `GARDEN_HOME` 下：`db upgrade`、`scan --detach`、`stop`
