### PR TITLE
修复安装升级并收敛资产报告

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ garden scan http://127.0.0.1:13000/
 
 首次运行会自动启动或复用仅监听本机回环地址的 Web UI，并输出首页和本次扫描详情地址；默认前台显示进度，但不会自动打开浏览器。用户数据默认保存于 `~/.garden`，可用 `GARDEN_HOME` 覆盖。若安装后找不到命令，请按安装器输出将 `~/.local/bin` 加入 PATH。
 
+安装器会自动寻找首个满足 3.10+ 的 `python3`、`python3.13`、`python3.12`、`python3.11` 或 `python3.10`；也会识别常见 Homebrew 版本化安装路径。需要固定解释器时可设置 `GARDEN_PYTHON=/path/to/python3`。正式命令使用隔离入口加载已安装包，即使从 Garden 仓库目录执行，也不会被当前源码覆盖。
+
 ```bash
 garden scan http://127.0.0.1:13000/ --detach  # 仅提交，立即返回
 garden stop                                   # 中断活动扫描并停止本机 UI

--- a/app/redaction/service.py
+++ b/app/redaction/service.py
@@ -34,6 +34,26 @@ class RedactionService:
         "key",
     }
     _path_like_keys = {"path", "screenshot_path", "storage_ref"}
+    _safe_http_metadata_headers = {
+        "accept-ranges",
+        "cache-control",
+        "connection",
+        "content-encoding",
+        "content-length",
+        "content-type",
+        "date",
+        "etag",
+        "expires",
+        "last-modified",
+        "permissions-policy",
+        "referrer-policy",
+        "server",
+        "strict-transport-security",
+        "transfer-encoding",
+        "vary",
+        "x-content-type-options",
+        "x-frame-options",
+    }
 
     def redact_text(self, value: str | None, *, limit: int = 400) -> str:
         if not value:
@@ -73,6 +93,19 @@ class RedactionService:
                 redacted[key] = [self._redact_list_entry(entry, limit=limit) for entry in item]
                 continue
             redacted[key] = self._redact_scalar(item, limit=limit)
+        return redacted
+
+    def redact_http_headers(self, value: dict[str, str], *, limit: int = 400) -> dict[str, str]:
+        redacted: dict[str, str] = {}
+        for key, item in value.items():
+            lowered = key.lower()
+            if self._is_sensitive_key(key):
+                redacted[key] = "***"
+            elif lowered in self._safe_http_metadata_headers:
+                cleaned = self._control_character_pattern.sub(" ", item)
+                redacted[key] = " ".join(cleaned.split())[:limit]
+            else:
+                redacted[key] = self.redact_text(item, limit=limit)
         return redacted
 
     def _redact_scalar(self, value: Any, *, limit: int) -> Any:

--- a/app/schemas/scan.py
+++ b/app/schemas/scan.py
@@ -138,6 +138,7 @@ class FetchResult(BaseModel):
     discovered_urls: list[str] = Field(default_factory=list)
     discovered_assets: list[DiscoveredAsset] = Field(default_factory=list)
     body_sha256: str = ""
+    body_truncated: bool = False
     redirects: list[str] = Field(default_factory=list)
     attempts: int = 1
     elapsed_ms: int = 0

--- a/app/services/scan_network.py
+++ b/app/services/scan_network.py
@@ -229,14 +229,22 @@ class HttpScanGateway:
         self.transport = transport
         self.sleeper = sleeper
 
-    def fetch(self, url: str, options: ScanOptions) -> FetchResult:
+    def fetch(
+        self,
+        url: str,
+        options: ScanOptions,
+        *,
+        expected_origin: tuple[str, str, int] | None = None,
+    ) -> FetchResult:
         started = time.monotonic()
         current = self.policy.normalize_url(url)
         redirects: list[str] = []
         total_attempts = 0
         for redirect_index in range(options.max_redirects + 1):
             self.policy.ensure_destination_allowed(current)
-            response, body, attempts = self._request_once_with_retry(current, options)
+            response, body, attempts, body_truncated = self._request_once_with_retry(
+                current, options
+            )
             total_attempts += attempts
             if response.status_code in {301, 302, 303, 307, 308}:
                 location = response.headers.get("location")
@@ -254,8 +262,16 @@ class HttpScanGateway:
                         url=current,
                         attempts=total_attempts,
                     )
-                current = self.policy.normalize_url(urljoin(current, location))
-                self.policy.ensure_destination_allowed(current)
+                next_url = self.policy.normalize_url(urljoin(current, location))
+                if expected_origin is not None and self._origin(next_url) != expected_origin:
+                    raise FetchError(
+                        "cross_origin_redirect_blocked",
+                        "Redirect left the configured same-origin collection boundary.",
+                        url=next_url,
+                        attempts=total_attempts,
+                    )
+                self.policy.ensure_destination_allowed(next_url)
+                current = next_url
                 redirects.append(current)
                 continue
             content_type = response.headers.get("content-type")
@@ -275,6 +291,7 @@ class HttpScanGateway:
                 discovered_urls=[item.url for item in discovered_assets],
                 discovered_assets=discovered_assets,
                 body_sha256=hashlib.sha256(body).hexdigest(),
+                body_truncated=body_truncated,
                 redirects=redirects,
                 attempts=total_attempts,
                 elapsed_ms=int((time.monotonic() - started) * 1000),
@@ -283,7 +300,7 @@ class HttpScanGateway:
 
     def _request_once_with_retry(
         self, url: str, options: ScanOptions
-    ) -> tuple[httpx.Response, bytes, int]:
+    ) -> tuple[httpx.Response, bytes, int, bool]:
         retries = options.retry_attempts or 0
         proxy = self.policy.proxy_for_url(url)
         timeout = options.request_timeout_seconds or 5.0
@@ -300,15 +317,24 @@ class HttpScanGateway:
                     with client.stream("GET", url) as response:
                         chunks: list[bytes] = []
                         size = 0
+                        body_truncated = False
                         for chunk in response.iter_bytes():
                             remaining = MAX_RESPONSE_BYTES - size
                             if remaining <= 0:
+                                body_truncated = True
                                 break
+                            if len(chunk) > remaining:
+                                body_truncated = True
                             chunks.append(chunk[:remaining])
                             size += min(len(chunk), remaining)
+                            if body_truncated:
+                                break
                         body = b"".join(chunks)
+                        content_length = response.headers.get("content-length")
+                        if content_length and content_length.isdigit():
+                            body_truncated = body_truncated or int(content_length) > len(body)
                 if response.status_code not in TRANSIENT_STATUS_CODES:
-                    return response, body, attempt
+                    return response, body, attempt, body_truncated
                 if attempt > retries:
                     raise FetchError(
                         "transient_http_exhausted",
@@ -329,6 +355,11 @@ class HttpScanGateway:
             if attempt <= retries:
                 self.sleeper(0.2 * (2 ** (attempt - 1)))
         raise AssertionError("unreachable retry state")
+
+    def _origin(self, url: str) -> tuple[str, str, int]:
+        parsed = urlparse(url)
+        effective_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        return parsed.scheme, parsed.hostname or "", effective_port
 
     def _decode(self, body: bytes, encoding: str | None) -> str:
         return body.decode(encoding or "utf-8", errors="replace")

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections import Counter
 from datetime import datetime, timezone
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -379,13 +379,12 @@ class ScanPipeline:
         page_requests = 1
         resource_count = 0
         resource_requests = 0
-        skipped_external = 0
+        skipped_external: set[str] = set()
         depth_limited: list[DiscoveredAsset] = []
 
         def enqueue(discovery: DiscoveredAsset, depth: int) -> None:
-            nonlocal skipped_external
             if self._origin(discovery.url) != origin:
-                skipped_external += 1
+                skipped_external.add(discovery.url)
                 return
             candidates.setdefault(discovery.url, discovery)
             if discovery.url in seen:
@@ -410,7 +409,7 @@ class ScanPipeline:
             requested.add(url)
             page_requests += 1
             try:
-                result = self.gateway.fetch(url, options)
+                result = self.gateway.fetch(url, options, expected_origin=origin)
                 self._check_interrupted(session, run.id)
             except (FetchError, InputValidationError, TargetPolicyError) as error:
                 code, retryable, attempts, failed_url = self._error_details(error, url)
@@ -445,7 +444,7 @@ class ScanPipeline:
             requested.add(url)
             resource_requests += 1
             try:
-                result = self.gateway.fetch(url, options)
+                result = self.gateway.fetch(url, options, expected_origin=origin)
                 self._check_interrupted(session, run.id)
             except (FetchError, InputValidationError, TargetPolicyError) as error:
                 code, retryable, attempts, failed_url = self._error_details(error, url)
@@ -501,7 +500,7 @@ class ScanPipeline:
             )
         return None, (
             f"Recorded {page_count} page(s) and {resource_count} resource(s); skipped "
-            f"{skipped_external} external link(s); {len(uncovered)} URL(s) remained "
+            f"{len(skipped_external)} unique external link(s); {len(uncovered)} URL(s) remained "
             "outside configured bounds."
         )
 
@@ -582,8 +581,9 @@ class ScanPipeline:
         asset_type = classify_asset_type(
             result.final_url, result.content_type, hint=asset_type_hint
         )
-        version_hints = self._version_hints(result.final_url, result.body_text)
+        version_hints = self._version_hints(result.final_url, result.body_text, asset_type)
         security_signals = self._resource_security_signals(asset_type, result.body_text)
+        collection_bucket = "page" if asset_type_hint in {None, "page"} else "resource"
         attributes = {
             "content_type": result.content_type,
             "body_size_bytes": result.body_size_bytes,
@@ -594,6 +594,8 @@ class ScanPipeline:
             "redirects": result.redirects,
             "discovered_urls": result.discovered_urls,
             "body_sha256": result.body_sha256,
+            "body_truncated": result.body_truncated,
+            "collection_bucket": collection_bucket,
             "version_hints": version_hints,
             "security_signals": security_signals,
         }
@@ -612,12 +614,13 @@ class ScanPipeline:
             )
             session.add(asset)
             session.flush()
-        headers = self.redaction_service.redact_mapping(result.headers)
+        headers = self.redaction_service.redact_http_headers(result.headers)
         resource_summary = None
         if asset_type in {"stylesheet", "script", "image", "document"}:
             resource_summary = {
                 "size_bytes": result.body_size_bytes,
                 "sha256": result.body_sha256,
+                "truncated": result.body_truncated,
                 "version_hints": version_hints,
                 "security_signals": security_signals,
             }
@@ -652,6 +655,7 @@ class ScanPipeline:
                     "headers": headers,
                     "preview": preview,
                     "resource_summary": resource_summary,
+                    "collection_bucket": collection_bucket,
                 },
                 collected_at=now,
             )
@@ -667,11 +671,24 @@ class ScanPipeline:
             for url in result.discovered_urls
         ]
 
-    def _version_hints(self, url: str, body: str) -> list[str]:
-        values = re.findall(
-            r"(?<!\d)(\d+\.\d+(?:\.\d+)?)(?!\d)",
-            f"{urlparse(url).path}\n{body[:4096]}",
-        )
+    def _version_hints(self, url: str, body: str, asset_type: str) -> list[str]:
+        parsed = urlparse(url)
+        values: list[str] = []
+        version_pattern = r"(?<!\d)(\d+\.\d+(?:\.\d+)?)(?!\d)"
+        values.extend(re.findall(version_pattern, parsed.path))
+        query = parse_qs(parsed.query)
+        for key in ("v", "ver", "version"):
+            for candidate in query.get(key, []):
+                match = re.fullmatch(version_pattern, candidate.strip())
+                if match:
+                    values.append(match.group(1))
+        if asset_type in {"stylesheet", "script"}:
+            context_pattern = (
+                r"(?i)(?:\bversion\b|\bver\b|\bv\b|\bjquery\b|\bswiper\b|"
+                r"\bslick\b|\bjwplayer\b|\bpdf\.js\b|\blibrary\b|\bwidget\b)"
+                r"\s*[:=_-]?\s*" + version_pattern
+            )
+            values.extend(re.findall(context_pattern, body[:4096]))
         return list(dict.fromkeys(values))[:5]
 
     def _resource_security_signals(self, asset_type: str, body: str) -> list[str]:

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -58,6 +58,7 @@ class ScanReportService:
         assets = sorted(run.assets, key=lambda item: item.id)
         evidence = sorted(run.evidence, key=lambda item: item.id)
         findings = sorted(run.findings, key=lambda item: item.id)
+        finding_groups = self._group_findings(findings)
         stages = sorted(run.stages, key=lambda item: item.position)
         summary_status = run.status
         if summary_status == "running":
@@ -71,7 +72,7 @@ class ScanReportService:
             f"- 入口 URL：{run.normalized_url}",
             f"- 发现资产：{len(assets)}",
             f"- 证据记录：{len(evidence)}",
-            f"- 风险或关注项：{len(findings)}",
+            f"- 风险或关注项：{len(finding_groups)} 类（{len(findings)} 条原始观察）",
             f"- 覆盖告警：{len(coverage_warnings)}",
             f"- 请求或阶段失败：{len(request_failures)}",
             "",
@@ -112,7 +113,9 @@ class ScanReportService:
         lines.extend(["", "## 证据", ""])
         if not evidence:
             lines.append("没有可用证据；请结合失败与未覆盖部分判断报告完整性。")
-        for item in evidence:
+        detailed_evidence = [item for item in evidence if not item.data.get("resource_summary")]
+        resource_evidence = [item for item in evidence if item.data.get("resource_summary")]
+        for item in detailed_evidence:
             headers = item.data.get("headers", {})
             rendered_headers = ", ".join(
                 f"{key}={self._inline(str(value))}" for key, value in sorted(headers.items())[:12]
@@ -125,23 +128,34 @@ class ScanReportService:
                 f"- 摘要：{item.summary}",
                 f"- 响应头证据：{rendered_headers or '-'}",
             ]
-            resource_summary = item.data.get("resource_summary")
-            if resource_summary:
-                versions = ", ".join(resource_summary.get("version_hints") or []) or "未识别"
-                signals = ", ".join(resource_summary.get("security_signals") or []) or "未观察到"
-                evidence_lines.append(
-                    "- 资源摘要："
-                    f"size={resource_summary.get('size_bytes', 0)} bytes；"
-                    f"SHA-256={resource_summary.get('sha256') or '-'}；"
-                    f"版本线索={versions}；安全信号={signals}"
-                )
-                preview = str(item.data.get("preview") or "")
-                if preview.startswith("[non-text response omitted"):
-                    evidence_lines.append(f"- 内容说明：{self._inline(preview)}")
-            else:
-                preview = self._inline(str(item.data.get("preview") or "-"))[:500]
-                evidence_lines.append(f"- 脱敏内容预览：{preview}")
+            preview = self._inline(str(item.data.get("preview") or "-"))[:500]
+            evidence_lines.append(f"- 脱敏内容预览：{preview}")
             lines.extend([*evidence_lines, ""])
+        if resource_evidence:
+            lines.extend(["### 静态资源证据索引", ""])
+        for item in resource_evidence:
+            resource_summary = item.data["resource_summary"]
+            versions = ", ".join(resource_summary.get("version_hints") or []) or "未识别"
+            signals = ", ".join(resource_summary.get("security_signals") or []) or "未观察到"
+            truncated = bool(resource_summary.get("truncated"))
+            hash_label = "采集片段 SHA-256" if truncated else "SHA-256"
+            preview = str(item.data.get("preview") or "")
+            content_note = (
+                f"；内容说明={self._inline(preview)}"
+                if preview.startswith("[non-text response omitted")
+                else ""
+            )
+            asset_ref = f"A{item.asset_id}" if item.asset_id else "未关联"
+            lines.append(
+                f"- E{item.id}（{asset_ref}）资源摘要："
+                f"size={resource_summary.get('size_bytes', 0)} bytes；"
+                f"truncated={str(truncated).lower()}；"
+                f"{hash_label}={resource_summary.get('sha256') or '-'}；"
+                f"版本线索={versions}；安全信号={signals}；"
+                f"来源={self._inline(item.source_url)}{content_note}"
+            )
+        if resource_evidence:
+            lines.append("")
 
         observed_controls = self._observed_security_controls(evidence)
         lines.extend(["## 已观察到的安全控制", ""])
@@ -154,19 +168,29 @@ class ScanReportService:
         lines.extend(["## 风险或关注项", ""])
         if not findings:
             lines.append("未识别到风险或关注项。这不代表目标不存在未覆盖风险。")
-        for finding in findings:
-            evidence_refs = ", ".join(f"E{item}" for item in finding.evidence_ids) or "无"
-            asset_refs = ", ".join(f"A{item}" for item in finding.asset_ids) or "无"
+        for group in finding_groups:
+            findings_in_group = group["findings"]
+            first = findings_in_group[0]
+            evidence_ids = sorted(
+                {item for finding in findings_in_group for item in finding.evidence_ids}
+            )
+            asset_ids = sorted(
+                {item for finding in findings_in_group for item in finding.asset_ids}
+            )
+            evidence_refs = self._sample_refs("E", evidence_ids)
+            asset_refs = self._sample_refs("A", asset_ids)
+            heading_id = f"F{first.id} 等" if len(findings_in_group) > 1 else f"F{first.id}"
             lines.extend(
                 [
-                    f"### F{finding.id}：{finding.title}",
+                    f"### {heading_id}：{first.title}",
                     "",
-                    f"- 严重性 / 置信度：{finding.severity} / {finding.confidence}",
-                    f"- 类别：{finding.category}",
-                    f"- 关联资产：{asset_refs}",
-                    f"- 关联证据：{evidence_refs}",
-                    f"- 说明：{finding.summary}",
-                    f"- 建议：{finding.remediation}",
+                    f"- 严重性 / 置信度：{first.severity} / {first.confidence}",
+                    f"- 类别：{first.category}",
+                    f"- 影响范围：{len(asset_ids)} 个资产，{len(evidence_ids)} 条证据",
+                    f"- 关联资产样本：{asset_refs}",
+                    f"- 关联证据样本：{evidence_refs}",
+                    f"- 说明：{first.summary}",
+                    f"- 建议：{first.remediation}",
                     "",
                 ]
             )
@@ -177,16 +201,29 @@ class ScanReportService:
             return stage.status
 
         completed_stages = sum(1 for stage in stages if report_status(stage) == "completed")
+        has_collection_buckets = any("collection_bucket" in item.data for item in evidence)
+        if has_collection_buckets:
+            page_requests = sum(item.data.get("collection_bucket") == "page" for item in evidence)
+            resource_requests = sum(
+                item.data.get("collection_bucket") == "resource" for item in evidence
+            )
+            request_coverage = (
+                f"页面队列 {page_requests}/{run.options.get('max_pages', '-')}，"
+                f"资源队列 {resource_requests}/{run.options.get('max_resources', '-')}"
+            )
+        else:
+            final_pages = sum(asset.asset_type == "page" for asset in assets)
+            final_resources = sum(asset.asset_type != "page" for asset in assets)
+            request_coverage = (
+                f"旧版记录未保存请求预算桶；仅可确认最终页面类型 {final_pages}，"
+                f"其他资产类型 {final_resources}"
+            )
         lines.extend(
             [
                 "## 扫描覆盖范围",
                 "",
                 f"- 阶段完成：{completed_stages}/{len(stages)}",
-                "- 已请求并记录："
-                f"页面 {sum(asset.asset_type == 'page' for asset in assets)}/"
-                f"{run.options.get('max_pages', '-')}，静态资源 "
-                f"{sum(asset.asset_type != 'page' for asset in assets)}/"
-                f"{run.options.get('max_resources', '-')}",
+                f"- 已请求并记录：{request_coverage}",
             ]
         )
         for stage in stages:
@@ -222,6 +259,28 @@ class ScanReportService:
             ]
         )
         return lines
+
+    def _group_findings(self, findings) -> list[dict[str, object]]:
+        groups: dict[tuple[str, ...], list] = {}
+        for finding in findings:
+            key = (
+                finding.title,
+                finding.category,
+                finding.severity,
+                finding.confidence,
+                finding.summary,
+                finding.remediation,
+            )
+            groups.setdefault(key, []).append(finding)
+        return [{"findings": items} for items in groups.values()]
+
+    def _sample_refs(self, prefix: str, identifiers: list[int], limit: int = 10) -> str:
+        if not identifiers:
+            return "无"
+        rendered = ", ".join(f"{prefix}{identifier}" for identifier in identifiers[:limit])
+        if len(identifiers) > limit:
+            rendered += f" 等（共 {len(identifiers)} 条）"
+        return rendered
 
     def _observed_security_controls(self, evidence) -> list[tuple[str, str]]:
         names = {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,8 @@ garden scan http://127.0.0.1:8080/
 
 安装器不使用 `sudo`，也不会修改 shell 配置。运行环境位于 `~/.local/share/garden/runtime/`，命令入口是 `~/.local/bin/garden` 与兼容入口 `~/.local/bin/gardenctl`。若 `~/.local/bin` 不在 PATH，按安装器输出的命令配置后重新打开终端。
 
+安装器会从 `python3` 和版本化命令中选择首个满足 3.10+ 的解释器，并识别 macOS 上常见的 Homebrew `python@3.x` 路径。若要固定解释器，执行 `GARDEN_PYTHON=/path/to/python3 ./install.sh`。正式启动器通过隔离模式和绝对 bootstrap 文件加载运行环境中的 Garden 包，因此当前目录下的同名 `app` 源码或 `PYTHONPATH` 不会遮蔽已安装版本。
+
 若当前 shell 设置了 SOCKS `ALL_PROXY`，安装器会在创建隔离运行环境时临时忽略该变量，并增加依赖下载重试；不会修改当前 shell 或其他项目的代理配置。
 
 用户数据默认位于 `~/.garden`，可通过 `GARDEN_HOME` 覆盖：
@@ -58,6 +60,8 @@ garden stop
 ```
 
 `garden stop` 会把全部 queued/running 扫描标记为 `interrupted` 并停止本机 UI，已写入的资产和证据会保留。安装器升级前会自动备份 SQLite 数据库；如果服务仍在运行，先执行 `garden stop`。正式 CLI 只读取 `$GARDEN_HOME/config.env`，不读取当前目录 `.env`，而当前 shell 环境变量优先。
