### PR TITLE
默认允许已授权公网目标

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,9 @@ GARDEN_API_PORT=8000
 # Local SQLite database for the default demo workflow
 GARDEN_DATABASE_URL=sqlite+pysqlite:///./data/garden.db
 
-# Safe-by-default guardrail: keep false for local/demo use only
-GARDEN_ALLOW_NON_LOCAL_TARGETS=false
-# RFC1918/ULA addresses other than loopback require a separate explicit opt-in
+# 已授权公网目标默认允许；如需仅扫描本机目标，可显式改为 false。
+GARDEN_ALLOW_NON_LOCAL_TARGETS=true
+# RFC1918/ULA 私网地址（回环地址除外）仍需单独显式开启。
 GARDEN_ALLOW_PRIVATE_TARGETS=false
 
 # URL scan networking: environment proxies are ignored unless this is set.

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ exports/scan-reports/scan-<id>.md
 
 ## 安全边界
 
-Garden 只应用于已获得授权的目标，并默认采用保守策略：
+Garden 只应用于已获得授权的目标，并采用以下有界策略：
 
 - 仅允许 `http` 和 `https`
 - 只执行有界、同源的被动 `GET` 请求
 - 每次连接和重定向都会重新校验目标地址
-- 默认只允许本机回环目标
-- 公网目标需要显式设置 `GARDEN_ALLOW_NON_LOCAL_TARGETS=true`
+- 默认允许已授权的公网目标和本机回环目标
+- 如需恢复仅本机模式，可显式设置 `GARDEN_ALLOW_NON_LOCAL_TARGETS=false`
 - RFC1918/ULA 内网目标还需要设置 `GARDEN_ALLOW_PRIVATE_TARGETS=true`
 - link-local、云元数据常用地址、组播和未指定地址始终拒绝
 - 请求超时、整体超时、并发、重试、页面数和深度均有限制

--- a/app/core/guardrails.py
+++ b/app/core/guardrails.py
@@ -12,9 +12,8 @@ SAFE_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "host.docker.internal"}
 def ensure_target_allowed(target: str, settings: Settings) -> None:
     """Conservative Phase 1 guardrail for target admission.
 
-    This intentionally allows only clearly local/demo destinations unless the
-    explicit override flag is enabled. Future phases can expand this policy
-    with richer target models and audit context.
+    Garden 默认允许登记公网和本机目标；部署方仍可显式关闭公网目标。
+    实际网络连接会继续执行独立的 DNS/IP 策略检查。
     """
 
     if settings.allow_non_local_targets:
