### PR TITLE
精简 Web UI 导航并打通扫描详情入口

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,13 +15,6 @@
         <nav class="flex gap-3 text-sm text-slate-600">
           <a href="/" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Dashboard</a>
           <a href="/scans" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">URL Scans</a>
-          <a href="/targets" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Targets</a>
-          <a href="/credentials" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Credentials</a>
-          <a href="/jobs" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Jobs</a>
-          <a href="/sessions" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Sessions</a>
-          <a href="/inventory" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Inventory</a>
-          <a href="/findings" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Findings</a>
-          <a href="/evidence" class="rounded-full border border-black/10 px-3 py-1.5 hover:bg-stone-100">Evidence</a>
         </nav>
       </div>
     </header>

--- a/app/templates/scans_list.html
+++ b/app/templates/scans_list.html
@@ -17,8 +17,13 @@
         </thead>
         <tbody class="divide-y divide-black/5">
           {% for scan in scans %}
-            <tr class="hover:bg-stone-50">
-              <td class="px-5 py-4 font-medium"><a href="/scans/{{ scan.id }}">#{{ scan.id }}</a></td>
+            <tr
+              class="cursor-pointer transition-colors hover:bg-stone-50 focus-within:bg-stone-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-emerald-600"
+              data-scan-detail-url="/scans/{{ scan.id }}"
+            >
+              <td class="px-5 py-4 font-medium">
+                <a href="/scans/{{ scan.id }}" aria-label="View scan #{{ scan.id }}">#{{ scan.id }}</a>
+              </td>
               <td class="max-w-xl truncate px-5 py-4">{{ scan.normalized_url }}</td>
               <td class="px-5 py-4">{{ status_badge(scan.status) }}</td>
               <td class="px-5 py-4">{{ scan.current_stage }}</td>
@@ -31,4 +36,19 @@
       </table>
     </div>
   </section>
+  <script>
+    (function () {
+      function scanRowFromEvent(event) {
+        if (!(event.target instanceof Element)) return null;
+        if (event.target.closest('a, button, input, select, textarea')) return null;
+        return event.target.closest('[data-scan-detail-url]');
+      }
+
+      document.addEventListener('click', function (event) {
+        var row = scanRowFromEvent(event);
+        if (row) window.location.assign(row.dataset.scanDetailUrl);
+      });
+
+    })();
+  </script>
 {% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
 
 
@@ -20,6 +22,41 @@ def test_index_page_loads(app) -> None:
     assert "Dashboard" in response.text
     assert "One URL to a structured report" in response.text
     assert "Start scan" in response.text
+
+
+def test_scans_page_uses_compact_navigation_and_clickable_scan_rows(app) -> None:
+    scan = SimpleNamespace(
+        id=4,
+        normalized_url="http://127.0.0.1:3000/",
+        status="completed_with_warnings",
+        current_stage="finished",
+        progress=100,
+    )
+
+    with TestClient(app) as client:
+        original_service = app.state.scan_service
+        app.state.scan_service = SimpleNamespace(list_scans=lambda: [scan])
+        try:
+            response = client.get("/scans")
+        finally:
+            app.state.scan_service = original_service
+
+    assert response.status_code == 200
+    assert 'href="/"' in response.text
+    assert 'href="/scans"' in response.text
+    for hidden_path in (
+        "/targets",
+        "/credentials",
+        "/jobs",
+        "/sessions",
+        "/inventory",
+        "/findings",
+        "/evidence",
+    ):
+        assert f'href="{hidden_path}"' not in response.text
+    assert 'data-scan-detail-url="/scans/4"' in response.text
+    assert 'aria-label="View scan #4"' in response.text
+    assert 'href="/scans/4"' in response.text
 
 
 def test_management_pages_render(app, seeded_findings) -> None:


### PR DESCRIPTION
## 变更内容

- 顶栏仅保留 Dashboard 和 URL Scans，隐藏尚未作为当前产品主线入口的管理页面
- 扫描列表支持点击整行进入 `/scans/{id}`，同时保留原生 ID 链接和键盘访问
- 增加页面契约测试，防止高级导航入口或扫描行交互意外回归

## 影响范围

本次仅修改服务端模板和页面测试，不删除 Targets、Credentials、Jobs、Sessions、Inventory、Findings、Evidence 的后端路由、服务或 CLI 能力。

## 验证

- `pytest`：184 passed，1 个既有 Starlette/httpx 弃用警告
- `ruff check .`：通过
- `ruff format --check .`：通过
- Playwright：点击第 4 条扫描的非链接区域进入 `/scans/4`
- Playwright：Tab 聚焦 `#4` 原生链接后按 Enter 进入 `/scans/4`