+
+配置文件由新安装器创建时会带有托管版本标记。升级遇到旧安装器原样生成、仍带旧版 guardrail 注释的 `GARDEN_ALLOW_NON_LOCAL_TARGETS=false` 时，会迁移为当前默认的公网目标策略；没有旧版生成特征的自定义 local-only 配置保持不变。
 
 ## 三、本地开发部署
 

--- a/install.sh
+++ b/install.sh
@@ -40,19 +40,45 @@ case "$(uname -m)" in
     ;;
 esac
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "未找到 python3。请先安装 Python 3.10 或更高版本。" >&2
-  exit 1
-fi
-
-if ! python3 - <<'PY'
+python_is_usable() {
+  "$1" - <<'PY' >/dev/null 2>&1
 import sys
 raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
 PY
-then
-  echo "Garden 需要 Python 3.10 或更高版本。" >&2
+}
+
+GARDEN_PYTHON_BIN=""
+if [ -n "${GARDEN_PYTHON:-}" ]; then
+  if command -v "$GARDEN_PYTHON" >/dev/null 2>&1 && python_is_usable "$GARDEN_PYTHON"; then
+    GARDEN_PYTHON_BIN="$(command -v "$GARDEN_PYTHON")"
+  else
+    echo "GARDEN_PYTHON 指向的解释器不可用或低于 Python 3.10：$GARDEN_PYTHON" >&2
+    exit 1
+  fi
+else
+  for candidate in \
+    python3 python3.13 python3.12 python3.11 python3.10 \
+    /opt/homebrew/opt/python@3.13/libexec/bin/python3 \
+    /opt/homebrew/opt/python@3.12/libexec/bin/python3 \
+    /opt/homebrew/opt/python@3.11/libexec/bin/python3 \
+    /usr/local/opt/python@3.13/libexec/bin/python3 \
+    /usr/local/opt/python@3.12/libexec/bin/python3 \
+    /usr/local/opt/python@3.11/libexec/bin/python3
+  do
+    if command -v "$candidate" >/dev/null 2>&1 && python_is_usable "$candidate"; then
+      GARDEN_PYTHON_BIN="$(command -v "$candidate")"
+      break
+    fi
+  done
+fi
+
+if [ -z "$GARDEN_PYTHON_BIN" ]; then
+  echo "未找到 Python 3.10 或更高版本。可安装 Python 3.12，或通过 GARDEN_PYTHON 指定解释器。" >&2
   exit 1
 fi
