### PR TITLE
修复正式 CLI 安装与可移动运行时

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -1,5 +1,8 @@
 """Typer CLI entrypoint for Garden."""
 
+import os
+from typing import Annotated
+
 import typer
 
 from app.cli.baseline import app as baseline_app
@@ -30,12 +33,24 @@ app = typer.Typer(
         "verification workflows."
     ),
     no_args_is_help=True,
+    invoke_without_command=True,
 )
 
 
 @app.callback()
-def main() -> None:
+def main(
+    context: typer.Context,
+    show_version: Annotated[
+        bool,
+        typer.Option("--version", help="Show the current Garden version.", is_eager=True),
+    ] = False,
+) -> None:
     settings = get_settings()
+    if show_version:
+        console.print(f"[bold]{settings.project_name}[/bold] {settings.project_version}")
+        raise typer.Exit
+    if context.invoked_subcommand == "version":
+        return
     configure_logging(settings.log_level)
     init_database(settings.database_url)
 
@@ -72,4 +87,4 @@ app.add_typer(database_app, name="db")
 
 
 if __name__ == "__main__":
-    app()
+    app(prog_name=os.environ.get("GARDEN_CLI_NAME", "garden"))

--- a/app/cli/paths.py
+++ b/app/cli/paths.py
@@ -68,3 +68,11 @@ class GardenPaths:
             self.runtime_dir,
         ):
             directory.mkdir(parents=True, exist_ok=True)
+
+
+def formal_runtime_paths() -> GardenPaths | None:
+    """正式 CLI 运行时返回用户目录约定；仓库开发模式保持原路径。"""
+
+    if os.environ.get("GARDEN_CLI_RUNTIME") != "1":
+        return None
+    return GardenPaths.from_environment()

--- a/app/services/evidence_storage.py
+++ b/app/services/evidence_storage.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from app.cli.paths import formal_runtime_paths
 from app.core.errors import InputValidationError
 
 
@@ -13,7 +14,12 @@ class EvidenceStorageService:
     """Store structured evidence payloads separately from screenshot assets."""
 
     def __init__(self, base_directory: Path | None = None) -> None:
-        self.base_directory = base_directory or (Path.cwd() / "data" / "evidence")
+        formal_paths = formal_runtime_paths()
+        self.base_directory = base_directory or (
+            formal_paths.storage_dir / "evidence"
+            if formal_paths is not None
+            else Path.cwd() / "data" / "evidence"
+        )
         self.base_directory.mkdir(parents=True, exist_ok=True)
         self.screenshot_directory = self.base_directory / "screenshots"
         self.screenshot_directory.mkdir(parents=True, exist_ok=True)

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
+from app.cli.paths import formal_runtime_paths
 from app.core.errors import ResourceNotFoundError
 from app.models.scan_run import ScanRun
 
@@ -19,7 +20,12 @@ class ScanReportService:
     _control_character_pattern = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
     def __init__(self, output_root: Path | None = None) -> None:
-        self.output_root = output_root or (Path.cwd() / "exports" / "scan-reports")
+        formal_paths = formal_runtime_paths()
+        self.output_root = output_root or (
+            formal_paths.reports_dir
+            if formal_paths is not None
+            else Path.cwd() / "exports" / "scan-reports"
+        )
 
     def generate(self, session: Session, scan_run_id: int) -> str:
         run = session.scalar(

--- a/app/services/session_storage.py
+++ b/app/services/session_storage.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from app.cli.paths import formal_runtime_paths
 from app.core.errors import InputValidationError
 
 
@@ -15,7 +16,12 @@ class SessionStorageService:
     """Store raw session material outside the main database record."""
 
     def __init__(self, base_directory: Path | None = None) -> None:
-        self.base_directory = base_directory or (Path.cwd() / "data" / "session_payloads")
+        formal_paths = formal_runtime_paths()
+        self.base_directory = base_directory or (
+            formal_paths.storage_dir / "session_payloads"
+            if formal_paths is not None
+            else Path.cwd() / "data" / "session_payloads"
+        )
         self.base_directory.mkdir(parents=True, exist_ok=True)
 
     def write_payload(self, session_id: int, payload: dict[str, Any]) -> str:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,8 @@ garden scan http://127.0.0.1:8080/
 
 安装器不使用 `sudo`，也不会修改 shell 配置。运行环境位于 `~/.local/share/garden/runtime/`，命令入口是 `~/.local/bin/garden` 与兼容入口 `~/.local/bin/gardenctl`。若 `~/.local/bin` 不在 PATH，按安装器输出的命令配置后重新打开终端。
 
+若当前 shell 设置了 SOCKS `ALL_PROXY`，安装器会在创建隔离运行环境时临时忽略该变量，并增加依赖下载重试；不会修改当前 shell 或其他项目的代理配置。
+
 用户数据默认位于 `~/.garden`，可通过 `GARDEN_HOME` 覆盖：
 
 ```text

--- a/install.sh
+++ b/install.sh
@@ -104,11 +104,25 @@ cleanup_stage() {
 trap cleanup_stage EXIT
 
 python3 -m venv "$GARDEN_STAGE_DIR/venv"
-"$GARDEN_STAGE_DIR/venv/bin/python" -m pip install --upgrade pip
-"$GARDEN_STAGE_DIR/venv/bin/python" -m pip install "$GARDEN_SOURCE_ROOT"
+GARDEN_STAGE_PYTHON="$GARDEN_STAGE_DIR/venv/bin/python"
+export PIP_RETRIES="${PIP_RETRIES:-10}"
+export PIP_TIMEOUT="${PIP_TIMEOUT:-30}"
+run_install_pip() {
+  case "${ALL_PROXY:-${all_proxy:-}}" in
+    socks* | SOCKS*)
+      echo "检测到 SOCKS ALL_PROXY；安装依赖时临时忽略该变量。"
+      env -u ALL_PROXY -u all_proxy "$GARDEN_STAGE_PYTHON" -m pip "$@"
+      ;;
+    *)
+      "$GARDEN_STAGE_PYTHON" -m pip "$@"
+      ;;
+  esac
+}
+run_install_pip install --upgrade pip
+run_install_pip install "$GARDEN_SOURCE_ROOT"
 
 GARDEN_CLI_RUNTIME=1 GARDEN_HOME="$GARDEN_HOME" \
-  "$GARDEN_STAGE_DIR/venv/bin/gardenctl" db upgrade
+  "$GARDEN_STAGE_PYTHON" -m app.cli.main db upgrade
 
 if [ -d "$GARDEN_RUNTIME_DIR" ]; then
   mv "$GARDEN_RUNTIME_DIR" "$GARDEN_OLD_RUNTIME_DIR"
@@ -120,18 +134,20 @@ fi
 
 write_launcher() {
   local launcher_path="$1"
+  local command_name="$2"
   cat > "$launcher_path" <<EOF
 #!/usr/bin/env sh
 set -eu
 export GARDEN_CLI_RUNTIME=1
+export GARDEN_CLI_NAME="$command_name"
 export GARDEN_HOME="\${GARDEN_HOME:-$GARDEN_HOME}"
-exec "$GARDEN_RUNTIME_DIR/venv/bin/gardenctl" "\$@"
+exec "$GARDEN_RUNTIME_DIR/venv/bin/python" -m app.cli.main "\$@"
 EOF
   chmod 0755 "$launcher_path"
 }
 
-write_launcher "$GARDEN_BIN_DIR/garden"
-write_launcher "$GARDEN_BIN_DIR/gardenctl"
+write_launcher "$GARDEN_BIN_DIR/garden" "garden"
+write_launcher "$GARDEN_BIN_DIR/gardenctl" "gardenctl"
 
 echo "Garden 已安装。"
 echo "命令入口：$GARDEN_BIN_DIR/garden"

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,6 +1,20 @@
 from app.core.settings import clear_settings_cache, get_settings
 
 
+def test_formal_runtime_services_keep_outputs_inside_garden_home(monkeypatch, tmp_path):
+    from app.services.evidence_storage import EvidenceStorageService
+    from app.services.scan_reporting import ScanReportService
+    from app.services.session_storage import SessionStorageService
+
+    home = tmp_path / "garden-home"
+    monkeypatch.setenv("GARDEN_HOME", str(home))
+    monkeypatch.setenv("GARDEN_CLI_RUNTIME", "1")
+
+    assert ScanReportService().output_root == home / "reports"
+    assert SessionStorageService().base_directory == home / "storage" / "session_payloads"
+    assert EvidenceStorageService().base_directory == home / "storage" / "evidence"
+
+
 def test_formal_runtime_paths_use_garden_home(monkeypatch, tmp_path):
     from app.cli.paths import GardenPaths
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -25,6 +25,119 @@ def test_install_script_uses_launchers_without_mutating_shell_configuration():
     script = (PROJECT_ROOT / "install.sh").read_text(encoding="utf-8")
 
     assert "GARDEN_CLI_RUNTIME=1" in script
+    assert "GARDEN_CLI_NAME" in script
     assert "gardenctl" in script
     assert ">>" not in script
     assert 'source "$GARDEN_SHELL_CONFIG"' not in script
+
+
+def _fake_installer_environment(tmp_path):
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        """#!/bin/sh
+set -eu
+if [ "${1:-}" = "-" ]; then
+  exit 0
+fi
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "venv" ]; then
+  target="$3"
+  mkdir -p "$target/bin"
+  cp "$0" "$target/bin/python"
+  chmod 0755 "$target/bin/python"
+  printf '#!%s/bin/python\\n' "$target" > "$target/bin/gardenctl"
+  chmod 0755 "$target/bin/gardenctl"
+  exit 0
+fi
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "pip" ]; then
+  proxy_is_set=0
+  if [ -n "${ALL_PROXY+x}" ] || [ -n "${all_proxy+x}" ]; then
+    proxy_is_set=1
+  fi
+  if [ "${REJECT_SOCKS_PROXY:-0}" = "1" ] && [ "$proxy_is_set" = "1" ]; then
+    echo "SOCKS proxy leaked into isolated pip" >&2
+    exit 42
+  fi
+  exit 0
+fi
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "app.cli.main" ]; then
+  if [ "${3:-}" = "version" ] || [ "${3:-}" = "--version" ]; then
+    echo "Garden 0.1.0"
+  fi
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    install_root = tmp_path / "install"
+    bin_dir = tmp_path / "bin"
+    environment = {
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "GARDEN_HOME": str(tmp_path / "garden-home"),
+        "GARDEN_INSTALL_ROOT": str(install_root),
+        "GARDEN_BIN_DIR": str(bin_dir),
+    }
+    return environment, bin_dir
+
+
+def test_install_ignores_socks_all_proxy_for_isolated_pip(tmp_path):
+    environment, _ = _fake_installer_environment(tmp_path)
+    environment.update(
+        {
+            "ALL_PROXY": "socks5://127.0.0.1:1080",
+            "all_proxy": "socks5://127.0.0.1:1080",
+            "REJECT_SOCKS_PROXY": "1",
+        }
+    )
+
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert installed.returncode == 0, installed.stderr
+
+
+def test_installed_launchers_survive_runtime_move(tmp_path):
+    environment, bin_dir = _fake_installer_environment(tmp_path)
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert installed.returncode == 0, installed.stderr
+
+    garden = subprocess.run(
+        [str(bin_dir / "garden"), "version"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    gardenctl = subprocess.run(
+        [str(bin_dir / "gardenctl"), "--version"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert garden.returncode == 0, garden.stderr
+    assert garden.stdout.strip() == "Garden 0.1.0"
+    assert gardenctl.returncode == 0, gardenctl.stderr
+    assert gardenctl.stdout.strip() == "Garden 0.1.0"

--- a/tests/test_quick_scan_cli.py
+++ b/tests/test_quick_scan_cli.py
@@ -10,6 +10,15 @@ from app.services.login_configs import LoginConfigService, encode_inline_login_c
 runner = CliRunner()
 
 
+def test_global_version_option_matches_version_command() -> None:
+    option = runner.invoke(app, ["--version"])
+    command = runner.invoke(app, ["version"])
+
+    assert option.exit_code == 0
+    assert option.stdout == command.stdout
+    assert "Database initialized" not in command.stderr
+
+
 def test_inline_playwright_config_round_trip_for_legacy_commands() -> None:
     encoded = encode_inline_login_config(
         {


### PR DESCRIPTION
## 根因

- 安装器在临时目录创建 venv 后整体移动，console script 的绝对 shebang 仍指向已删除路径
- 新 venv 在 SOCKS `ALL_PROXY` 环境缺少代理依赖，pip 启动即失败
- `garden --version` 未实现，正式模式报告与存储仍受当前目录影响

## 修复

- 启动器改用 runtime Python 的模块入口，并保留 `garden` / `gardenctl` 命令名
- 安装阶段识别 SOCKS `ALL_PROXY`，仅对依赖安装临时忽略并提高重试上限
- 同时支持 `garden version` 与 `garden --version`
- 正式模式报告与受保护存储固定写入 `$GARDEN_HOME`

## 验证

- 187 项 pytest 全部通过
- Ruff、格式、shell 语法与 wheel 构建通过
- 本机真实验证 `garden`/`gardenctl` 版本与帮助
- 对 `127.0.0.1:3000` 完成前台扫描，报告位于 `~/.garden/reports`
- Ctrl+C 返回 130，扫描持久化为 `interrupted` 且不生成报告
- `garden stop` 停止 UI 并清理状态文件