@@ -25,7 +24,7 @@ def ensure_target_allowed(target: str, settings: Settings) -> None:
         return
 
     raise TargetPolicyError(
-        "Non-local targets are disabled by default. Set "
+        "Non-local targets are disabled by configuration. Set "
         "GARDEN_ALLOW_NON_LOCAL_TARGETS=true only for authorized environments."
     )
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
         alias="GARDEN_DEMO_USER_PASSWORD",
     )
     allow_non_local_targets: bool = Field(
-        default=False,
+        default=True,
         alias="GARDEN_ALLOW_NON_LOCAL_TARGETS",
     )
     allow_private_targets: bool = Field(

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,7 +32,7 @@
           </div>
           <div>
             <dt class="text-slate-500">Target Guardrail</dt>
-            <dd class="mt-1 font-medium">Local-only by default</dd>
+            <dd class="mt-1 font-medium">Authorized public + local by default</dd>
           </div>
           <div>
             <dt class="text-slate-500">UI Scope</dt>

--- a/design-output/deploy/index.html
+++ b/design-output/deploy/index.html
@@ -317,7 +317,7 @@ pre{
     <div class="item">
       <div class="label">Safe by default</div>
       <h3>安全护栏默认开启</h3>
-      <p>默认仅允许本地目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
+      <p>默认允许已授权公网与本机目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
     </div>
   </div>
 </section>
@@ -355,7 +355,7 @@ pre{
   <div class="tag">Constraints</div>
   <h2>设计约束</h2>
   <ul class="checks" style="margin-top:12px">
-    <li>默认只允许本地目标</li>
+    <li>默认允许已授权公网与本机目标</li>
     <li>不做破坏性测试 / exploit</li>
     <li>核心逻辑在 service 层</li>
     <li>secret 不直接存储、不直接打印</li>
@@ -497,7 +497,7 @@ $ playwright install chromium</pre>
 
 <h2>环境配置</h2>
 <pre>$ cp .env.example .env
-# ensure GARDEN_ALLOW_NON_LOCAL_TARGETS=false</pre>
+# 默认 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</pre>
 
 <h2>启动服务</h2>
 <pre>$ make demo
@@ -591,7 +591,7 @@ targets:{b:'核心概念 > 目标管理',h:`
 <p>每个安全验证的起点都是一个 Target。Garden 要求所有操作都绑定在明确的目标上，包含 name、base_url、type、owner、tags、status。</p>
 
 <h2>安全护栏</h2>
-<p>默认只允许 localhost / 127.0.0.1 / Docker 网络地址。非本地目标需要显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>。</p>
+<p>默认允许已授权公网目标及 localhost / 127.0.0.1。RFC1918/ULA 私网目标仍需显式设置 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</p>
 
 <h2>CLI 操作</h2>
 <pre>$ gardenctl target add --name my-app --base-url http://127.0.0.1:8080 --type web --owner appsec
@@ -1050,8 +1050,8 @@ guardrails:{b:'进阶 > 安全护栏',h:`
 <p>这些限制不是暂时没做，而是 Garden 产品身份的一部分。</p>
 
 <ul class="check-list">
-  <li>默认仅允许本地 / demo 目标</li>
-  <li>非本地目标需 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</li>
+  <li>默认允许已授权公网与本机 / demo 目标</li>
+  <li>可设置 GARDEN_ALLOW_NON_LOCAL_TARGETS=false 恢复仅本机模式</li>
   <li>不做破坏性测试</li>
   <li>不做 exploit execution</li>
   <li>不做 brute-force / fuzzing</li>

--- a/design-output/docs.html
+++ b/design-output/docs.html
@@ -317,7 +317,7 @@ pre{
     <div class="item">
       <div class="label">Safe by default</div>
       <h3>安全护栏默认开启</h3>
-      <p>默认仅允许本地目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
+      <p>默认允许已授权公网与本机目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
     </div>
   </div>
 </section>
@@ -355,7 +355,7 @@ pre{
   <div class="tag">Constraints</div>
   <h2>设计约束</h2>
   <ul class="checks" style="margin-top:12px">
-    <li>默认只允许本地目标</li>
+    <li>默认允许已授权公网与本机目标</li>
     <li>不做破坏性测试 / exploit</li>
     <li>核心逻辑在 service 层</li>
     <li>secret 不直接存储、不直接打印</li>
@@ -503,7 +503,7 @@ $ playwright install chromium</pre>
 
 <h2>环境配置</h2>
 <pre>$ cp .env.example .env
-# ensure GARDEN_ALLOW_NON_LOCAL_TARGETS=false</pre>
+# 默认 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</pre>
 
 <h2>启动服务</h2>
 <pre>$ make demo
@@ -612,7 +612,7 @@ targets:{b:'核心概念 > 目标管理',h:`
 <p>每个安全验证的起点都是一个 Target。Garden 要求所有操作都绑定在明确的目标上，包含 name、base_url、type、owner、tags、status。</p>
 
 <h2>安全护栏</h2>
-<p>默认只允许 localhost / 127.0.0.1 / Docker 网络地址。非本地目标需要显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>。</p>
+<p>默认允许已授权公网目标及 localhost / 127.0.0.1。RFC1918/ULA 私网目标仍需显式设置 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</p>
 
 <h2>CLI 操作</h2>
 <pre>$ gardenctl target add --name my-app --base-url http://127.0.0.1:8080 --type web --owner appsec
@@ -974,7 +974,7 @@ report:{b:'证据与报告 > 报告生成',h:`
   --password-selector '#basic_password' \\
   --submit-selector 'button:has-text("Login") >> nth=1' \\
   --success-text 'Dashboard'</pre>
-<div class="tip">密码可以通过隐藏交互输入或 <code>GARDEN_QUICKSCAN_PASSWORD</code> 环境变量传入；非本地授权目标仍需显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>。</div>
+<div class="tip">密码可以通过隐藏交互输入或 <code>GARDEN_QUICKSCAN_PASSWORD</code> 环境变量传入；已授权公网目标默认允许，RFC1918/ULA 私网仍需单独开启。</div>
 `},
 'cli-target':{b:'CLI 参考 > gardenctl target',h:`
 <h1>gardenctl target</h1>
@@ -1089,8 +1089,8 @@ guardrails:{b:'进阶 > 安全护栏',h:`
 <p>这些限制不是暂时没做，而是 Garden 产品身份的一部分。</p>
 
 <ul class="check-list">
-  <li>默认仅允许本地 / demo 目标</li>
-  <li>非本地目标需 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</li>
+  <li>默认允许已授权公网与本机 / demo 目标</li>
+  <li>可设置 GARDEN_ALLOW_NON_LOCAL_TARGETS=false 恢复仅本机模式</li>
   <li>不做破坏性测试</li>
   <li>不做 exploit execution</li>
   <li>不做 brute-force / fuzzing</li>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,8 +65,9 @@ disallows implicit environment proxies, follows redirects itself, and validates
 each redirect destination. Link-local, multicast, unspecified, and non-global
 special-purpose addresses are blocked. Loopback is allowed for safe local tests.
 
-Remote public targets require `GARDEN_ALLOW_NON_LOCAL_TARGETS=true`. RFC1918/ULA
-targets additionally require `GARDEN_ALLOW_PRIVATE_TARGETS=true`. DNS answers
+Authorized remote public targets and loopback targets are enabled by default.
+Operators can restore local-only mode with `GARDEN_ALLOW_NON_LOCAL_TARGETS=false`.
+RFC1918/ULA targets still require `GARDEN_ALLOW_PRIVATE_TARGETS=true`. DNS answers
 containing any disallowed address fail closed.
 
 Requests have a per-request timeout, an overall task deadline, a response-size

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,7 +99,7 @@ cp .env.example .env
 
 ```bash
 export GARDEN_DATABASE_URL=sqlite+pysqlite:///./data/garden.db
-export GARDEN_ALLOW_NON_LOCAL_TARGETS=false
+export GARDEN_ALLOW_NON_LOCAL_TARGETS=true
 export GARDEN_DEMO_ADMIN_PASSWORD=demo-admin-password
 export GARDEN_DEMO_USER_PASSWORD=demo-user-password
 ```
@@ -166,7 +166,7 @@ docker run --rm -it \
   -p 8000:8000 \
   -v "$(pwd)/exports:/app/exports" \
   -e GARDEN_DATABASE_URL=sqlite+pysqlite:///./data/garden.db \
-  -e GARDEN_ALLOW_NON_LOCAL_TARGETS=false \
+  -e GARDEN_ALLOW_NON_LOCAL_TARGETS=true \
   -e GARDEN_DEMO_ADMIN_PASSWORD=demo-admin-password \
   -e GARDEN_DEMO_USER_PASSWORD=demo-user-password \
   garden:local
@@ -374,10 +374,9 @@ source .venv/bin/activate
 ./.venv/bin/gardenctl --help
 ```
 
-### 2. 非本地 target 被拒绝
+### 2. 公网 target 被意外拒绝
 
-Garden 默认只允许本地目标。  
-如果确实是在授权环境中测试，才显式放开：
+Garden 默认允许已授权的公网目标。如果公网目标被拒绝，先确认没有显式关闭：
 
 ```bash
 export GARDEN_ALLOW_NON_LOCAL_TARGETS=true

--- a/docs/index.html
+++ b/docs/index.html
@@ -318,7 +318,7 @@ pre{
     <div class="item">
       <div class="label">Safe by default</div>
       <h3>安全护栏默认开启</h3>
-      <p>默认仅允许本地目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
+      <p>默认允许已授权公网与本机目标、不做破坏性检查、secret 不直接存储、evidence 默认脱敏、所有关键操作记审计日志。</p>
     </div>
   </div>
 </section>
@@ -352,7 +352,7 @@ pre{
   <div class="tag">Constraints</div>
   <h2>设计约束</h2>
   <ul class="checks" style="margin-top:12px">
-    <li>默认只允许本地目标</li>
+    <li>默认允许已授权公网与本机目标</li>
     <li>不做破坏性测试 / exploit</li>
     <li>核心逻辑在 service 层</li>
     <li>secret 不直接存储、不直接打印</li>
@@ -495,7 +495,7 @@ $ playwright install chromium</pre>
 
 <h2>环境配置</h2>
 <pre>$ cp .env.example .env
-# ensure GARDEN_ALLOW_NON_LOCAL_TARGETS=false</pre>
+# 默认 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</pre>
 
 <h2>启动服务</h2>
 <pre>$ make demo
@@ -600,7 +600,7 @@ targets:{b:'核心概念 > 目标管理',h:`
 <p>每个安全验证的起点都是一个 Target。Garden 要求所有操作都绑定在明确的目标上，包含 name、base_url、type、owner、tags、status。</p>
 
 <h2>安全护栏</h2>
-<p>默认只允许 localhost / 127.0.0.1 / Docker 网络地址。非本地目标需要显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>。</p>
+<p>默认允许已授权公网目标及 localhost / 127.0.0.1。RFC1918/ULA 私网目标仍需显式设置 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</p>
 
 <h2>CLI 操作</h2>
 <pre>$ gardenctl target add --name my-app --base-url http://127.0.0.1:8080 --type web --owner appsec
@@ -956,7 +956,7 @@ report:{b:'证据与报告 > 报告生成',h:`
 <pre>gardenctl scan \\
   --url http://127.0.0.1:8888/ \\
   --max-pages 10 --max-depth 1 --retries 1</pre>
-<div class="tip">非本地公网目标需显式设置 <code>GARDEN_ALLOW_NON_LOCAL_TARGETS=true</code>；RFC1918/ULA 内网还需 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</div>
+<div class="tip">已授权公网目标默认允许；RFC1918/ULA 内网仍需设置 <code>GARDEN_ALLOW_PRIVATE_TARGETS=true</code>。</div>
 `},
 'cli-target':{b:'CLI 参考 > gardenctl target',h:`
 <h1>gardenctl target</h1>
@@ -1070,8 +1070,8 @@ guardrails:{b:'进阶 > 安全护栏',h:`
 <p>这些限制不是暂时没做，而是 Garden 产品身份的一部分。</p>
 
 <ul class="check-list">
-  <li>默认仅允许本地 / demo 目标</li>
-  <li>非本地目标需 GARDEN_ALLOW_NON_LOCAL_TARGETS=true</li>
+  <li>默认允许已授权公网与本机 / demo 目标</li>
+  <li>可设置 GARDEN_ALLOW_NON_LOCAL_TARGETS=false 恢复仅本机模式</li>
   <li>RFC1918 / ULA 内网目标需额外设置 GARDEN_ALLOW_PRIVATE_TARGETS=true</li>
   <li>每个连接与重定向都执行 DNS / SSRF 策略检查</li>
   <li>请求、整体任务、页面、深度、响应体和并发均有上限</li>

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -22,11 +22,11 @@ It must not be positioned as a tool for unauthorized access, mass scanning, or o
 
 Garden is safe by default:
 
-- local/demo targets only by default
-- non-local targets require explicit opt-in
+- authorized public and loopback targets are enabled by default
+- private RFC1918/ULA targets require explicit opt-in
 - no destructive checks
 - no exploit modules
-- no public scanning defaults
+- no mass or unauthorized scanning
 - no true IDOR exploitation
 - no dangerous file upload testing
 - no aggressive crawling or fuzzing
@@ -35,16 +35,16 @@ This default posture is a core product constraint, not just an implementation de
 
 ## Target Restrictions
 
-By default, Garden only allows:
+By default, Garden allows:
 
 - `localhost`
 - `127.0.0.1`
-- local demo or containerized local networks when explicitly configured
+- authorized public targets
 
-Remote targets require:
+Operators must:
 
-- an explicit configuration change such as `GARDEN_ALLOW_NON_LOCAL_TARGETS=true`
-- a consciously authorized environment
+- submit only targets for which they have explicit authorization
+- set `GARDEN_ALLOW_NON_LOCAL_TARGETS=false` when local-only operation is required
 
 Private RFC1918/ULA targets require the separate
 `GARDEN_ALLOW_PRIVATE_TARGETS=true` opt-in. URL scans resolve and classify DNS

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,7 @@ def test_index_page_loads(app) -> None:
     assert "Dashboard" in response.text
     assert "One URL to a structured report" in response.text
     assert "Start scan" in response.text
+    assert "Authorized public + local by default" in response.text
 
 
 def test_scans_page_uses_compact_navigation_and_clickable_scan_rows(app) -> None:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -3,6 +3,7 @@ import pytest
 from app.core.errors import TargetPolicyError
 from app.core.guardrails import ensure_target_allowed
 from app.core.settings import Settings
+from app.services.scan_network import TargetNetworkPolicy
 
 
 def test_localhost_target_allowed_by_default() -> None:
@@ -10,7 +11,28 @@ def test_localhost_target_allowed_by_default() -> None:
     ensure_target_allowed("http://localhost:8000", settings)
 
 
-def test_non_local_target_blocked_by_default() -> None:
-    settings = Settings()
+def test_non_local_target_allowed_by_project_default(monkeypatch) -> None:
+    monkeypatch.delenv("GARDEN_ALLOW_NON_LOCAL_TARGETS", raising=False)
+    settings = Settings(_env_file=None)
+
+    assert settings.allow_non_local_targets is True
+    ensure_target_allowed("https://example.com", settings)
+
+
+def test_non_local_target_can_be_disabled_explicitly() -> None:
+    settings = Settings().model_copy(update={"allow_non_local_targets": False})
     with pytest.raises(TargetPolicyError):
         ensure_target_allowed("https://example.com", settings)
+
+
+def test_private_target_remains_blocked_by_project_default(monkeypatch) -> None:
+    monkeypatch.delenv("GARDEN_ALLOW_NON_LOCAL_TARGETS", raising=False)
+    settings = Settings(_env_file=None)
+    policy = TargetNetworkPolicy(
+        settings,
+        resolver=lambda host, port, **kwargs: [(2, 1, 6, "", ("10.0.0.1", port))],
+    )
+
+    assert policy.policy_name == "public-and-local"
+    with pytest.raises(TargetPolicyError):
+        policy.preflight("https://internal.example/")


### PR DESCRIPTION
## 变更内容

- 将 `GARDEN_ALLOW_NON_LOCAL_TARGETS` 的项目默认值改为 `true`
- 保留显式设置 `false` 恢复仅本机模式的能力
- 保持 `GARDEN_ALLOW_PRIVATE_TARGETS=false`，RFC1918/ULA 私网仍默认拒绝
- 同步 Dashboard、环境示例、README、部署文档、架构文档与威胁模型
- 增加默认公网允许、显式关闭和私网继续拒绝的回归测试

## 变更原因

单 URL 扫描是 Garden 的低门槛入口。用户提交已授权公网 URL 时，不应再额外配置环境变量；安全边界继续由单 URL、有界 GET、DNS/IP 重校验、私网独立开关和超时/页面/并发限制保证。

## 用户影响

- 完整的已授权公网 URL 默认可扫描
- 设置 `GARDEN_ALLOW_NON_LOCAL_TARGETS=false` 可恢复仅本机策略
- RFC1918/ULA、link-local、云元数据、组播和未指定地址不会因此默认放开

## 验证

- `pytest`：190 passed，1 个既有 Starlette/httpx 弃用警告
- `ruff check app tests`：通过
- `ruff format --check app tests`：172 files already formatted
- 无环境变量实测：`allow_non_local_targets=true`、`policy=public-and-local`、`allow_private_targets=false`