+
+GARDEN_PYTHON_VERSION="$("$GARDEN_PYTHON_BIN" -c 'import platform; print(platform.python_version())')"
+echo "使用 Python：$GARDEN_PYTHON_BIN ($GARDEN_PYTHON_VERSION)"
 
 GARDEN_SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 GARDEN_USER_HOME="${HOME:?HOME 未设置，无法执行用户级安装。}"
@@ -81,9 +107,30 @@ fi
 mkdir -p "$GARDEN_HOME" "$GARDEN_HOME/reports" "$GARDEN_HOME/storage" \
   "$GARDEN_HOME/logs" "$GARDEN_RUNTIME_STATE_DIR" "$GARDEN_INSTALL_ROOT" "$GARDEN_BIN_DIR"
 
-if [ ! -f "$GARDEN_HOME/config.env" ]; then
-  grep -v '^GARDEN_DATABASE_URL=' "$GARDEN_SOURCE_ROOT/.env.example" \
-    > "$GARDEN_HOME/config.env"
+GARDEN_CONFIG_FILE="$GARDEN_HOME/config.env"
+GARDEN_CONFIG_MARKER="# GARDEN_INSTALLER_MANAGED_CONFIG_VERSION=2"
+if [ ! -f "$GARDEN_CONFIG_FILE" ]; then
+  {
+    echo "$GARDEN_CONFIG_MARKER"
+    grep -v '^GARDEN_DATABASE_URL=' "$GARDEN_SOURCE_ROOT/.env.example"
+  } > "$GARDEN_CONFIG_FILE"
+elif ! grep -Fq "$GARDEN_CONFIG_MARKER" "$GARDEN_CONFIG_FILE" \
+  && grep -Fq '# Garden local demo defaults' "$GARDEN_CONFIG_FILE" \
+  && grep -Fq '# Safe-by-default guardrail: keep false for local/demo use only' "$GARDEN_CONFIG_FILE" \
+  && grep -Fqx 'GARDEN_ALLOW_NON_LOCAL_TARGETS=false' "$GARDEN_CONFIG_FILE"
+then
+  GARDEN_CONFIG_STAGE="$(mktemp "$GARDEN_HOME/.config.env.XXXXXX")"
+  {
+    echo "$GARDEN_CONFIG_MARKER"
+    sed \
+      -e 's|# Safe-by-default guardrail: keep false for local/demo use only|# 已授权公网目标默认允许；如需仅扫描本机目标，可显式改为 false。|' \
+      -e 's|^GARDEN_ALLOW_NON_LOCAL_TARGETS=false$|GARDEN_ALLOW_NON_LOCAL_TARGETS=true|' \
+      "$GARDEN_CONFIG_FILE"
+  } > "$GARDEN_CONFIG_STAGE"
+  chmod --reference="$GARDEN_CONFIG_FILE" "$GARDEN_CONFIG_STAGE" 2>/dev/null \
+    || chmod 0600 "$GARDEN_CONFIG_STAGE"
+  mv "$GARDEN_CONFIG_STAGE" "$GARDEN_CONFIG_FILE"
+  echo "已迁移旧版自动生成的公网目标策略：GARDEN_ALLOW_NON_LOCAL_TARGETS=true"
 fi
 
 if [ -f "$GARDEN_HOME/garden.db" ]; then
