### PR TITLE
对齐单 URL 扫描 Dashboard

### DIFF
--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,97 +1,105 @@
-"""Dashboard summary helpers for the minimal web UI."""
+"""单 URL 扫描 Dashboard 汇总。"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session
 
-from app.models.credential_profile import CredentialProfile
-from app.models.enums import FindingConfidence, FindingSeverity
-from app.models.finding import Finding
-from app.models.finding_retest import FindingRetestRun
-from app.models.scan_job import ScanJob
-from app.models.target import Target
-from app.services.findings import FindingService
+from app.models.enums import AssessmentMode, FindingConfidence, FindingSeverity
+from app.models.scan_run import ScanAsset, ScanFinding, ScanRun
 
 
 @dataclass
 class DashboardSummary:
-    total_targets: int
-    total_credential_profiles: int
+    total_scans: int
+    total_assets: int
     total_findings: int
     high_severity_findings: int
     high_confidence_findings: int
-    recent_jobs: list[ScanJob]
+    recent_scans: list[ScanRun]
     status_breakdown: dict[str, int]
     category_distribution: list[tuple[str, int]]
-    recent_retests: list[FindingRetestRun]
 
 
 class DashboardService:
-    """Build a concise dashboard snapshot for demo and review flows."""
-
-    def __init__(self, *, finding_service: FindingService | None = None) -> None:
-        self.finding_service = finding_service or FindingService()
+    """汇总低门槛 quick scan 的用户可见结果。"""
 
     def build_summary(self, session: Session) -> DashboardSummary:
-        total_targets = session.scalar(select(func.count(Target.id))) or 0
-        total_credential_profiles = session.scalar(select(func.count(CredentialProfile.id))) or 0
-        total_findings = session.scalar(select(func.count(Finding.id))) or 0
+        quick_mode = AssessmentMode.QUICK.value
+        total_scans = (
+            session.scalar(select(func.count(ScanRun.id)).where(ScanRun.mode == quick_mode)) or 0
+        )
+        total_assets = (
+            session.scalar(
+                select(func.count(ScanAsset.id))
+                .join(ScanRun, ScanAsset.scan_run_id == ScanRun.id)
+                .where(ScanRun.mode == quick_mode)
+            )
+            or 0
+        )
+        total_findings = (
+            session.scalar(
+                select(func.count(ScanFinding.id))
+                .join(ScanRun, ScanFinding.scan_run_id == ScanRun.id)
+                .where(ScanRun.mode == quick_mode)
+            )
+            or 0
+        )
         high_severity_findings = (
             session.scalar(
-                select(func.count(Finding.id)).where(Finding.severity == FindingSeverity.HIGH.value)
+                select(func.count(ScanFinding.id))
+                .join(ScanRun, ScanFinding.scan_run_id == ScanRun.id)
+                .where(
+                    ScanRun.mode == quick_mode,
+                    ScanFinding.severity == FindingSeverity.HIGH.value,
+                )
             )
             or 0
         )
         high_confidence_findings = (
             session.scalar(
-                select(func.count(Finding.id)).where(
-                    Finding.confidence == FindingConfidence.HIGH.value
+                select(func.count(ScanFinding.id))
+                .join(ScanRun, ScanFinding.scan_run_id == ScanRun.id)
+                .where(
+                    ScanRun.mode == quick_mode,
+                    ScanFinding.confidence == FindingConfidence.HIGH.value,
                 )
             )
             or 0
         )
-        recent_jobs = list(
+        recent_scans = list(
             session.scalars(
-                select(ScanJob)
-                .options(
-                    selectinload(ScanJob.target),
-                    selectinload(ScanJob.credential_profile),
-                )
-                .order_by(ScanJob.id.desc())
+                select(ScanRun)
+                .where(ScanRun.mode == quick_mode)
+                .order_by(ScanRun.id.desc())
                 .limit(6)
             )
         )
+        status_rows = session.execute(
+            select(ScanRun.status, func.count(ScanRun.id))
+            .where(ScanRun.mode == quick_mode)
+            .group_by(ScanRun.status)
+            .order_by(ScanRun.status.asc())
+        ).all()
         category_rows = session.execute(
-            select(Finding.category, func.count(Finding.id))
-            .group_by(Finding.category)
-            .order_by(func.count(Finding.id).desc(), Finding.category.asc())
+            select(ScanFinding.category, func.count(ScanFinding.id))
+            .join(ScanRun, ScanFinding.scan_run_id == ScanRun.id)
+            .where(ScanRun.mode == quick_mode)
+            .group_by(ScanFinding.category)
+            .order_by(func.count(ScanFinding.id).desc(), ScanFinding.category.asc())
             .limit(8)
         ).all()
-        recent_retests = list(
-            session.scalars(
-                select(FindingRetestRun)
-                .options(
-                    selectinload(FindingRetestRun.finding),
-                    selectinload(FindingRetestRun.target),
-                    selectinload(FindingRetestRun.credential_profile),
-                )
-                .order_by(FindingRetestRun.id.desc())
-                .limit(5)
-            )
-        )
         return DashboardSummary(
-            total_targets=total_targets,
-            total_credential_profiles=total_credential_profiles,
+            total_scans=total_scans,
+            total_assets=total_assets,
             total_findings=total_findings,
             high_severity_findings=high_severity_findings,
             high_confidence_findings=high_confidence_findings,
-            recent_jobs=recent_jobs,
-            status_breakdown=self.finding_service.status_breakdown(session),
+            recent_scans=recent_scans,
+            status_breakdown={str(status): int(count) for status, count in status_rows},
             category_distribution=[
                 (str(category), int(count)) for category, count in category_rows
             ],
-            recent_retests=recent_retests,
         )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import severity_badge, confidence_badge, status_badge %}
+{% from "_macros.html" import status_badge %}
 
 {% block content %}
   <section class="space-y-8">
@@ -44,15 +44,15 @@
 
     <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
       <div class="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
-        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Targets</p>
-        <p class="mt-3 text-3xl font-semibold">{{ dashboard.total_targets }}</p>
+        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">URL Scans</p>
+        <p class="mt-3 text-3xl font-semibold">{{ dashboard.total_scans }}</p>
       </div>
       <div class="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
-        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Credential Profiles</p>
-        <p class="mt-3 text-3xl font-semibold">{{ dashboard.total_credential_profiles }}</p>
+        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Assets</p>
+        <p class="mt-3 text-3xl font-semibold">{{ dashboard.total_assets }}</p>
       </div>
       <div class="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
-        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Findings</p>
+        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Passive Findings</p>
         <p class="mt-3 text-3xl font-semibold">{{ dashboard.total_findings }}</p>
       </div>
       <div class="rounded-2xl border border-red-200 bg-red-50/50 p-5 shadow-sm">
@@ -68,29 +68,29 @@
     <div class="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
       <div class="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
         <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold">Recent Jobs</h2>
-          <a href="/jobs" class="text-sm text-slate-500">View all</a>
+          <h2 class="text-lg font-semibold">Recent URL Scans</h2>
+          <a href="/scans" class="text-sm text-slate-500">View all</a>
         </div>
         <div class="mt-4 overflow-hidden rounded-2xl border border-black/10">
           <table class="min-w-full divide-y divide-black/5 text-sm">
             <thead class="bg-stone-50 text-left text-slate-500">
               <tr>
-                <th class="px-4 py-3">Job</th>
-                <th class="px-4 py-3">Target</th>
-                <th class="px-4 py-3">Profile</th>
+                <th class="px-4 py-3">Scan</th>
+                <th class="px-4 py-3">URL</th>
                 <th class="px-4 py-3">Status</th>
+                <th class="px-4 py-3">Progress</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-black/5">
-              {% for job in dashboard.recent_jobs %}
+              {% for scan in dashboard.recent_scans %}
                 <tr class="hover:bg-stone-50">
-                  <td class="px-4 py-3 font-medium"><a href="/jobs/{{ job.id }}">{{ job.id }}</a></td>
-                  <td class="px-4 py-3">{{ job.target.name if job.target else job.target_id }}</td>
-                  <td class="px-4 py-3">{{ job.credential_profile.name if job.credential_profile else job.credential_profile_id }}</td>
-                  <td class="px-4 py-3">{{ status_badge(job.status) }}</td>
+                  <td class="px-4 py-3 font-medium"><a href="/scans/{{ scan.id }}">#{{ scan.id }}</a></td>
+                  <td class="max-w-xs truncate px-4 py-3"><a href="/scans/{{ scan.id }}">{{ scan.normalized_url }}</a></td>
+                  <td class="px-4 py-3">{{ status_badge(scan.status) }}</td>
+                  <td class="px-4 py-3">{{ scan.progress }}%</td>
                 </tr>
               {% else %}
-                <tr><td colspan="4" class="px-4 py-6 text-center text-slate-500">No workflow jobs have been recorded yet.</td></tr>
+                <tr><td colspan="4" class="px-4 py-6 text-center text-slate-500">No URL scans yet.</td></tr>
               {% endfor %}
             </tbody>
           </table>
@@ -100,13 +100,13 @@
       <div class="space-y-6">
         <div class="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
           <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold">Findings Overview</h2>
-            <a href="/findings" class="text-sm text-slate-500">Open findings</a>
+            <h2 class="text-lg font-semibold">Scan Status</h2>
+            <a href="/scans" class="text-sm text-slate-500">View scans</a>
           </div>
           <div class="mt-4 grid gap-3 sm:grid-cols-2">
             {% for status, count in dashboard.status_breakdown.items() %}
               <div class="rounded-2xl border border-black/10 bg-stone-50 p-4">
-                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">{{ status }}</p>
+                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">{{ status | replace('_', ' ') }}</p>
                 <p class="mt-2 text-2xl font-semibold">{{ count }}</p>
               </div>
             {% endfor %}
@@ -132,33 +132,6 @@
             {% endfor %}
           </div>
         </div>
-      </div>
-    </div>
-
-    <div class="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
-      <div class="flex items-center justify-between">
-        <h2 class="text-lg font-semibold">Recent Retest Outcomes</h2>
-        <a href="/findings" class="text-sm text-slate-500">Manage findings</a>
-      </div>
-      <div class="mt-4 grid gap-4 lg:grid-cols-2">
-        {% for retest in dashboard.recent_retests %}
-          <div class="rounded-2xl border border-black/10 bg-stone-50 p-4">
-            <p class="text-sm font-medium text-slate-900">
-              <a href="/findings/{{ retest.finding.id if retest.finding else retest.finding_id }}">Finding #{{ retest.finding_id }}</a>
-              · {{ status_badge(retest.status) }}
-            </p>
-            <p class="mt-1 text-sm text-slate-600">
-              {{ retest.target.name if retest.target else retest.target_id }} ·
-              {{ retest.credential_profile.name if retest.credential_profile else retest.credential_profile_id }}
-            </p>
-            <p class="mt-2 text-sm text-slate-700">{{ retest.summary }}</p>
-            <p class="mt-2 text-xs uppercase tracking-[0.16em] text-slate-500"><time data-iso="{{ retest.created_at.isoformat() }}">{{ retest.created_at.isoformat() }}</time></p>
-          </div>
-        {% else %}
-          <div class="rounded-2xl border border-dashed border-black/10 bg-stone-50 p-6 text-sm text-slate-500">
-            No retest outcomes recorded yet. Move a finding to <span class="font-medium">fixed</span> and run a retest to populate this view.
-          </div>
-        {% endfor %}
       </div>
     </div>
   </section>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,11 @@
+import re
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
+
+from app.db.bootstrap import session_scope
+from app.models.scan_run import ScanAsset, ScanFinding, ScanRun
 
 
 def test_healthz_returns_ok(app) -> None:
@@ -128,14 +133,90 @@ def test_management_pages_render(app, seeded_findings) -> None:
 
 
 def test_dashboard_page_shows_summary_cards(app, seeded_findings) -> None:
+    with session_scope() as session:
+        scan = ScanRun(
+            mode="quick",
+            input_url="http://127.0.0.1:3000/",
+            normalized_url="http://127.0.0.1:3000/",
+            status="completed_with_warnings",
+            current_stage="finished",
+            progress=100,
+            options={},
+        )
+        session.add(scan)
+        session.flush()
+        session.add_all(
+            [
+                ScanAsset(
+                    scan_run_id=scan.id,
+                    identity_key=f"GET:/asset-{index}",
+                    asset_type="page",
+                    url=f"http://127.0.0.1:3000/asset-{index}",
+                    method="GET",
+                    attributes={},
+                    discovered_at=datetime.now(timezone.utc),
+                )
+                for index in range(3)
+            ]
+        )
+        session.add_all(
+            [
+                ScanFinding(
+                    scan_run_id=scan.id,
+                    dedup_key="high-confidence",
+                    title="High-confidence passive finding",
+                    category="security-headers",
+                    severity="high",
+                    confidence="high",
+                    summary="Passive finding summary.",
+                    remediation="Apply the documented remediation.",
+                    asset_ids=[],
+                    evidence_ids=[],
+                    created_at=datetime.now(timezone.utc),
+                ),
+                ScanFinding(
+                    scan_run_id=scan.id,
+                    dedup_key="medium-confidence",
+                    title="Medium-confidence passive finding",
+                    category="information-exposure",
+                    severity="low",
+                    confidence="medium",
+                    summary="Passive finding summary.",
+                    remediation="Apply the documented remediation.",
+                    asset_ids=[],
+                    evidence_ids=[],
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        session.flush()
+        scan_id = scan.id
+
     with TestClient(app) as client:
         response = client.get("/")
 
     assert response.status_code == 200
-    assert "Findings Overview" in response.text
+    for label, value in (
+        ("URL Scans", 1),
+        ("Assets", 3),
+        ("Passive Findings", 2),
+        ("High Severity", 1),
+        ("High Confidence", 1),
+    ):
+        assert re.search(rf">{label}</p>\s*<p[^>]*>{value}</p>", response.text)
+    assert "Recent URL Scans" in response.text
+    assert "Scan Status" in response.text
     assert "Category Distribution" in response.text
-    assert "Recent Retest Outcomes" in response.text
-    assert "High Confidence" in response.text
+    assert f'href="/scans/{scan_id}"' in response.text
+    assert "http://127.0.0.1:3000/" in response.text
+    for legacy_content in (
+        ">Targets</p>",
+        ">Credential Profiles</p>",
+        "Recent Jobs",
+        "Findings Overview",
+        "Recent Retest Outcomes",
+    ):
+        assert legacy_content not in response.text
 
 
 def test_finding_status_update_route_updates_lifecycle_state(app, seeded_findings) -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,16 +1,137 @@
+from datetime import datetime, timezone
+
 from app.db.bootstrap import session_scope
+from app.models.scan_run import ScanAsset, ScanFinding, ScanRun
 from app.services.dashboard import DashboardService
 
 
-def test_dashboard_summary_aggregates_workflow_state(seeded_findings) -> None:
+def _add_run(session, *, mode: str, status: str, url: str) -> ScanRun:
+    run = ScanRun(
+        mode=mode,
+        input_url=url,
+        normalized_url=url,
+        status=status,
+        current_stage="finished",
+        progress=100,
+        options={},
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+def _add_asset(session, run: ScanRun, *, suffix: str) -> None:
+    session.add(
+        ScanAsset(
+            scan_run_id=run.id,
+            identity_key=f"GET:/{suffix}",
+            asset_type="page",
+            url=f"{run.normalized_url}{suffix}",
+            method="GET",
+            attributes={},
+            discovered_at=datetime.now(timezone.utc),
+        )
+    )
+
+
+def _add_finding(
+    session,
+    run: ScanRun,
+    *,
+    key: str,
+    category: str,
+    severity: str,
+    confidence: str,
+) -> None:
+    session.add(
+        ScanFinding(
+            scan_run_id=run.id,
+            dedup_key=key,
+            title=f"Finding {key}",
+            category=category,
+            severity=severity,
+            confidence=confidence,
+            summary="Passive finding summary.",
+            remediation="Apply the documented remediation.",
+            asset_ids=[],
+            evidence_ids=[],
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+
+
+def test_dashboard_summary_aggregates_quick_scan_state_only() -> None:
     service = DashboardService()
 
     with session_scope() as session:
+        first = _add_run(
+            session,
+            mode="quick",
+            status="completed_with_warnings",
+            url="http://127.0.0.1:3000/",
+        )
+        second = _add_run(
+            session,
+            mode="quick",
+            status="failed",
+            url="http://127.0.0.1:4000/",
+        )
+        authenticated = _add_run(
+            session,
+            mode="authenticated_coverage",
+            status="completed",
+            url="http://127.0.0.1:5000/",
+        )
+
+        _add_asset(session, first, suffix="")
+        _add_asset(session, first, suffix="about")
+        _add_asset(session, second, suffix="")
+        _add_asset(session, authenticated, suffix="admin")
+
+        _add_finding(
+            session,
+            first,
+            key="headers-csp",
+            category="security-headers",
+            severity="low",
+            confidence="high",
+        )
+        _add_finding(
+            session,
+            first,
+            key="headers-hsts",
+            category="security-headers",
+            severity="high",
+            confidence="medium",
+        )
+        _add_finding(
+            session,
+            second,
+            key="exposure-debug",
+            category="information-exposure",
+            severity="high",
+            confidence="high",
+        )
+        _add_finding(
+            session,
+            authenticated,
+            key="admin-only",
+            category="authorization",
+            severity="high",
+            confidence="high",
+        )
+        session.flush()
+
         summary = service.build_summary(session)
 
-    assert summary.total_targets >= 1
-    assert summary.total_credential_profiles >= 1
-    assert summary.total_findings >= 1
-    assert summary.recent_jobs
-    assert "new" in summary.status_breakdown
-    assert summary.category_distribution
+    assert summary.total_scans == 2
+    assert summary.total_assets == 3
+    assert summary.total_findings == 3
+    assert summary.high_severity_findings == 2
+    assert summary.high_confidence_findings == 2
+    assert [scan.id for scan in summary.recent_scans] == [second.id, first.id]
+    assert summary.status_breakdown == {"completed_with_warnings": 1, "failed": 1}
+    assert summary.category_distribution == [
+        ("security-headers", 2),
+        ("information-exposure", 1),
+    ]


### PR DESCRIPTION
## 变更内容

- Dashboard 指标改为仅汇总 quick `ScanRun`、`ScanAsset` 和 `ScanFinding`
- 五张卡片展示 URL Scans、Assets、Passive Findings、High Severity、High Confidence
- Recent Jobs 改为 Recent URL Scans，并链接到 `/scans/{id}`
- Findings Overview 改为 Scan Status，分类分布改用被动扫描发现
- 移除 Dashboard 上与当前产品主线不符的 Targets、Credentials、Retest 展示；高级后端能力保持不变

## 根因

原 Dashboard 仍查询旧认证工作流的 Target、CredentialProfile、ScanJob 和 Finding。单 URL 扫描结果实际写入 ScanRun、ScanAsset、ScanFinding，因此扫描完成后页面仍全部显示 0。

## 验证

- TDD 服务汇总测试：quick 统计正确且 authenticated run 不会混入
- TDD 首页集成测试：真实数据库数据映射到五张卡片和扫描详情链接
- `pytest`：188 passed，1 个既有 Starlette/httpx 弃用警告
- `ruff check .`：通过
- `ruff format --check .`：通过
- `git diff --check`：通过
- Playwright 使用本地数据库副本验证：5 scans、22 assets、3 passive findings、0 high severity、3 high confidence
- Playwright 点击 Recent URL Scans 的 #5 成功进入 `/scans/5`