@@ -103,7 +150,7 @@ cleanup_stage() {
 }
 trap cleanup_stage EXIT
 
-python3 -m venv "$GARDEN_STAGE_DIR/venv"
+"$GARDEN_PYTHON_BIN" -m venv "$GARDEN_STAGE_DIR/venv"
 GARDEN_STAGE_PYTHON="$GARDEN_STAGE_DIR/venv/bin/python"
 export PIP_RETRIES="${PIP_RETRIES:-10}"
 export PIP_TIMEOUT="${PIP_TIMEOUT:-30}"
@@ -141,10 +188,23 @@ set -eu
 export GARDEN_CLI_RUNTIME=1
 export GARDEN_CLI_NAME="$command_name"
 export GARDEN_HOME="\${GARDEN_HOME:-$GARDEN_HOME}"
-exec "$GARDEN_RUNTIME_DIR/venv/bin/python" -m app.cli.main "\$@"
+exec "$GARDEN_RUNTIME_DIR/venv/bin/python" -I "$GARDEN_INSTALL_ROOT/launcher.py" "\$@"
 EOF
   chmod 0755 "$launcher_path"
 }
+
+cat > "$GARDEN_INSTALL_ROOT/launcher.py" <<'PY'
+"""Garden 正式安装入口；隔离当前目录与 PYTHONPATH 后加载已安装包。"""
+
+import os
+
+from app.cli.main import app
+
+
+if __name__ == "__main__":
+    app(prog_name=os.environ.get("GARDEN_CLI_NAME", "garden"))
+PY
+chmod 0644 "$GARDEN_INSTALL_ROOT/launcher.py"
 
 write_launcher "$GARDEN_BIN_DIR/garden" "garden"
 write_launcher "$GARDEN_BIN_DIR/gardenctl" "gardenctl"

--- a/tests/test_evidence_service.py
+++ b/tests/test_evidence_service.py
@@ -26,6 +26,24 @@ def test_redaction_masks_sensitive_material() -> None:
     assert 'token":"supersecretvalue' not in redacted
 
 
+def test_http_header_redaction_preserves_safe_content_type_metadata() -> None:
+    service = RedactionService()
+
+    redacted = service.redact_http_headers(
+        {
+            "content-type": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            "set-cookie": "session=secret-value",
+        }
+    )
+
+    assert redacted["content-type"] == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert redacted["set-cookie"] == "***"
+
+
 def test_evidence_export_outputs_are_redacted(seeded_inventory, fake_evidence_service) -> None:
     check_service = CheckRunService(evidence_service=fake_evidence_service)
     with session_scope() as session:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -67,6 +67,12 @@ if [ "${1:-}" = "-m" ] && [ "${2:-}" = "app.cli.main" ]; then
   fi
   exit 0
 fi
+if [ "${1:-}" = "-I" ] && [ "$(basename "${2:-}")" = "launcher.py" ]; then
+  if [ "${3:-}" = "version" ] || [ "${3:-}" = "--version" ]; then
+    echo "Garden 0.1.0"
+  fi
+  exit 0
+fi
 exit 0
 """,
         encoding="utf-8",
@@ -141,3 +147,118 @@ def test_installed_launchers_survive_runtime_move(tmp_path):
     assert garden.stdout.strip() == "Garden 0.1.0"
     assert gardenctl.returncode == 0, gardenctl.stderr
     assert gardenctl.stdout.strip() == "Garden 0.1.0"
+
+
+def test_installer_discovers_usable_versioned_python_after_old_python3(tmp_path):
+    environment, _ = _fake_installer_environment(tmp_path)
+    fake_bin = Path(environment["PATH"].split(":", 1)[0])
+    usable_python = fake_bin / "python3.12"
+    (fake_bin / "python3").replace(usable_python)
+    old_python = fake_bin / "python3"
+    old_python.write_text(
+        """#!/bin/sh
+if [ "${1:-}" = "-" ]; then
+  exit 1
+fi
+exit 99
+""",
+        encoding="utf-8",
+    )
+    old_python.chmod(0o755)
+
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert installed.returncode == 0, installed.stderr
+    assert "python3.12" in installed.stdout
+
+
+def test_upgrade_migrates_legacy_installer_generated_public_target_policy(tmp_path):
+    environment, _ = _fake_installer_environment(tmp_path)
+    config_path = Path(environment["GARDEN_HOME"]) / "config.env"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """# Garden local demo defaults
+# Copy this file to .env for local development.
+# Safe-by-default guardrail: keep false for local/demo use only
+GARDEN_ALLOW_NON_LOCAL_TARGETS=false
+GARDEN_ALLOW_PRIVATE_TARGETS=false
+""",
+        encoding="utf-8",
+    )
+
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert installed.returncode == 0, installed.stderr
+    migrated = config_path.read_text(encoding="utf-8")
+    assert "GARDEN_ALLOW_NON_LOCAL_TARGETS=true" in migrated
+    assert "GARDEN_INSTALLER_MANAGED_CONFIG_VERSION=2" in migrated
+    assert "已迁移旧版自动生成的公网目标策略" in installed.stdout
+
+
+def test_upgrade_preserves_explicit_custom_local_only_policy(tmp_path):
+    environment, _ = _fake_installer_environment(tmp_path)
+    config_path = Path(environment["GARDEN_HOME"]) / "config.env"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "GARDEN_ALLOW_NON_LOCAL_TARGETS=false\nGARDEN_ALLOW_PRIVATE_TARGETS=false\n",
+        encoding="utf-8",
+    )
+
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert installed.returncode == 0, installed.stderr
+    assert "GARDEN_ALLOW_NON_LOCAL_TARGETS=false" in config_path.read_text(encoding="utf-8")
+
+
+def test_installed_launcher_does_not_use_module_mode_from_repository_cwd(tmp_path):
+    environment, bin_dir = _fake_installer_environment(tmp_path)
+    installed = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "install.sh")],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert installed.returncode == 0, installed.stderr
+
+    repository_cwd = tmp_path / "repository"
+    (repository_cwd / "app" / "cli").mkdir(parents=True)
+    (repository_cwd / "app" / "cli" / "main.py").write_text(
+        "raise RuntimeError('shadowed source tree')\n", encoding="utf-8"
+    )
+    launched = subprocess.run(
+        [str(bin_dir / "garden"), "version"],
+        cwd=repository_cwd,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert launched.returncode == 0, launched.stderr
+    assert launched.stdout.strip() == "Garden 0.1.0"
+    launcher = (bin_dir / "garden").read_text(encoding="utf-8")
+    assert "-m app.cli.main" not in launcher
+    assert "launcher.py" in launcher

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -13,7 +13,7 @@ from app.db.bootstrap import session_scope
 from app.models.scan_run import ScanAsset
 from app.schemas.scan import ScanOptions
 from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
-from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_network import MAX_RESPONSE_BYTES, HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_pipeline import ScanPipeline
 from app.services.scan_reporting import ScanReportService
 
@@ -383,6 +383,116 @@ def test_static_resources_use_metadata_summary_and_report_positive_controls(tmp_
     assert "source_map_reference" in report
     assert "secret-long-preview-marker" not in report
     assert ".secret-marker" not in report
+    assert "### 静态资源证据索引" in report
+    assert report.count("### E") == 1
+
+
+def test_collection_blocks_cross_origin_redirect_before_following_it(tmp_path) -> None:
+    calls = []
+
+    def handler(request):
+        calls.append((request.url.host, request.url.path))
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<a href="/redirect">Redirect</a>',
+            )
+        return httpx.Response(
+            302,
+            headers={"location": "http://other.example/final"},
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan(
+        "http://127.0.0.1/",
+        ScanOptions(max_pages=2, retry_attempts=0),
+    )
+
+    assert calls == [("127.0.0.1", "/"), ("127.0.0.1", "/redirect")]
+    assert scan.status == "completed_with_warnings"
+    assert any(failure.code == "cross_origin_redirect_blocked" for failure in scan.failures)
+
+
+def test_truncated_resource_is_labeled_as_a_collected_fragment(tmp_path) -> None:
+    oversized = b"x" * (MAX_RESPONSE_BYTES + 32)
+
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<script src="/large.js"></script>',
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/javascript"},
+            content=oversized,
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan(
+        "http://127.0.0.1/",
+        ScanOptions(max_pages=1, max_resources=1, retry_attempts=0),
+    )
+    report = service.read_report(scan.id)
+
+    assert "truncated=true" in report
+    assert "采集片段 SHA-256=" in report
+    assert f"size={MAX_RESPONSE_BYTES} bytes" in report
+
+
+def test_version_hints_require_context_and_include_version_query(tmp_path) -> None:
+    stylesheet = "path { d: 17.405 20.651 194.423; opacity: 0.18; }"
+
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<link rel="stylesheet" href="/style.css?v=1.0.0">',
+            )
+        return httpx.Response(200, headers={"content-type": "text/css"}, text=stylesheet)
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan(
+        "http://127.0.0.1/",
+        ScanOptions(max_pages=1, max_resources=1, retry_attempts=0),
+    )
+    report = service.read_report(scan.id)
+
+    assert "版本线索=1.0.0" in report
+    assert "17.405" not in report
+    assert "20.651" not in report
+    assert "0.18" not in report
+
+
+def test_report_uses_request_buckets_and_aggregates_repeated_findings(tmp_path) -> None:
+    def handler(request):
+        if request.url.path == "/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text='<a href="/about">About</a><script src="/html-script.js"></script>',
+            )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html"},
+            text="<html><title>Fixture</title></html>",
+        )
+
+    service = _service(tmp_path, handler)
+    scan = service.start_scan(
+        "http://127.0.0.1/",
+        ScanOptions(max_pages=2, max_resources=1, retry_attempts=0),
+    )
+    report = service.read_report(scan.id)
+
+    assert "页面队列 2/2，资源队列 1/1" in report
+    assert report.count("缺少 Content-Security-Policy 响应头") == 1
+    assert report.count("缺少 X-Content-Type-Options 响应头") == 1
+    assert "3 个资产" in report
+    assert "2 类（6 条原始观察）" in report
 
 
 def test_active_duplicate_submission_returns_same_parent_task(tmp_path) -> None:


### PR DESCRIPTION
## 变更内容

- 安装器自动发现可用的 Python 3.10+，支持版本化命令、常见 Homebrew 路径和显式 `GARDEN_PYTHON`
- 仅迁移可识别的旧安装器自动生成公网策略，保留用户明确自定义的 local-only 配置
- 正式 CLI 改用 Python 隔离模式和绝对 bootstrap，避免仓库源码或 `PYTHONPATH` 遮蔽已安装包
- 同源采集在跟随跨源重定向前阻断，并按唯一 URL 统计外部链接
- 持久化页面/资源请求预算桶，区分最终响应类型与调度预算；旧记录明确标注不可恢复的预算信息
- 标记 256 KiB 截断响应，截断资源仅报告采集片段哈希
- 收紧版本线索提取，避免把 CSS 数值和 SVG 坐标误判成版本
- 保留安全响应头元数据，避免长 MIME 类型被通用令牌脱敏破坏
- 报告按规则聚合重复发现，静态资源证据压缩为单行索引

## 根因

安装器硬编码首个 `python3`、对已有配置完全跳过处理，并通过 `python -m` 继承当前目录的模块搜索路径。报告侧把最终资产类型当作请求预算桶、对每个资产重复渲染同一规则，并且没有区分完整响应与限长采集片段。

## 用户影响

升级安装能复用机器上已有的 Python 3.12，旧版自动生成策略会迁移到当前公网默认值，从仓库目录运行正式命令也会稳定加载已安装版本。新报告的覆盖数字和哈希语义更准确，#12 的真实数据回放由 3540 行 / 293 KB 收敛到 1348 行 / 172 KB。

## 验证

- `202 passed in 45.36s`
- `ruff check app tests`
- `ruff format --check app tests`
- `bash -n install.sh`
- `git diff --check`
- 临时 HOME 下真实 Python 3.12 已完成解释器选择和项目 wheel 构建阶段；Playwright 42.5 MB wheel 因网络仅约 94 KB/s，在 21.2 MB 时主动中止，因此未把该次下载描述为完整安装成功