### PR TITLE
feat: 发布 v0.3.0 被动认证覆盖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium --no-shell
+
       - name: Ruff lint
         run: ruff check .
 
@@ -38,8 +41,6 @@ jobs:
         run: ruff format --check .
 
       - name: Run tests
-        # The suite uses Playwright contract/mocks, not a real browser,
-        # so no browser install step is needed here.
         run: pytest -q
 
   docker-build:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ garden stop                                   # 中断活动扫描并停止本�
 
 `gardenctl` 是兼容别名，既有命令组和 `gardenctl scan --url URL` 均继续可用。
 
+## 被动认证覆盖（高级工作流）
+
+默认入口仍是 quick scan；`garden scan`、首页单 URL 表单和 `/api/scans` 的交互没有改变。需要比较匿名、普通用户和管理员三个登录上下文时，才使用独立入口：
+
+```bash
+garden coverage URL
+```
+
+在交互式终端中，向导会按 assessment URL 的同源信息选择或创建 Target，再分别选择或创建角色精确为 `user` 和 `admin` 的凭据档案。新凭据的敏感值使用隐藏输入；原始值只写入权限为 `0600` 的短生命周期文件，档案只保存 `ephemeral-file://` 引用，并在会话建立与验证后删除该临时文件。密码、令牌和 Cookie 不会进入命令参数、普通数据库字段、日志或报告。
+
+自动化环境必须显式提供两个档案，缺少任一参数会立即失败而不会等待输入：
+
+```bash
+garden coverage https://app.example/ \
+  --user-profile 12 \
+  --admin-profile 13 \
+  --non-interactive
+```
+
+coverage 固定执行 `anonymous`、`user`、`admin` 三上下文的有界被动采集。主动权限重放未执行；报告中的覆盖差异不是已确认漏洞，需要结合业务授权模型复核。上下文失败或不完整时，未观察到的资产显示为 `unknown`，不会被误报为 `absent`。
+
 ## 仓库开发快速开始
 
 环境要求：Python 3.10+。
@@ -161,6 +182,8 @@ ScanReportService
 ```
 
 CLI、路由和页面模板只是适配层，核心业务流程位于应用服务和流水线中。单个阶段或页面失败会被持久化并显示在任务和报告中，不会静默伪装成完整结果。
+
+认证覆盖使用独立的 `start_assessment` / `execute_authenticated` 链路，在 quick 六阶段之外建立并比较固定三上下文；`garden scan` 仍使用原有 quick 链路。
 
 需要登录态、人工 triage、retest 或高级证据生命周期时，原有高级工作流仍然可用，但它们不是 URL 自动扫描的前置步骤。迁移说明见 [docs/legacy-cli-migration.md](docs/legacy-cli-migration.md)。
 

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from app.api.routes.assessments import router as assessments_router
 from app.api.routes.credentials import router as credentials_router
 from app.api.routes.demo_auth import router as demo_auth_router
 from app.api.routes.evidence import router as evidence_router
@@ -17,6 +18,7 @@ from app.api.routes.targets import router as targets_router
 api_router = APIRouter()
 api_router.include_router(pages_router)
 api_router.include_router(scans_router)
+api_router.include_router(assessments_router)
 api_router.include_router(targets_router)
 api_router.include_router(credentials_router)
 api_router.include_router(jobs_router)

--- a/app/api/routes/assessments.py
+++ b/app/api/routes/assessments.py
@@ -47,9 +47,9 @@ def assessment_report(
     assessment_id: int,
     download: bool = Query(default=False),
 ):
+    view = request.app.state.scan_service.get_assessment(assessment_id)
     report = request.app.state.scan_service.read_report(assessment_id)
     if download:
-        view = request.app.state.scan_service.get_assessment(assessment_id)
         return FileResponse(
             view.report_path,
             media_type="text/markdown; charset=utf-8",

--- a/app/api/routes/assessments.py
+++ b/app/api/routes/assessments.py
@@ -1,0 +1,58 @@
+"""Passive authenticated coverage HTTP adapters."""
+
+from fastapi import APIRouter, Query, Request, status
+from fastapi.responses import FileResponse, PlainTextResponse
+
+from app.schemas.assessment import (
+    AssessmentRunView,
+    CoverageDifferenceView,
+    PassiveCoverageStartRequest,
+)
+
+router = APIRouter(prefix="/api/assessments", tags=["assessments"])
+
+
+@router.post("", response_model=AssessmentRunView, status_code=status.HTTP_202_ACCEPTED)
+def start_assessment(
+    request: Request,
+    payload: PassiveCoverageStartRequest,
+) -> AssessmentRunView:
+    return request.app.state.scan_service.start_assessment(payload.to_assessment_request())
+
+
+@router.get("/{assessment_id}", response_model=AssessmentRunView)
+def get_assessment(request: Request, assessment_id: int) -> AssessmentRunView:
+    return request.app.state.scan_service.get_assessment(assessment_id)
+
+
+@router.get(
+    "/{assessment_id}/differences",
+    response_model=list[CoverageDifferenceView],
+)
+def list_differences(
+    request: Request,
+    assessment_id: int,
+) -> list[CoverageDifferenceView]:
+    return request.app.state.scan_service.list_coverage_differences(assessment_id)
+
+
+@router.post("/{assessment_id}/cancel", response_model=AssessmentRunView)
+def cancel_assessment(request: Request, assessment_id: int) -> AssessmentRunView:
+    return request.app.state.scan_service.cancel_assessment(assessment_id)
+
+
+@router.get("/{assessment_id}/report")
+def assessment_report(
+    request: Request,
+    assessment_id: int,
+    download: bool = Query(default=False),
+):
+    report = request.app.state.scan_service.read_report(assessment_id)
+    if download:
+        view = request.app.state.scan_service.get_assessment(assessment_id)
+        return FileResponse(
+            view.report_path,
+            media_type="text/markdown; charset=utf-8",
+            filename=f"garden-assessment-{assessment_id}.md",
+        )
+    return PlainTextResponse(report, media_type="text/markdown; charset=utf-8")

--- a/app/cli/coverage.py
+++ b/app/cli/coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from collections import Counter
 from typing import Annotated
@@ -17,6 +18,7 @@ from app.core.errors import GardenError
 from app.core.settings import get_settings
 from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES
 from app.schemas.assessment import AssessmentRunView, PassiveCoverageStartRequest
+from app.schemas.scan import ScanOptions
 
 
 class TyperCoveragePrompts:
@@ -47,6 +49,10 @@ class TyperCoveragePrompts:
         console.print(text, markup=False)
 
 
+def _is_interactive_terminal() -> bool:
+    return sys.stdin.isatty()
+
+
 def coverage(
     entry_url: Annotated[str, typer.Argument(help="已授权的 HTTP(S) 入口 URL。")],
     user_profile: Annotated[int | None, typer.Option("--user-profile", min=1)] = None,
@@ -57,6 +63,25 @@ def coverage(
     ] = False,
     detach: Annotated[bool, typer.Option("--detach", help="提交后立即返回。")] = False,
     ui_port: Annotated[int | None, typer.Option("--ui-port", min=1, max=65535)] = None,
+    source_run: Annotated[int | None, typer.Option("--source-run", min=1)] = None,
+    max_pages: Annotated[int, typer.Option("--max-pages", min=1, max=500)] = 50,
+    max_resources: Annotated[
+        int,
+        typer.Option("--max-resources", min=0, max=2000),
+    ] = 200,
+    max_depth: Annotated[int, typer.Option("--max-depth", min=0, max=5)] = 2,
+    request_timeout: Annotated[
+        float | None,
+        typer.Option("--request-timeout", min=0.1, max=60),
+    ] = None,
+    overall_timeout: Annotated[
+        float | None,
+        typer.Option("--overall-timeout", min=0.1, max=1800),
+    ] = None,
+    retry_attempts: Annotated[
+        int | None,
+        typer.Option("--retry-attempts", min=0, max=2),
+    ] = None,
 ) -> None:
     """引导并执行 anonymous/user/admin 三上下文的仅被动覆盖评估。"""
 
@@ -64,17 +89,31 @@ def coverage(
     result = None
     manager = None
     try:
+        options = ScanOptions(
+            max_pages=max_pages,
+            max_resources=max_resources,
+            max_depth=max_depth,
+            request_timeout_seconds=request_timeout,
+            overall_timeout_seconds=overall_timeout,
+            retry_attempts=retry_attempts,
+        )
         if non_interactive:
             if user_profile is None or admin_profile is None:
                 console.print("--non-interactive 必须同时提供 --user-profile 和 --admin-profile。")
                 raise typer.Exit(code=2)
             request = PassiveCoverageStartRequest(
                 url=entry_url,
+                source_run_id=source_run,
                 user_profile_id=user_profile,
                 admin_profile_id=admin_profile,
+                options=options,
             )
         else:
+            if not _is_interactive_terminal():
+                console.print("当前输入不是交互终端；请使用 --non-interactive 并提供两个档案 ID。")
+                raise typer.Exit(code=2)
             request = CoverageSetupWizard(prompts=TyperCoveragePrompts()).run(entry_url)
+            request = request.model_copy(update={"source_run_id": source_run, "options": options})
 
         manager = WebRuntimeManager(
             paths=GardenPaths.from_environment(),

--- a/app/cli/coverage.py
+++ b/app/cli/coverage.py
@@ -1,0 +1,150 @@
+"""Guided passive authenticated coverage command."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from typing import Annotated
+
+import typer
+
+from app.cli.coverage_wizard import CoverageSetupWizard, PromptChoice
+from app.cli.local_api import LocalScanApi
+from app.cli.paths import GardenPaths
+from app.cli.utils import console, handle_cli_error, render_key_value
+from app.cli.web_runtime import WebRuntimeError, WebRuntimeManager
+from app.core.errors import GardenError
+from app.core.settings import get_settings
+from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES
+from app.schemas.assessment import AssessmentRunView, PassiveCoverageStartRequest
+
+
+class TyperCoveragePrompts:
+    """Small prompt adapter that keeps all sensitive input hidden."""
+
+    def choose(self, label: str, choices: list[PromptChoice]) -> str:
+        console.print(f"\n[bold]{label}[/bold]")
+        for index, choice in enumerate(choices, start=1):
+            console.print(f"  {index}. {choice.label}", markup=False)
+        while True:
+            selected = typer.prompt("请输入序号", type=int, default=1)
+            if 1 <= selected <= len(choices):
+                return choices[selected - 1].value
+            console.print(f"请输入 1 到 {len(choices)} 之间的序号。")
+
+    def confirm(self, label: str, *, default: bool = True) -> bool:
+        return typer.confirm(label, default=default)
+
+    def text(self, label: str, *, default: str | None = None) -> str:
+        if default is None:
+            return typer.prompt(label)
+        return typer.prompt(label, default=default)
+
+    def secret(self, label: str) -> str:
+        return typer.prompt(label, hide_input=True)
+
+    def write(self, text: str) -> None:
+        console.print(text, markup=False)
+
+
+def coverage(
+    entry_url: Annotated[str, typer.Argument(help="已授权的 HTTP(S) 入口 URL。")],
+    user_profile: Annotated[int | None, typer.Option("--user-profile", min=1)] = None,
+    admin_profile: Annotated[int | None, typer.Option("--admin-profile", min=1)] = None,
+    non_interactive: Annotated[
+        bool,
+        typer.Option("--non-interactive", help="跳过向导；必须显式提供两个档案 ID。"),
+    ] = False,
+    detach: Annotated[bool, typer.Option("--detach", help="提交后立即返回。")] = False,
+    ui_port: Annotated[int | None, typer.Option("--ui-port", min=1, max=65535)] = None,
+) -> None:
+    """引导并执行 anonymous/user/admin 三上下文的仅被动覆盖评估。"""
+
+    api = None
+    result = None
+    manager = None
+    try:
+        if non_interactive:
+            if user_profile is None or admin_profile is None:
+                console.print("--non-interactive 必须同时提供 --user-profile 和 --admin-profile。")
+                raise typer.Exit(code=2)
+            request = PassiveCoverageStartRequest(
+                url=entry_url,
+                user_profile_id=user_profile,
+                admin_profile_id=admin_profile,
+            )
+        else:
+            request = CoverageSetupWizard(prompts=TyperCoveragePrompts()).run(entry_url)
+
+        manager = WebRuntimeManager(
+            paths=GardenPaths.from_environment(),
+            default_port=get_settings().api_port,
+        )
+        runtime = manager.ensure(ui_port=ui_port)
+        api = LocalScanApi(runtime.base_url)
+        result = api.start_assessment(request)
+        console.print(f"Web UI：{runtime.base_url}")
+        console.print(f"认证覆盖状态：{runtime.base_url}/api/assessments/{result.id}")
+        console.print("模式：仅被动三上下文覆盖；不执行主动权限重放。")
+        if detach:
+            console.print(f"认证覆盖评估 {result.id} 已后台提交。")
+            return
+        result = _wait_for_assessment(api, result)
+        differences = api.list_coverage_differences(result.id)
+        _print_result(result, differences)
+        if result.status == "failed":
+            raise typer.Exit(code=1)
+    except KeyboardInterrupt:
+        if api is not None and result is not None and manager is not None:
+            _cancel_from_interrupt(api, result.id, manager)
+        raise typer.Exit(code=130) from None
+    except (GardenError, WebRuntimeError) as error:
+        handle_cli_error(error)
+
+
+def _wait_for_assessment(api: LocalScanApi, initial: AssessmentRunView) -> AssessmentRunView:
+    result = initial
+    shown: tuple[str, int] | None = None
+    while result.status not in TERMINAL_SCAN_RUN_STATUSES:
+        progress = (result.current_stage, result.progress)
+        if progress != shown:
+            console.print(f"认证覆盖 {result.id}：{result.current_stage}，{result.progress}%")
+            shown = progress
+        time.sleep(0.2)
+        result = api.get_assessment(result.id)
+    return result
+
+
+def _print_result(result, differences) -> None:
+    render_key_value(
+        [
+            ("认证覆盖", str(result.id)),
+            ("状态", result.status),
+            ("完整性", result.completeness),
+            ("报告", result.report_path or "未生成"),
+        ],
+        title="Garden 认证覆盖结果",
+    )
+    console.print("三上下文：")
+    for context in result.contexts:
+        console.print(
+            f"- {context.kind.value}: {context.status} / {context.collection_status}",
+            markup=False,
+        )
+    counts = Counter(item.classification for item in differences)
+    console.print("覆盖分类：")
+    if not counts:
+        console.print("- 暂无差异")
+    for classification, count in sorted(counts.items()):
+        console.print(f"- {classification}: {count}", markup=False)
+
+
+def _cancel_from_interrupt(api, assessment_id, manager) -> None:
+    try:
+        api.cancel_assessment(assessment_id)
+    except Exception:  # noqa: BLE001 - Ctrl+C 必须在有限时间内退出
+        pass
+    if manager.started_by_this_command:
+        manager.stop()
+    console.print("认证覆盖评估已中断。")
+    raise typer.Exit(code=130)

--- a/app/cli/coverage.py
+++ b/app/cli/coverage.py
@@ -80,7 +80,7 @@ def coverage(
     ] = None,
     retry_attempts: Annotated[
         int | None,
-        typer.Option("--retry-attempts", min=0, max=2),
+        typer.Option("--retries", min=0, max=2),
     ] = None,
 ) -> None:
     """引导并执行 anonymous/user/admin 三上下文的仅被动覆盖评估。"""
@@ -88,6 +88,8 @@ def coverage(
     api = None
     result = None
     manager = None
+    wizard = None
+    submission_started = False
     try:
         options = ScanOptions(
             max_pages=max_pages,
@@ -112,7 +114,8 @@ def coverage(
             if not _is_interactive_terminal():
                 console.print("当前输入不是交互终端；请使用 --non-interactive 并提供两个档案 ID。")
                 raise typer.Exit(code=2)
-            request = CoverageSetupWizard(prompts=TyperCoveragePrompts()).run(entry_url)
+            wizard = CoverageSetupWizard(prompts=TyperCoveragePrompts())
+            request = wizard.run(entry_url)
             request = request.model_copy(update={"source_run_id": source_run, "options": options})
 
         manager = WebRuntimeManager(
@@ -121,6 +124,7 @@ def coverage(
         )
         runtime = manager.ensure(ui_port=ui_port)
         api = LocalScanApi(runtime.base_url)
+        submission_started = True
         result = api.start_assessment(request)
         console.print(f"Web UI：{runtime.base_url}")
         console.print(f"认证覆盖状态：{runtime.base_url}/api/assessments/{result.id}")
@@ -136,18 +140,50 @@ def coverage(
     except KeyboardInterrupt:
         if api is not None and result is not None and manager is not None:
             _cancel_from_interrupt(api, result.id, manager)
+        if wizard is not None and not submission_started:
+            wizard.cleanup_unsubmitted_secrets()
         raise typer.Exit(code=130) from None
     except (GardenError, WebRuntimeError) as error:
+        if wizard is not None and not submission_started:
+            wizard.cleanup_unsubmitted_secrets()
         handle_cli_error(error)
 
 
 def _wait_for_assessment(api: LocalScanApi, initial: AssessmentRunView) -> AssessmentRunView:
     result = initial
-    shown: tuple[str, int] | None = None
+    shown: tuple[object, ...] | None = None
     while result.status not in TERMINAL_SCAN_RUN_STATUSES:
-        progress = (result.current_stage, result.progress)
+        context_health = tuple(
+            (
+                context.kind.value,
+                context.status,
+                context.login_status,
+                context.session_validation_status,
+                context.collection_status,
+            )
+            for context in result.contexts
+        )
+        comparison_status = next(
+            (stage.status for stage in result.stages if stage.name == "compare_coverage"),
+            "pending",
+        )
+        progress = (
+            result.current_stage,
+            result.progress,
+            context_health,
+            comparison_status,
+        )
         if progress != shown:
-            console.print(f"认证覆盖 {result.id}：{result.current_stage}，{result.progress}%")
+            console.print(
+                f"认证覆盖 {result.id}：{result.current_stage}，{result.progress}%"
+                f"，比较={comparison_status}"
+            )
+            for kind, status, login, validation, collection in context_health:
+                console.print(
+                    f"  - {kind}: 状态={status}，登录={login}，"
+                    f"验证={validation}，采集={collection}",
+                    markup=False,
+                )
             shown = progress
         time.sleep(0.2)
         result = api.get_assessment(result.id)
@@ -167,7 +203,8 @@ def _print_result(result, differences) -> None:
     console.print("三上下文：")
     for context in result.contexts:
         console.print(
-            f"- {context.kind.value}: {context.status} / {context.collection_status}",
+            f"- {context.kind.value}: 状态={context.status}，登录={context.login_status}，"
+            f"验证={context.session_validation_status}，采集={context.collection_status}",
             markup=False,
         )
     counts = Counter(item.classification for item in differences)

--- a/app/cli/coverage_wizard.py
+++ b/app/cli/coverage_wizard.py
@@ -8,7 +8,7 @@ from typing import Protocol
 from urllib.parse import urljoin, urlparse
 
 from app.cli.paths import formal_runtime_paths
-from app.core.errors import InputValidationError
+from app.core.errors import GardenError, InputValidationError
 from app.db.bootstrap import session_scope
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import AuthType, TargetType
@@ -19,6 +19,8 @@ from app.schemas.target import TargetCreate
 from app.services.credentials import CredentialProfileService
 from app.services.ephemeral_secret_store import EphemeralSecretStore
 from app.services.login_configs import LoginConfigService, encode_inline_login_config
+from app.services.secret_resolver import SecretResolver
+from app.services.sessions import AuthSessionService
 from app.services.targets import TargetService
 
 
@@ -50,6 +52,7 @@ class CoverageSetupWizard:
         target_service: TargetService | None = None,
         credential_service: CredentialProfileService | None = None,
         login_config_service: LoginConfigService | None = None,
+        auth_session_service: AuthSessionService | None = None,
         secret_store: EphemeralSecretStore | None = None,
         session_factory=session_scope,
     ) -> None:
@@ -58,7 +61,11 @@ class CoverageSetupWizard:
         self.credential_service = credential_service or CredentialProfileService()
         self.login_config_service = login_config_service or LoginConfigService()
         self.secret_store = secret_store or EphemeralSecretStore(self._default_secret_root())
+        self.auth_session_service = auth_session_service or AuthSessionService(
+            secret_resolver=SecretResolver(ephemeral_store=self.secret_store)
+        )
         self.session_factory = session_factory
+        self._unsubmitted_secret_refs: tuple[str, ...] = ()
 
     def run(self, entry_url: str) -> PassiveCoverageStartRequest:
         entry_origin = self._origin(entry_url)
@@ -83,16 +90,23 @@ class CoverageSetupWizard:
                 )
                 if not self.prompts.confirm("提交认证覆盖任务？", default=True):
                     raise InputValidationError("已取消认证覆盖任务。")
-                return PassiveCoverageStartRequest(
+                request = PassiveCoverageStartRequest(
                     url=entry_url,
                     target_id=target.id,
                     user_profile_id=user.id,
                     admin_profile_id=admin.id,
                 )
-        except Exception:
+                self._unsubmitted_secret_refs = tuple(draft_secret_refs)
+                return request
+        except BaseException:
             for reference in draft_secret_refs:
                 self.secret_store.delete(reference)
             raise
+
+    def cleanup_unsubmitted_secrets(self) -> None:
+        for reference in self._unsubmitted_secret_refs:
+            self.secret_store.delete(reference)
+        self._unsubmitted_secret_refs = ()
 
     def _select_or_create_target(
         self,
@@ -122,7 +136,10 @@ class CoverageSetupWizard:
         selected = self.prompts.choose(
             "选择同源 Target",
             [
-                PromptChoice(value=str(target.id), label=f"#{target.id} {target.name}")
+                PromptChoice(
+                    value=str(target.id),
+                    label=f"#{target.id} {target.name}（owner: {target.owner}）",
+                )
                 for target in targets
             ],
         )
@@ -156,7 +173,12 @@ class CoverageSetupWizard:
         if profiles:
             selected = self._select_profile_or_create(profiles, role)
             if selected is not None:
-                return self._prepare_existing_profile(selected, role, draft_secret_refs)
+                return self._prepare_existing_profile(
+                    session,
+                    selected,
+                    role,
+                    draft_secret_refs,
+                )
         elif not self.prompts.confirm(
             f"没有 role={role} 的凭据档案，立即创建？",
             default=True,
@@ -202,6 +224,7 @@ class CoverageSetupWizard:
 
     def _prepare_existing_profile(
         self,
+        session,
         profile: CredentialProfile,
         role: str,
         draft_secret_refs: list[str],
@@ -213,6 +236,11 @@ class CoverageSetupWizard:
             if self.secret_store.path_for(profile.secret_ref).exists():
                 return profile
         except InputValidationError:
+            pass
+        try:
+            self.auth_session_service.ensure_valid_for_profile(session, profile.id)
+            return profile
+        except GardenError:
             pass
         secret = self.prompts.secret(f"{role} 密码已过期，请重新输入（输入已隐藏）")
         reference = self.secret_store.write(secret)

--- a/app/cli/coverage_wizard.py
+++ b/app/cli/coverage_wizard.py
@@ -1,0 +1,222 @@
+"""Guided setup for passive authenticated coverage runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urljoin, urlparse
+
+from app.cli.paths import formal_runtime_paths
+from app.core.errors import InputValidationError
+from app.db.bootstrap import session_scope
+from app.models.credential_profile import CredentialProfile
+from app.models.enums import AuthType, TargetType
+from app.models.target import Target
+from app.schemas.assessment import PassiveCoverageStartRequest
+from app.schemas.credential import CredentialProfileCreate
+from app.schemas.target import TargetCreate
+from app.services.credentials import CredentialProfileService
+from app.services.ephemeral_secret_store import EphemeralSecretStore
+from app.services.login_configs import encode_inline_login_config
+from app.services.targets import TargetService
+
+
+@dataclass(frozen=True)
+class PromptChoice:
+    value: str
+    label: str
+
+
+class CoveragePrompts(Protocol):
+    def choose(self, label: str, choices: list[PromptChoice]) -> str: ...
+
+    def confirm(self, label: str, *, default: bool = True) -> bool: ...
+
+    def text(self, label: str, *, default: str | None = None) -> str: ...
+
+    def secret(self, label: str) -> str: ...
+
+    def write(self, text: str) -> None: ...
+
+
+class CoverageSetupWizard:
+    """Select same-origin target and exact fixed-role credential profiles."""
+
+    def __init__(
+        self,
+        *,
+        prompts: CoveragePrompts,
+        target_service: TargetService | None = None,
+        credential_service: CredentialProfileService | None = None,
+        secret_store: EphemeralSecretStore | None = None,
+        session_factory=session_scope,
+    ) -> None:
+        self.prompts = prompts
+        self.target_service = target_service or TargetService()
+        self.credential_service = credential_service or CredentialProfileService()
+        self.secret_store = secret_store or EphemeralSecretStore(self._default_secret_root())
+        self.session_factory = session_factory
+
+    def run(self, entry_url: str) -> PassiveCoverageStartRequest:
+        entry_origin = self._origin(entry_url)
+        draft_secret_refs: list[str] = []
+        self.secret_store.purge_expired()
+        try:
+            with self.session_factory() as session:
+                targets = [
+                    target
+                    for target in self.target_service.list(session)
+                    if self._origin(target.base_url) == entry_origin
+                ]
+                target = self._select_or_create_target(session, entry_url, targets)
+                user = self._select_or_create_profile(session, target, "user", draft_secret_refs)
+                admin = self._select_or_create_profile(session, target, "admin", draft_secret_refs)
+                self.prompts.write(
+                    "\n认证覆盖配置摘要\n"
+                    f"Target: #{target.id} {target.name}\n"
+                    f"user: #{user.id} {user.name}\n"
+                    f"admin: #{admin.id} {admin.name}\n"
+                    "模式: 仅被动采集\n"
+                )
+                if not self.prompts.confirm("提交认证覆盖任务？", default=True):
+                    raise InputValidationError("已取消认证覆盖任务。")
+                return PassiveCoverageStartRequest(
+                    url=entry_url,
+                    target_id=target.id,
+                    user_profile_id=user.id,
+                    admin_profile_id=admin.id,
+                )
+        except Exception:
+            for reference in draft_secret_refs:
+                self.secret_store.delete(reference)
+            raise
+
+    def _select_or_create_target(
+        self,
+        session,
+        entry_url: str,
+        targets: list[Target],
+    ) -> Target:
+        if targets:
+            return self._select_target(targets)
+        if not self.prompts.confirm("没有同源 Target，立即创建？", default=True):
+            raise InputValidationError("没有与入口 URL 同源的 Target。")
+        name = self.prompts.text("Target 名称", default=urlparse(entry_url).hostname)
+        owner = self.prompts.text("Target 负责人", default="local-user")
+        return self.target_service.create(
+            session,
+            TargetCreate(
+                name=name,
+                base_url=self._origin_base_url(entry_url),
+                type=TargetType.WEB,
+                owner=owner,
+            ),
+        )
+
+    def _select_target(self, targets: list[Target]) -> Target:
+        if not targets:
+            raise InputValidationError("没有与入口 URL 同源的 Target。")
+        selected = self.prompts.choose(
+            "选择同源 Target",
+            [
+                PromptChoice(value=str(target.id), label=f"#{target.id} {target.name}")
+                for target in targets
+            ],
+        )
+        return next(target for target in targets if str(target.id) == selected)
+
+    def _select_profile(self, session, target: Target, role: str) -> CredentialProfile:
+        profiles = self.credential_service.list_for_target_role(session, target.id, role)
+        if not profiles:
+            raise InputValidationError(f"Target #{target.id} 没有 role={role} 的凭据档案。")
+        selected = self.prompts.choose(
+            f"选择 {role} 凭据档案",
+            [
+                PromptChoice(value=str(profile.id), label=f"#{profile.id} {profile.name}")
+                for profile in profiles
+            ],
+        )
+        return next(profile for profile in profiles if str(profile.id) == selected)
+
+    def _select_or_create_profile(
+        self,
+        session,
+        target: Target,
+        role: str,
+        draft_secret_refs: list[str],
+    ) -> CredentialProfile:
+        profiles = self.credential_service.list_for_target_role(session, target.id, role)
+        if profiles:
+            return self._select_profile(session, target, role)
+        if not self.prompts.confirm(f"没有 role={role} 的凭据档案，立即创建？", default=True):
+            raise InputValidationError(f"Target #{target.id} 没有 role={role} 的凭据档案。")
+
+        name = self.prompts.text(f"{role} 档案名称", default=f"{target.name}-{role}")
+        login_url = self._same_origin_url(
+            target.base_url,
+            self.prompts.text(f"{role} 登录地址", default="/login"),
+        )
+        validate_url = self._same_origin_url(
+            target.base_url,
+            self.prompts.text(f"{role} 登录后验证地址", default="/"),
+        )
+        username = self.prompts.text(f"{role} 用户名")
+        secret = self.prompts.secret(f"{role} 密码（输入已隐藏）")
+        reference = self.secret_store.write(secret)
+        draft_secret_refs.append(reference)
+        login_config = encode_inline_login_config(
+            {
+                "adapter": "playwright",
+                "login_url": login_url,
+                "validate_url": validate_url,
+                "username_selector": "auto",
+                "password_selector": "auto",
+                "submit_selector": "auto",
+                "auto_detect_selectors": True,
+            }
+        )
+        return self.credential_service.create(
+            session,
+            CredentialProfileCreate(
+                target_id=target.id,
+                name=name,
+                role=role,
+                auth_type=AuthType.PASSWORD,
+                username=username,
+                secret_ref=reference,
+                login_config_path=login_config,
+            ),
+        )
+
+    def _same_origin_url(self, base_url: str, value: str) -> str:
+        candidate = urljoin(f"{base_url.rstrip('/')}/", value.strip())
+        if self._origin(candidate) != self._origin(base_url):
+            raise InputValidationError("登录与验证地址必须和 Target 同源。")
+        return candidate
+
+    def _origin_base_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        origin = self._origin(url)
+        host = (
+            f"[{parsed.hostname}]"
+            if parsed.hostname and ":" in parsed.hostname
+            else parsed.hostname
+        )
+        default_port = 443 if origin[0] == "https" else 80
+        port = f":{origin[2]}" if origin[2] != default_port else ""
+        return f"{origin[0]}://{host}{port}"
+
+    def _default_secret_root(self) -> Path:
+        paths = formal_runtime_paths()
+        return paths.secrets_dir if paths is not None else Path.cwd() / "data/ephemeral-secrets"
+
+    def _origin(self, url: str) -> tuple[str, str, int]:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise InputValidationError("coverage 入口必须是有效 HTTP(S) URL。")
+        try:
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        except ValueError as error:
+            raise InputValidationError("coverage 入口端口无效。") from error
+        return parsed.scheme.lower(), parsed.hostname.lower(), port

--- a/app/cli/coverage_wizard.py
+++ b/app/cli/coverage_wizard.py
@@ -14,6 +14,7 @@ from app.models.credential_profile import CredentialProfile
 from app.models.enums import AuthType, TargetType
 from app.models.target import Target
 from app.schemas.assessment import PassiveCoverageStartRequest
+from app.schemas.auth import HttpLoginConfig, PlaywrightLoginConfig
 from app.schemas.credential import CredentialProfileCreate
 from app.schemas.target import TargetCreate
 from app.services.credentials import CredentialProfileService
@@ -175,6 +176,7 @@ class CoverageSetupWizard:
             if selected is not None:
                 return self._prepare_existing_profile(
                     session,
+                    target,
                     selected,
                     role,
                     draft_secret_refs,
@@ -225,11 +227,13 @@ class CoverageSetupWizard:
     def _prepare_existing_profile(
         self,
         session,
+        target: Target,
         profile: CredentialProfile,
         role: str,
         draft_secret_refs: list[str],
     ) -> CredentialProfile:
-        self.login_config_service.load(profile.login_config_path)
+        config = self.login_config_service.load(profile.login_config_path)
+        self._validate_login_config_origin(target, config)
         if not profile.secret_ref.startswith("ephemeral-file://"):
             return profile
         try:
@@ -247,6 +251,26 @@ class CoverageSetupWizard:
         draft_secret_refs.append(reference)
         profile.secret_ref = reference
         return profile
+
+    def _validate_login_config_origin(
+        self,
+        target: Target,
+        config: HttpLoginConfig | PlaywrightLoginConfig,
+    ) -> None:
+        if isinstance(config, PlaywrightLoginConfig):
+            configured_urls = (config.login_url, config.validate_url)
+        else:
+            configured_urls = tuple(
+                request.url
+                for request in (
+                    config.login_request,
+                    config.validate_request,
+                    config.refresh_request,
+                )
+                if request is not None
+            )
+        for configured_url in configured_urls:
+            self._same_origin_url(target.base_url, configured_url)
 
     def _same_origin_url(self, base_url: str, value: str) -> str:
         candidate = urljoin(f"{base_url.rstrip('/')}/", value.strip())

--- a/app/cli/coverage_wizard.py
+++ b/app/cli/coverage_wizard.py
@@ -18,7 +18,7 @@ from app.schemas.credential import CredentialProfileCreate
 from app.schemas.target import TargetCreate
 from app.services.credentials import CredentialProfileService
 from app.services.ephemeral_secret_store import EphemeralSecretStore
-from app.services.login_configs import encode_inline_login_config
+from app.services.login_configs import LoginConfigService, encode_inline_login_config
 from app.services.targets import TargetService
 
 
@@ -49,12 +49,14 @@ class CoverageSetupWizard:
         prompts: CoveragePrompts,
         target_service: TargetService | None = None,
         credential_service: CredentialProfileService | None = None,
+        login_config_service: LoginConfigService | None = None,
         secret_store: EphemeralSecretStore | None = None,
         session_factory=session_scope,
     ) -> None:
         self.prompts = prompts
         self.target_service = target_service or TargetService()
         self.credential_service = credential_service or CredentialProfileService()
+        self.login_config_service = login_config_service or LoginConfigService()
         self.secret_store = secret_store or EphemeralSecretStore(self._default_secret_root())
         self.session_factory = session_factory
 
@@ -103,7 +105,7 @@ class CoverageSetupWizard:
         if not self.prompts.confirm("没有同源 Target，立即创建？", default=True):
             raise InputValidationError("没有与入口 URL 同源的 Target。")
         name = self.prompts.text("Target 名称", default=urlparse(entry_url).hostname)
-        owner = self.prompts.text("Target 负责人", default="local-user")
+        owner = self.prompts.text("Target 负责人（用于资产归属）", default="local-user")
         return self.target_service.create(
             session,
             TargetCreate(
@@ -126,17 +128,21 @@ class CoverageSetupWizard:
         )
         return next(target for target in targets if str(target.id) == selected)
 
-    def _select_profile(self, session, target: Target, role: str) -> CredentialProfile:
-        profiles = self.credential_service.list_for_target_role(session, target.id, role)
-        if not profiles:
-            raise InputValidationError(f"Target #{target.id} 没有 role={role} 的凭据档案。")
+    def _select_profile_or_create(
+        self,
+        profiles: list[CredentialProfile],
+        role: str,
+    ) -> CredentialProfile | None:
         selected = self.prompts.choose(
             f"选择 {role} 凭据档案",
             [
                 PromptChoice(value=str(profile.id), label=f"#{profile.id} {profile.name}")
                 for profile in profiles
-            ],
+            ]
+            + [PromptChoice(value="__create__", label=f"创建新的 {role} 凭据档案")],
         )
+        if selected == "__create__":
+            return None
         return next(profile for profile in profiles if str(profile.id) == selected)
 
     def _select_or_create_profile(
@@ -148,8 +154,13 @@ class CoverageSetupWizard:
     ) -> CredentialProfile:
         profiles = self.credential_service.list_for_target_role(session, target.id, role)
         if profiles:
-            return self._select_profile(session, target, role)
-        if not self.prompts.confirm(f"没有 role={role} 的凭据档案，立即创建？", default=True):
+            selected = self._select_profile_or_create(profiles, role)
+            if selected is not None:
+                return self._prepare_existing_profile(selected, role, draft_secret_refs)
+        elif not self.prompts.confirm(
+            f"没有 role={role} 的凭据档案，立即创建？",
+            default=True,
+        ):
             raise InputValidationError(f"Target #{target.id} 没有 role={role} 的凭据档案。")
 
         name = self.prompts.text(f"{role} 档案名称", default=f"{target.name}-{role}")
@@ -188,6 +199,26 @@ class CoverageSetupWizard:
                 login_config_path=login_config,
             ),
         )
+
+    def _prepare_existing_profile(
+        self,
+        profile: CredentialProfile,
+        role: str,
+        draft_secret_refs: list[str],
+    ) -> CredentialProfile:
+        self.login_config_service.load(profile.login_config_path)
+        if not profile.secret_ref.startswith("ephemeral-file://"):
+            return profile
+        try:
+            if self.secret_store.path_for(profile.secret_ref).exists():
+                return profile
+        except InputValidationError:
+            pass
+        secret = self.prompts.secret(f"{role} 密码已过期，请重新输入（输入已隐藏）")
+        reference = self.secret_store.write(secret)
+        draft_secret_refs.append(reference)
+        profile.secret_ref = reference
+        return profile
 
     def _same_origin_url(self, base_url: str, value: str) -> str:
         candidate = urljoin(f"{base_url.rstrip('/')}/", value.strip())

--- a/app/cli/local_api.py
+++ b/app/cli/local_api.py
@@ -7,6 +7,11 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from app.core.errors import GardenError
+from app.schemas.assessment import (
+    AssessmentRunView,
+    CoverageDifferenceView,
+    PassiveCoverageStartRequest,
+)
 from app.schemas.scan import ScanOptions, ScanRunView
 
 
@@ -29,9 +34,43 @@ class LocalScanApi:
     def cancel_scan(self, scan_run_id: int) -> ScanRunView:
         return self._scan_request("POST", f"/api/scans/{scan_run_id}/cancel")
 
+    def start_assessment(
+        self,
+        request: PassiveCoverageStartRequest,
+    ) -> AssessmentRunView:
+        payload = request.model_dump(exclude_none=True)
+        return AssessmentRunView.model_validate(
+            self._request_json("POST", "/api/assessments", payload)
+        )
+
+    def get_assessment(self, assessment_id: int) -> AssessmentRunView:
+        return AssessmentRunView.model_validate(
+            self._request_json("GET", f"/api/assessments/{assessment_id}")
+        )
+
+    def cancel_assessment(self, assessment_id: int) -> AssessmentRunView:
+        return AssessmentRunView.model_validate(
+            self._request_json("POST", f"/api/assessments/{assessment_id}/cancel")
+        )
+
+    def list_coverage_differences(
+        self,
+        assessment_id: int,
+    ) -> list[CoverageDifferenceView]:
+        payload = self._request_json("GET", f"/api/assessments/{assessment_id}/differences")
+        return [CoverageDifferenceView.model_validate(item) for item in payload]
+
     def _scan_request(
         self, method: str, path: str, payload: dict[str, object] | None = None
     ) -> ScanRunView:
+        return ScanRunView.model_validate(self._request_json(method, path, payload))
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ):
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
         request = Request(
             f"{self.base_url}{path}",
@@ -41,7 +80,7 @@ class LocalScanApi:
         )
         try:
             with urlopen(request, timeout=5) as response:  # noqa: S310 - loopback URL only
-                return ScanRunView.model_validate(json.loads(response.read()))
+                return json.loads(response.read())
         except HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
             raise LocalApiError(f"本机 Garden Web UI 返回 HTTP {error.code}: {detail}") from error

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -7,6 +7,7 @@ import typer
 
 from app.cli.baseline import app as baseline_app
 from app.cli.checks import app as checks_app
+from app.cli.coverage import coverage as coverage_command
 from app.cli.credentials import app as credential_app
 from app.cli.database import app as database_app
 from app.cli.evidence import app as evidence_app
@@ -70,6 +71,7 @@ def healthcheck() -> None:
 
 
 app.command("scan")(scan_command)
+app.command("coverage")(coverage_command)
 app.command("stop")(stop_command)
 app.add_typer(target_app, name="target")
 app.add_typer(credential_app, name="cred")

--- a/app/cli/paths.py
+++ b/app/cli/paths.py
@@ -48,6 +48,10 @@ class GardenPaths:
         return self.home / "runtime"
 
     @property
+    def secrets_dir(self) -> Path:
+        return self.runtime_dir / "secrets"
+
+    @property
     def server_state_file(self) -> Path:
         return self.runtime_dir / "server.json"
 
@@ -68,6 +72,8 @@ class GardenPaths:
             self.runtime_dir,
         ):
             directory.mkdir(parents=True, exist_ok=True)
+        self.secrets_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.secrets_dir.chmod(0o700)
 
 
 def formal_runtime_paths() -> GardenPaths | None:

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -29,6 +29,14 @@ class ConflictError(GardenError):
     """Raised when an operation conflicts with current persisted state."""
 
 
+class OverallScanTimeout(RuntimeError):
+    """Control-flow signal raised when an assessment exhausts its overall deadline."""
+
+
+class ScanInterrupted(RuntimeError):
+    """Control-flow signal raised when persisted cancellation is observed."""
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(ResourceNotFoundError)
     async def handle_not_found_error(request: Request, exc: ResourceNotFoundError) -> JSONResponse:

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -21,7 +21,7 @@ def _default_database_url() -> str:
 
 class Settings(BaseSettings):
     project_name: str = Field(default="Garden", alias="GARDEN_PROJECT_NAME")
-    project_version: str = Field(default="0.2.0", alias="GARDEN_PROJECT_VERSION")
+    project_version: str = Field(default="0.3.0", alias="GARDEN_PROJECT_VERSION")
     environment: str = Field(default="development", alias="GARDEN_ENVIRONMENT")
     log_level: str = Field(default="INFO", alias="GARDEN_LOG_LEVEL")
     api_host: str = Field(default="127.0.0.1", alias="GARDEN_API_HOST")

--- a/app/integrations/auth/http_adapter.py
+++ b/app/integrations/auth/http_adapter.py
@@ -9,6 +9,8 @@ from urllib.parse import urljoin
 
 import httpx
 
+from app.core.errors import TargetPolicyError
+from app.core.settings import get_settings
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import LoginFailureReason, SessionStatus
 from app.models.target import Target
@@ -19,6 +21,8 @@ from app.schemas.auth import (
     LoginExecutionResult,
     SessionValidationResult,
 )
+from app.services.authenticated_network import AuthenticatedNetworkGuard
+from app.services.scan_network import TargetNetworkPolicy
 
 _TEMPLATE_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
 
@@ -26,8 +30,16 @@ _TEMPLATE_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
 class HttpLoginAdapter:
     adapter_name = "http"
 
-    def __init__(self, *, transport: httpx.BaseTransport | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        policy: TargetNetworkPolicy | None = None,
+    ) -> None:
         self.transport = transport
+        self.network_guard = AuthenticatedNetworkGuard(
+            policy or TargetNetworkPolicy(get_settings())
+        )
 
     def login(
         self,
@@ -40,7 +52,9 @@ class HttpLoginAdapter:
         last_exception: Exception | None = None
         for _ in range(config.retry_attempts):
             try:
-                with self._build_client(timeout=config.request_timeout_seconds) as client:
+                with self._build_client(
+                    timeout=config.request_timeout_seconds, target=target
+                ) as client:
                     response = self._send_request(client, target, config.login_request, context)
                     if response.status_code in {401, 403}:
                         return self._failure(
@@ -91,6 +105,14 @@ class HttpLoginAdapter:
                         session_metadata_redacted=redact_session_metadata(metadata),
                         storage_payload={"cookies": cookie_payload},
                     )
+            except TargetPolicyError as error:
+                return self._failure(
+                    target,
+                    credential_profile,
+                    LoginFailureReason.CONFIG_ERROR,
+                    "HTTP login was blocked by the authenticated target boundary.",
+                    last_error=str(error),
+                )
             except httpx.HTTPError as error:
                 last_exception = error
         return self._failure(
@@ -112,6 +134,7 @@ class HttpLoginAdapter:
             with self._build_client(
                 timeout=config.request_timeout_seconds,
                 cookies=stored_payload.get("cookies", {}),
+                target=target,
             ) as client:
                 response = self._send_request(
                     client,
@@ -159,6 +182,14 @@ class HttpLoginAdapter:
                         }
                     ),
                 )
+        except TargetPolicyError as error:
+            return SessionValidationResult(
+                valid=False,
+                status=SessionStatus.ERROR,
+                failure_reason=LoginFailureReason.CONFIG_ERROR,
+                message="Validation was blocked by the authenticated target boundary.",
+                last_error=str(error),
+            )
         except httpx.HTTPError as error:
             return SessionValidationResult(
                 valid=False,
@@ -187,6 +218,7 @@ class HttpLoginAdapter:
             with self._build_client(
                 timeout=config.request_timeout_seconds,
                 cookies=stored_payload.get("cookies", {}),
+                target=target,
             ) as client:
                 response = self._send_request(
                     client,
@@ -230,6 +262,14 @@ class HttpLoginAdapter:
                     session_metadata_redacted=redact_session_metadata(metadata),
                     storage_payload={"cookies": cookie_payload},
                 )
+        except TargetPolicyError as error:
+            return self._failure(
+                target,
+                credential_profile,
+                LoginFailureReason.CONFIG_ERROR,
+                "Session refresh was blocked by the authenticated target boundary.",
+                last_error=str(error),
+            )
         except httpx.HTTPError as error:
             return self._failure(
                 target,
@@ -244,12 +284,18 @@ class HttpLoginAdapter:
         *,
         timeout: int,
         cookies: dict[str, object] | None = None,
+        target: Target,
     ) -> httpx.Client:
+        def guard_request(request: httpx.Request) -> None:
+            self.network_guard.ensure_allowed(target.base_url, str(request.url))
+
         return httpx.Client(
             follow_redirects=True,
             timeout=timeout,
             cookies=cookies,
             transport=self.transport,
+            trust_env=False,
+            event_hooks={"request": [guard_request]},
         )
 
     def _send_request(

--- a/app/integrations/auth/http_adapter.py
+++ b/app/integrations/auth/http_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 from urllib.parse import urljoin
@@ -47,13 +48,17 @@ class HttpLoginAdapter:
         credential_profile: CredentialProfile,
         secret_value: str,
         config: HttpLoginConfig,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> LoginExecutionResult:
         context = self._build_template_context(target, credential_profile, secret_value)
         last_exception: Exception | None = None
         for _ in range(config.retry_attempts):
             try:
                 with self._build_client(
-                    timeout=config.request_timeout_seconds, target=target
+                    timeout=config.request_timeout_seconds,
+                    target=target,
+                    before_request=before_request,
                 ) as client:
                     response = self._send_request(client, target, config.login_request, context)
                     if response.status_code in {401, 403}:
@@ -129,12 +134,15 @@ class HttpLoginAdapter:
         credential_profile: CredentialProfile,
         config: HttpLoginConfig,
         stored_payload: dict[str, object],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> SessionValidationResult:
         try:
             with self._build_client(
                 timeout=config.request_timeout_seconds,
                 cookies=stored_payload.get("cookies", {}),
                 target=target,
+                before_request=before_request,
             ) as client:
                 response = self._send_request(
                     client,
@@ -206,6 +214,8 @@ class HttpLoginAdapter:
         secret_value: str,
         config: HttpLoginConfig,
         stored_payload: dict[str, object],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> LoginExecutionResult:
         if config.refresh_request is None:
             return self._failure(
@@ -219,6 +229,7 @@ class HttpLoginAdapter:
                 timeout=config.request_timeout_seconds,
                 cookies=stored_payload.get("cookies", {}),
                 target=target,
+                before_request=before_request,
             ) as client:
                 response = self._send_request(
                     client,
@@ -285,8 +296,11 @@ class HttpLoginAdapter:
         timeout: int,
         cookies: dict[str, object] | None = None,
         target: Target,
+        before_request: Callable[[], None] | None,
     ) -> httpx.Client:
         def guard_request(request: httpx.Request) -> None:
+            if before_request is not None:
+                before_request()
             self.network_guard.ensure_allowed(target.base_url, str(request.url))
 
         return httpx.Client(

--- a/app/integrations/auth/playwright_adapter.py
+++ b/app/integrations/auth/playwright_adapter.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urljoin
 
-from app.core.errors import TargetPolicyError
+from app.core.errors import OverallScanTimeout, ScanInterrupted, TargetPolicyError
 from app.core.settings import get_settings
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import LoginFailureReason, SessionStatus, SessionType
@@ -107,6 +107,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                         "submit_selector": config.submit_selector,
                     }
                 self._wait_after_submit(page, config.request_timeout_seconds * 1000)
+                self._raise_request_guard_error(violations)
                 if config.success_url_contains:
                     try:
                         page.wait_for_url(
@@ -126,6 +127,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                     page.wait_for_selector(
                         config.success_selector, timeout=config.request_timeout_seconds * 1000
                     )
+                self._raise_request_guard_error(violations)
                 storage_state = context.storage_state()
                 current_url = page.url
                 page_text = page.text_content("body") or ""
@@ -177,6 +179,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                     violations,
                 )
                 self._wait_after_submit(page, config.request_timeout_seconds * 1000)
+                self._raise_request_guard_error(violations)
                 if config.success_text:
                     try:
                         page.locator("body").filter(has_text=config.success_text).wait_for(
@@ -188,6 +191,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                     page.wait_for_selector(
                         config.success_selector, timeout=config.request_timeout_seconds * 1000
                     )
+                self._raise_request_guard_error(violations)
                 current_url = page.url
                 page_text = page.text_content("body") or ""
                 password_inputs_count = self._visible_password_count(page)
@@ -207,8 +211,8 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         base_url: str,
         *,
         before_request: Callable[[], None] | None,
-    ) -> list[TargetPolicyError]:
-        violations: list[TargetPolicyError] = []
+    ) -> list[BaseException]:
+        violations: list[BaseException] = []
         cdp = context.new_cdp_session(page)
 
         def guard_request(event: dict[str, Any]) -> None:
@@ -217,7 +221,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 if before_request is not None:
                     before_request()
                 self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
-            except TargetPolicyError as error:
+            except (OverallScanTimeout, ScanInterrupted, TargetPolicyError) as error:
                 violations.append(error)
                 cdp.send(
                     "Fetch.failRequest",
@@ -236,7 +240,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         base_url: str,
         url: str,
         timeout_ms: int,
-        violations: list[TargetPolicyError],
+        violations: list[BaseException],
     ):
         self.network_guard.ensure_allowed(base_url, url)
         try:
@@ -249,6 +253,10 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
             raise violations[0]
         self.network_guard.ensure_allowed(base_url, page.url)
         return response
+
+    def _raise_request_guard_error(self, violations: list[BaseException]) -> None:
+        if violations:
+            raise violations[0]
 
     def _resolve_url(self, base_url: str, configured_url: str) -> str:
         return urljoin(f"{base_url.rstrip('/')}/", configured_url.lstrip("/"))
@@ -420,6 +428,8 @@ class PlaywrightLoginAdapter:
                     secret_value,
                     before_request=before_request,
                 )
+        except (OverallScanTimeout, ScanInterrupted):
+            raise
         except TimeoutError as error:
             return self._failure(
                 target,
@@ -501,6 +511,8 @@ class PlaywrightLoginAdapter:
                     stored_payload.get("storage_state", {}),
                     before_request=before_request,
                 )
+        except (OverallScanTimeout, ScanInterrupted):
+            raise
         except TimeoutError as error:
             return SessionValidationResult(
                 valid=False,

--- a/app/integrations/auth/playwright_adapter.py
+++ b/app/integrations/auth/playwright_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import urljoin
 
+from app.core.errors import TargetPolicyError
+from app.core.settings import get_settings
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import LoginFailureReason, SessionStatus, SessionType
 from app.models.target import Target
@@ -14,6 +16,8 @@ from app.schemas.auth import (
     PlaywrightLoginConfig,
     SessionValidationResult,
 )
+from app.services.authenticated_network import AuthenticatedNetworkGuard
+from app.services.scan_network import TargetNetworkPolicy
 
 
 class PlaywrightGatewayProtocol:
@@ -32,6 +36,11 @@ class PlaywrightGatewayProtocol:
 
 
 class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
+    def __init__(self, *, policy: TargetNetworkPolicy | None = None) -> None:
+        self.network_guard = AuthenticatedNetworkGuard(
+            policy or TargetNetworkPolicy(get_settings())
+        )
+
     def login(
         self, config: PlaywrightLoginConfig, target: Target, username: str, password: str
     ) -> dict[str, Any]:
@@ -48,15 +57,21 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context()
                 page = context.new_page()
-                page.goto(
+                violations = self._install_request_guard(context, page, target.base_url)
+                self._guarded_goto(
+                    page,
+                    target.base_url,
                     self._resolve_url(target.base_url, config.login_url),
-                    timeout=config.request_timeout_seconds * 1000,
+                    config.request_timeout_seconds * 1000,
+                    violations,
                 )
                 if config.auto_detect_selectors and self._visible_password_count(page) == 0:
-                    page.goto(
+                    self._guarded_goto(
+                        page,
+                        target.base_url,
                         self._resolve_url(target.base_url, "/"),
-                        wait_until="domcontentloaded",
-                        timeout=config.request_timeout_seconds * 1000,
+                        config.request_timeout_seconds * 1000,
+                        violations,
                     )
                     self._wait_after_submit(page, config.request_timeout_seconds * 1000)
                 login_url = page.url
@@ -126,9 +141,13 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context(storage_state=storage_state)
                 page = context.new_page()
-                page.goto(
+                violations = self._install_request_guard(context, page, target.base_url)
+                self._guarded_goto(
+                    page,
+                    target.base_url,
                     self._resolve_url(target.base_url, config.validate_url),
-                    timeout=config.request_timeout_seconds * 1000,
+                    config.request_timeout_seconds * 1000,
+                    violations,
                 )
                 self._wait_after_submit(page, config.request_timeout_seconds * 1000)
                 if config.success_text:
@@ -153,6 +172,47 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 }
         except PlaywrightTimeoutError as error:
             raise TimeoutError(str(error)) from error
+
+    def _install_request_guard(self, context, page, base_url: str) -> list[TargetPolicyError]:
+        violations: list[TargetPolicyError] = []
+        cdp = context.new_cdp_session(page)
+
+        def guard_request(event: dict[str, Any]) -> None:
+            request_id = str(event["requestId"])
+            try:
+                self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
+            except TargetPolicyError as error:
+                violations.append(error)
+                cdp.send(
+                    "Fetch.failRequest",
+                    {"requestId": request_id, "errorReason": "BlockedByClient"},
+                )
+                return
+            cdp.send("Fetch.continueRequest", {"requestId": request_id})
+
+        cdp.on("Fetch.requestPaused", guard_request)
+        cdp.send("Fetch.enable", {"patterns": [{"urlPattern": "*", "requestStage": "Request"}]})
+        return violations
+
+    def _guarded_goto(
+        self,
+        page,
+        base_url: str,
+        url: str,
+        timeout_ms: int,
+        violations: list[TargetPolicyError],
+    ):
+        self.network_guard.ensure_allowed(base_url, url)
+        try:
+            response = page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+        except Exception as error:
+            if violations:
+                raise violations[0] from error
+            raise
+        if violations:
+            raise violations[0]
+        self.network_guard.ensure_allowed(base_url, page.url)
+        return response
 
     def _resolve_url(self, base_url: str, configured_url: str) -> str:
         return urljoin(f"{base_url.rstrip('/')}/", configured_url.lstrip("/"))
@@ -324,6 +384,14 @@ class PlaywrightLoginAdapter:
                 str(error),
                 last_error=str(error),
             )
+        except TargetPolicyError as error:
+            return self._failure(
+                target,
+                credential_profile,
+                LoginFailureReason.CONFIG_ERROR,
+                "Playwright login was blocked by the authenticated target boundary.",
+                last_error=str(error),
+            )
 
         if not self._is_success(config, result):
             return self._failure(
@@ -385,6 +453,14 @@ class PlaywrightLoginAdapter:
                 status=SessionStatus.ERROR,
                 failure_reason=LoginFailureReason.CONFIG_ERROR,
                 message=str(error),
+                last_error=str(error),
+            )
+        except TargetPolicyError as error:
+            return SessionValidationResult(
+                valid=False,
+                status=SessionStatus.ERROR,
+                failure_reason=LoginFailureReason.CONFIG_ERROR,
+                message="Playwright validation was blocked by the authenticated target boundary.",
                 last_error=str(error),
             )
         if not self._is_success(config, result):

--- a/app/integrations/auth/playwright_adapter.py
+++ b/app/integrations/auth/playwright_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urljoin
 
@@ -22,7 +23,13 @@ from app.services.scan_network import TargetNetworkPolicy
 
 class PlaywrightGatewayProtocol:
     def login(
-        self, config: PlaywrightLoginConfig, target: Target, username: str, password: str
+        self,
+        config: PlaywrightLoginConfig,
+        target: Target,
+        username: str,
+        password: str,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError
 
@@ -31,6 +38,8 @@ class PlaywrightGatewayProtocol:
         config: PlaywrightLoginConfig,
         target: Target,
         storage_state: dict[str, Any],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError
 
@@ -42,7 +51,13 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         )
 
     def login(
-        self, config: PlaywrightLoginConfig, target: Target, username: str, password: str
+        self,
+        config: PlaywrightLoginConfig,
+        target: Target,
+        username: str,
+        password: str,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         try:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -57,7 +72,12 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context()
                 page = context.new_page()
-                violations = self._install_request_guard(context, page, target.base_url)
+                violations = self._install_request_guard(
+                    context,
+                    page,
+                    target.base_url,
+                    before_request=before_request,
+                )
                 self._guarded_goto(
                     page,
                     target.base_url,
@@ -127,6 +147,8 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         config: PlaywrightLoginConfig,
         target: Target,
         storage_state: dict[str, Any],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         try:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -141,7 +163,12 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
                 browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context(storage_state=storage_state)
                 page = context.new_page()
-                violations = self._install_request_guard(context, page, target.base_url)
+                violations = self._install_request_guard(
+                    context,
+                    page,
+                    target.base_url,
+                    before_request=before_request,
+                )
                 self._guarded_goto(
                     page,
                     target.base_url,
@@ -173,13 +200,22 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
         except PlaywrightTimeoutError as error:
             raise TimeoutError(str(error)) from error
 
-    def _install_request_guard(self, context, page, base_url: str) -> list[TargetPolicyError]:
+    def _install_request_guard(
+        self,
+        context,
+        page,
+        base_url: str,
+        *,
+        before_request: Callable[[], None] | None,
+    ) -> list[TargetPolicyError]:
         violations: list[TargetPolicyError] = []
         cdp = context.new_cdp_session(page)
 
         def guard_request(event: dict[str, Any]) -> None:
             request_id = str(event["requestId"])
             try:
+                if before_request is not None:
+                    before_request()
                 self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
             except TargetPolicyError as error:
                 violations.append(error)
@@ -365,9 +401,25 @@ class PlaywrightLoginAdapter:
         credential_profile: CredentialProfile,
         secret_value: str,
         config: PlaywrightLoginConfig,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> LoginExecutionResult:
         try:
-            result = self.gateway.login(config, target, credential_profile.username, secret_value)
+            if before_request is None:
+                result = self.gateway.login(
+                    config,
+                    target,
+                    credential_profile.username,
+                    secret_value,
+                )
+            else:
+                result = self.gateway.login(
+                    config,
+                    target,
+                    credential_profile.username,
+                    secret_value,
+                    before_request=before_request,
+                )
         except TimeoutError as error:
             return self._failure(
                 target,
@@ -432,13 +484,23 @@ class PlaywrightLoginAdapter:
         credential_profile: CredentialProfile,
         config: PlaywrightLoginConfig,
         stored_payload: dict[str, object],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> SessionValidationResult:
         try:
-            result = self.gateway.validate(
-                config,
-                target,
-                stored_payload.get("storage_state", {}),
-            )
+            if before_request is None:
+                result = self.gateway.validate(
+                    config,
+                    target,
+                    stored_payload.get("storage_state", {}),
+                )
+            else:
+                result = self.gateway.validate(
+                    config,
+                    target,
+                    stored_payload.get("storage_state", {}),
+                    before_request=before_request,
+                )
         except TimeoutError as error:
             return SessionValidationResult(
                 valid=False,
@@ -491,6 +553,8 @@ class PlaywrightLoginAdapter:
         secret_value: str,
         config: PlaywrightLoginConfig,
         stored_payload: dict[str, object],
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> LoginExecutionResult:
         if not config.refresh_via_relogin:
             return self._failure(
@@ -499,7 +563,13 @@ class PlaywrightLoginAdapter:
                 LoginFailureReason.CONFIG_ERROR,
                 "Playwright refresh is not configured.",
             )
-        return self.login(target, credential_profile, secret_value, config)
+        return self.login(
+            target,
+            credential_profile,
+            secret_value,
+            config,
+            before_request=before_request,
+        )
 
     def _is_success(self, config: PlaywrightLoginConfig, result: dict[str, Any]) -> bool:
         current_url = str(result.get("current_url", ""))

--- a/app/integrations/auth/playwright_adapter.py
+++ b/app/integrations/auth/playwright_adapter.py
@@ -45,7 +45,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
 
         try:
             with sync_playwright() as playwright:
-                browser = playwright.chromium.launch(headless=True)
+                browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context()
                 page = context.new_page()
                 page.goto(
@@ -123,7 +123,7 @@ class SyncPlaywrightGateway(PlaywrightGatewayProtocol):
 
         try:
             with sync_playwright() as playwright:
-                browser = playwright.chromium.launch(headless=True)
+                browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = browser.new_context(storage_state=storage_state)
                 page = context.new_page()
                 page.goto(

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -11,7 +11,12 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 from urllib.parse import parse_qs, urljoin, urlparse, urlunparse
 
-from app.core.errors import InputValidationError, TargetPolicyError
+from app.core.errors import (
+    InputValidationError,
+    OverallScanTimeout,
+    ScanInterrupted,
+    TargetPolicyError,
+)
 from app.core.settings import get_settings
 from app.models.enums import SessionType
 from app.models.target import Target
@@ -74,6 +79,8 @@ class PlaywrightInventoryGatewayProtocol(Protocol):
 
 
 class SyncPlaywrightInventoryGateway:
+    _MAX_CAPTURED_RESPONSE_BYTES = 256 * 1024
+
     """Collect inventory using Playwright navigation and network observation."""
 
     DOWNLOAD_SUFFIXES = (
@@ -225,6 +232,7 @@ class SyncPlaywrightInventoryGateway:
                         raise
                     if controls.delay_ms:
                         time.sleep(controls.delay_ms / 1000)
+                    self._raise_request_guard_error(violations)
                     final_url = self._normalize_page_url(page.url)
                     seen_page_urls.add(final_url)
                     title = page.title()
@@ -274,8 +282,8 @@ class SyncPlaywrightInventoryGateway:
         base_url: str,
         *,
         before_request: Callable[[], None] | None,
-    ) -> list[TargetPolicyError]:
-        violations: list[TargetPolicyError] = []
+    ) -> list[BaseException]:
+        violations: list[BaseException] = []
         cdp = context.new_cdp_session(page)
 
         def guard_request(event: dict[str, Any]) -> None:
@@ -284,7 +292,7 @@ class SyncPlaywrightInventoryGateway:
                 if before_request is not None:
                     before_request()
                 self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
-            except TargetPolicyError as error:
+            except (OverallScanTimeout, ScanInterrupted, TargetPolicyError) as error:
                 violations.append(error)
                 cdp.send(
                     "Fetch.failRequest",
@@ -303,7 +311,7 @@ class SyncPlaywrightInventoryGateway:
         base_url: str,
         url: str,
         timeout_ms: int,
-        violations: list[TargetPolicyError],
+        violations: list[BaseException],
     ):
         self.network_guard.ensure_allowed(base_url, url)
         try:
@@ -316,6 +324,10 @@ class SyncPlaywrightInventoryGateway:
             raise violations[0]
         self.network_guard.ensure_allowed(base_url, page.url)
         return response
+
+    def _raise_request_guard_error(self, violations: list[BaseException]) -> None:
+        if violations:
+            raise violations[0]
 
     def _build_context(self, browser, base_url: str, session_type: SessionType, session_payload):
         if session_type == SessionType.PLAYWRIGHT_STORAGE_STATE:
@@ -425,8 +437,10 @@ class SyncPlaywrightInventoryGateway:
         content_type = (response.header_value("content-type") or "").lower()
         if not any(token in content_type for token in ("json", "text", "html", "xml")):
             return None
+        if not self._response_body_is_safely_bounded(response):
+            return None
         try:
-            return response.text()[: 256 * 1024]
+            return response.text()
         except BaseException:
             return None
 
@@ -434,10 +448,24 @@ class SyncPlaywrightInventoryGateway:
         normalized_type = (content_type or "").lower()
         if not any(token in normalized_type for token in ("json", "text", "html", "xml")):
             return None
+        if not self._response_body_is_safely_bounded(response):
+            return None
         try:
-            return response.text()[: 256 * 1024]
+            return response.text()
         except BaseException:
             return None
+
+    def _response_body_is_safely_bounded(self, response) -> bool:
+        if response.header_value("content-encoding"):
+            return False
+        raw_length = response.header_value("content-length")
+        if raw_length is None:
+            return False
+        try:
+            length = int(raw_length)
+        except (TypeError, ValueError):
+            return False
+        return 0 <= length <= self._MAX_CAPTURED_RESPONSE_BYTES
 
     def _extract_cookie_metadata(self, response) -> tuple[list[str], list[str]]:
         raw_value = response.header_value("set-cookie") or ""

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -44,6 +44,8 @@ class ObservedPage:
     discovered_urls: list[str]
     status_code: int | None = None
     cache_control: str | None = None
+    content_type: str | None = None
+    response_text: str | None = None
     text_preview: str | None = None
 
 
@@ -113,7 +115,7 @@ class SyncPlaywrightInventoryGateway:
 
         try:
             with sync_playwright() as playwright:
-                browser = playwright.chromium.launch(headless=True)
+                browser = playwright.chromium.launch(headless=True, channel="chromium")
                 context = self._build_context(
                     browser,
                     target.base_url,
@@ -201,6 +203,10 @@ class SyncPlaywrightInventoryGateway:
                             cache_control=(
                                 response.header_value("cache-control") if response else None
                             ),
+                            content_type=(
+                                response.header_value("content-type") if response else None
+                            ),
+                            response_text=self._extract_navigation_response_text(response),
                             text_preview=self._extract_page_preview(page),
                         )
                     )
@@ -325,6 +331,17 @@ class SyncPlaywrightInventoryGateway:
         except Exception:
             return None
         return self._normalize_preview(preview)
+
+    def _extract_navigation_response_text(self, response) -> str | None:
+        if response is None:
+            return None
+        content_type = (response.header_value("content-type") or "").lower()
+        if not any(token in content_type for token in ("json", "text", "html", "xml")):
+            return None
+        try:
+            return response.text()[: 256 * 1024]
+        except BaseException:
+            return None
 
     def _extract_response_preview(self, response, content_type: str | None) -> str | None:
         normalized_type = (content_type or "").lower()

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -10,10 +10,13 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 from urllib.parse import parse_qs, urljoin, urlparse, urlunparse
 
-from app.core.errors import InputValidationError
+from app.core.errors import InputValidationError, TargetPolicyError
+from app.core.settings import get_settings
 from app.models.enums import SessionType
 from app.models.target import Target
 from app.schemas.inventory import InventoryBuildControls
+from app.services.authenticated_network import AuthenticatedNetworkGuard
+from app.services.scan_network import TargetNetworkPolicy
 
 
 @dataclass
@@ -89,6 +92,11 @@ class SyncPlaywrightInventoryGateway:
         ".csv",
     )
 
+    def __init__(self, *, policy: TargetNetworkPolicy | None = None) -> None:
+        self.network_guard = AuthenticatedNetworkGuard(
+            policy or TargetNetworkPolicy(get_settings())
+        )
+
     def collect(
         self,
         target: Target,
@@ -123,6 +131,7 @@ class SyncPlaywrightInventoryGateway:
                     session_payload,
                 )
                 page = context.new_page()
+                violations = self._install_request_guard(context, page, target.base_url)
 
                 def handle_response(response) -> None:
                     nonlocal request_counter
@@ -177,10 +186,12 @@ class SyncPlaywrightInventoryGateway:
                     if self._looks_like_download_url(current_url):
                         continue
                     try:
-                        response = page.goto(
+                        response = self._guarded_goto(
+                            page,
+                            target.base_url,
                             current_url,
-                            wait_until="domcontentloaded",
-                            timeout=15000,
+                            15000,
+                            violations,
                         )
                     except PlaywrightError as error:
                         if self._is_download_navigation_error(error):
@@ -229,6 +240,47 @@ class SyncPlaywrightInventoryGateway:
             pages=pages,
             endpoints=endpoints,
         )
+
+    def _install_request_guard(self, context, page, base_url: str) -> list[TargetPolicyError]:
+        violations: list[TargetPolicyError] = []
+        cdp = context.new_cdp_session(page)
+
+        def guard_request(event: dict[str, Any]) -> None:
+            request_id = str(event["requestId"])
+            try:
+                self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
+            except TargetPolicyError as error:
+                violations.append(error)
+                cdp.send(
+                    "Fetch.failRequest",
+                    {"requestId": request_id, "errorReason": "BlockedByClient"},
+                )
+                return
+            cdp.send("Fetch.continueRequest", {"requestId": request_id})
+
+        cdp.on("Fetch.requestPaused", guard_request)
+        cdp.send("Fetch.enable", {"patterns": [{"urlPattern": "*", "requestStage": "Request"}]})
+        return violations
+
+    def _guarded_goto(
+        self,
+        page,
+        base_url: str,
+        url: str,
+        timeout_ms: int,
+        violations: list[TargetPolicyError],
+    ):
+        self.network_guard.ensure_allowed(base_url, url)
+        try:
+            response = page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+        except Exception as error:
+            if violations:
+                raise violations[0] from error
+            raise
+        if violations:
+            raise violations[0]
+        self.network_guard.ensure_allowed(base_url, page.url)
+        return response
 
     def _build_context(self, browser, base_url: str, session_type: SessionType, session_payload):
         if session_type == SessionType.PLAYWRIGHT_STORAGE_STATE:

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -67,6 +68,7 @@ class PlaywrightInventoryGatewayProtocol(Protocol):
         controls: InventoryBuildControls,
         session_type: SessionType,
         session_payload: dict[str, Any],
+        before_request: Callable[[], None] | None = None,
     ) -> InventoryCollectionResult: ...
 
 
@@ -104,6 +106,7 @@ class SyncPlaywrightInventoryGateway:
         controls: InventoryBuildControls,
         session_type: SessionType,
         session_payload: dict[str, Any],
+        before_request: Callable[[], None] | None = None,
     ) -> InventoryCollectionResult:
         try:
             from playwright.sync_api import Error as PlaywrightError
@@ -131,7 +134,12 @@ class SyncPlaywrightInventoryGateway:
                     session_payload,
                 )
                 page = context.new_page()
-                violations = self._install_request_guard(context, page, target.base_url)
+                violations = self._install_request_guard(
+                    context,
+                    page,
+                    target.base_url,
+                    before_request=before_request,
+                )
 
                 def handle_response(response) -> None:
                     nonlocal request_counter
@@ -178,6 +186,8 @@ class SyncPlaywrightInventoryGateway:
                 page.on("response", handle_response)
 
                 while queued and len(seen_page_urls) < controls.max_pages:
+                    if before_request is not None:
+                        before_request()
                     current_url, depth = queued.popleft()
                     if current_url in seen_page_urls:
                         continue
@@ -186,13 +196,24 @@ class SyncPlaywrightInventoryGateway:
                     if self._looks_like_download_url(current_url):
                         continue
                     try:
-                        response = self._guarded_goto(
-                            page,
-                            target.base_url,
-                            current_url,
-                            15000,
-                            violations,
-                        )
+                        response = None
+                        for attempt in range(controls.retry_attempts + 1):
+                            try:
+                                response = self._guarded_goto(
+                                    page,
+                                    target.base_url,
+                                    current_url,
+                                    int(controls.request_timeout_seconds * 1000),
+                                    violations,
+                                )
+                                break
+                            except TargetPolicyError:
+                                raise
+                            except PlaywrightError:
+                                if attempt >= controls.retry_attempts:
+                                    raise
+                                if before_request is not None:
+                                    before_request()
                     except PlaywrightError as error:
                         if self._is_download_navigation_error(error):
                             continue
@@ -241,13 +262,22 @@ class SyncPlaywrightInventoryGateway:
             endpoints=endpoints,
         )
 
-    def _install_request_guard(self, context, page, base_url: str) -> list[TargetPolicyError]:
+    def _install_request_guard(
+        self,
+        context,
+        page,
+        base_url: str,
+        *,
+        before_request: Callable[[], None] | None,
+    ) -> list[TargetPolicyError]:
         violations: list[TargetPolicyError] = []
         cdp = context.new_cdp_session(page)
 
         def guard_request(event: dict[str, Any]) -> None:
             request_id = str(event["requestId"])
             try:
+                if before_request is not None:
+                    before_request()
                 self.network_guard.ensure_allowed(base_url, str(event["request"]["url"]))
             except TargetPolicyError as error:
                 violations.append(error)

--- a/app/integrations/inventory/playwright_gateway.py
+++ b/app/integrations/inventory/playwright_gateway.py
@@ -30,6 +30,7 @@ class ObservedEndpoint:
     cache_control: str | None = None
     content_type: str | None = None
     response_preview: str | None = None
+    response_text: str | None = None
     set_cookie_names: list[str] = field(default_factory=list)
     cookie_issue_flags: list[str] = field(default_factory=list)
     parameters: dict[str, list[str]] = field(default_factory=dict)
@@ -163,6 +164,7 @@ class SyncPlaywrightInventoryGateway:
                         response_headers = response.all_headers()
                     except Exception:
                         response_headers = {}
+                    response_text = self._extract_response_text(response, content_type)
                     endpoints.append(
                         ObservedEndpoint(
                             method=request.method.upper(),
@@ -173,7 +175,10 @@ class SyncPlaywrightInventoryGateway:
                             observed_at=datetime.now(timezone.utc),
                             cache_control=response.header_value("cache-control"),
                             content_type=content_type,
-                            response_preview=self._extract_response_preview(response, content_type),
+                            response_preview=(
+                                self._normalize_preview(response_text) if response_text else None
+                            ),
+                            response_text=response_text,
                             set_cookie_names=set_cookie_names,
                             cookie_issue_flags=cookie_issue_flags,
                             parameters=self._extract_parameters(request),
@@ -425,15 +430,14 @@ class SyncPlaywrightInventoryGateway:
         except BaseException:
             return None
 
-    def _extract_response_preview(self, response, content_type: str | None) -> str | None:
+    def _extract_response_text(self, response, content_type: str | None) -> str | None:
         normalized_type = (content_type or "").lower()
         if not any(token in normalized_type for token in ("json", "text", "html", "xml")):
             return None
         try:
-            preview = response.text()
+            return response.text()[: 256 * 1024]
         except BaseException:
             return None
-        return self._normalize_preview(preview)
 
     def _extract_cookie_metadata(self, response) -> tuple[list[str], list[str]]:
         raw_value = response.header_value("set-cookie") or ""

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,9 @@ async def lifespan(app: FastAPI):
     )
     init_database(settings.database_url)
     app.state.scan_service = ScanApplicationService(settings=settings)
+    purged = app.state.scan_service.purge_expired_temporary_secrets(max_age_seconds=900)
+    if purged:
+        logger.warning("Purged expired temporary coverage secrets", extra={"count": len(purged)})
     interrupted = app.state.scan_service.interrupt_active_scans()
     if interrupted:
         logger.warning("Interrupted stale active scans", extra={"count": interrupted})

--- a/app/models/scan_context.py
+++ b/app/models/scan_context.py
@@ -40,7 +40,7 @@ class ScanContext(TimestampMixin, Base):
     credential_profile_id: Mapped[int | None] = mapped_column(
         ForeignKey("credential_profiles.id"), nullable=True, index=True
     )
-    temporary_secret_ref: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    temporary_secret_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
     auth_session_id: Mapped[int | None] = mapped_column(
         ForeignKey("auth_sessions.id"), nullable=True, index=True
     )

--- a/app/models/scan_context.py
+++ b/app/models/scan_context.py
@@ -28,6 +28,10 @@ class ScanContext(TimestampMixin, Base):
         ),
         UniqueConstraint("scan_run_id", "kind", name="uq_scan_contexts_run_kind"),
         UniqueConstraint("scan_run_id", "id", name="uq_scan_contexts_run_id_id"),
+        UniqueConstraint(
+            "temporary_secret_ref",
+            name="uq_scan_contexts_temporary_secret_ref",
+        ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
@@ -36,6 +40,7 @@ class ScanContext(TimestampMixin, Base):
     credential_profile_id: Mapped[int | None] = mapped_column(
         ForeignKey("credential_profiles.id"), nullable=True, index=True
     )
+    temporary_secret_ref: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     auth_session_id: Mapped[int | None] = mapped_column(
         ForeignKey("auth_sessions.id"), nullable=True, index=True
     )

--- a/app/schemas/assessment.py
+++ b/app/schemas/assessment.py
@@ -42,7 +42,7 @@ class PassiveCoverageStartRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     url: str = Field(min_length=1, max_length=1000)
-    target_id: int = Field(gt=0)
+    target_id: int | None = Field(default=None, gt=0)
     user_profile_id: int = Field(gt=0)
     admin_profile_id: int = Field(gt=0)
     options: ScanOptions = Field(default_factory=ScanOptions)

--- a/app/schemas/assessment.py
+++ b/app/schemas/assessment.py
@@ -43,6 +43,7 @@ class PassiveCoverageStartRequest(BaseModel):
 
     url: str = Field(min_length=1, max_length=1000)
     target_id: int | None = Field(default=None, gt=0)
+    source_run_id: int | None = Field(default=None, gt=0)
     user_profile_id: int = Field(gt=0)
     admin_profile_id: int = Field(gt=0)
     options: ScanOptions = Field(default_factory=ScanOptions)
@@ -56,6 +57,7 @@ class PassiveCoverageStartRequest(BaseModel):
             url=self.url,
             mode=AssessmentMode.AUTHENTICATED_COVERAGE,
             target_id=self.target_id,
+            source_run_id=self.source_run_id,
             user_profile_id=self.user_profile_id,
             admin_profile_id=self.admin_profile_id,
             active_checks_enabled=False,

--- a/app/schemas/assessment.py
+++ b/app/schemas/assessment.py
@@ -36,6 +36,34 @@ class AssessmentStartRequest(BaseModel):
         return self
 
 
+class PassiveCoverageStartRequest(BaseModel):
+    """Public passive-only coverage request used by guided and HTTP adapters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(min_length=1, max_length=1000)
+    target_id: int = Field(gt=0)
+    user_profile_id: int = Field(gt=0)
+    admin_profile_id: int = Field(gt=0)
+    options: ScanOptions = Field(default_factory=ScanOptions)
+
+    @property
+    def active_checks_enabled(self) -> bool:
+        return False
+
+    def to_assessment_request(self) -> AssessmentStartRequest:
+        return AssessmentStartRequest(
+            url=self.url,
+            mode=AssessmentMode.AUTHENTICATED_COVERAGE,
+            target_id=self.target_id,
+            user_profile_id=self.user_profile_id,
+            admin_profile_id=self.admin_profile_id,
+            active_checks_enabled=False,
+            authorization_confirmed=False,
+            options=self.options,
+        )
+
+
 class CoverageDifferenceView(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -13,8 +13,10 @@ from app.core.errors import InputValidationError
 class InventoryBuildControls(BaseModel):
     max_pages: int = Field(default=25, ge=1, le=100)
     max_depth: int = Field(default=2, ge=0, le=5)
-    max_requests: int = Field(default=100, ge=1, le=500)
+    max_requests: int = Field(default=100, ge=0, le=2000)
     delay_ms: int = Field(default=250, ge=0, le=5000)
+    request_timeout_seconds: float = Field(default=15, gt=0, le=60)
+    retry_attempts: int = Field(default=0, ge=0, le=2)
     include: list[str] = Field(default_factory=list)
     exclude: list[str] = Field(default_factory=list)
 

--- a/app/services/authenticated_network.py
+++ b/app/services/authenticated_network.py
@@ -1,0 +1,33 @@
+"""Network admission for authenticated browser and HTTP activity."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from app.core.errors import TargetPolicyError
+from app.services.scan_network import TargetNetworkPolicy
+
+
+class AuthenticatedNetworkGuard:
+    """Enforce one authorized origin and the shared destination policy."""
+
+    def __init__(self, policy: TargetNetworkPolicy) -> None:
+        self.policy = policy
+
+    def ensure_allowed(self, base_url: str, candidate_url: str) -> str:
+        normalized_base = self.policy.normalize_url(base_url)
+        normalized_candidate = self.policy.normalize_url(candidate_url)
+        if self._origin(normalized_candidate) != self._origin(normalized_base):
+            raise TargetPolicyError(
+                "Authenticated request left the configured same-origin boundary."
+            )
+        self.policy.ensure_destination_allowed(normalized_candidate)
+        return normalized_candidate
+
+    def _origin(self, value: str) -> tuple[str, str, int]:
+        parsed = urlparse(value)
+        return (
+            parsed.scheme.lower(),
+            (parsed.hostname or "").lower(),
+            parsed.port or (443 if parsed.scheme == "https" else 80),
+        )

--- a/app/services/context_collection.py
+++ b/app/services/context_collection.py
@@ -196,6 +196,11 @@ class DefaultContextCollectionGateway:
         requests: list[ObservedRequest] = []
         for endpoint in result.endpoints:
             exact_url = endpoint.request_url or endpoint.url
+            response_text = (
+                endpoint.response_text
+                if endpoint.response_text is not None
+                else endpoint.response_preview or ""
+            )
             resources.append(
                 ObservedResource(
                     asset_type="endpoint",
@@ -207,7 +212,7 @@ class DefaultContextCollectionGateway:
                         "content_type": endpoint.content_type,
                         "cache_control": endpoint.cache_control,
                         "parameter_names": endpoint.parameters,
-                        "response_text": endpoint.response_preview or "",
+                        "response_text": response_text,
                     },
                 )
             )
@@ -224,7 +229,7 @@ class DefaultContextCollectionGateway:
                     body=endpoint.request_body,
                     status_code=endpoint.status_code,
                     response_headers=response_headers,
-                    response_text=endpoint.response_preview or "",
+                    response_text=response_text,
                 )
             )
         return resources, requests

--- a/app/services/context_collection.py
+++ b/app/services/context_collection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Protocol
@@ -62,6 +63,8 @@ class ContextCollectionGateway(Protocol):
         self,
         run: ScanRun,
         context: ScanContext,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> tuple[list[ObservedResource], list[ObservedRequest]]: ...
 
 
@@ -81,14 +84,18 @@ class DefaultContextCollectionGateway:
         self,
         run: ScanRun,
         context: ScanContext,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
         if context.kind == "anonymous":
-            return self._collect_anonymous(run)
-        return self._collect_authenticated(run, context)
+            return self._collect_anonymous(run, before_request=before_request)
+        return self._collect_authenticated(run, context, before_request=before_request)
 
     def _collect_anonymous(
         self,
         run: ScanRun,
+        *,
+        before_request: Callable[[], None] | None,
     ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
         options = ScanOptions.model_validate(run.options)
         queue: list[tuple[str, int]] = [(run.normalized_url, 0)]
@@ -101,7 +108,14 @@ class DefaultContextCollectionGateway:
             if url in seen or depth > options.max_depth or _origin(url) != origin:
                 continue
             seen.add(url)
-            result = self.http_gateway.fetch(url, options)
+            if before_request is None:
+                result = self.http_gateway.fetch(url, options)
+            else:
+                result = self.http_gateway.fetch(
+                    url,
+                    options,
+                    before_request=before_request,
+                )
             resources.append(
                 ObservedResource(
                     asset_type="page",
@@ -137,6 +151,8 @@ class DefaultContextCollectionGateway:
         self,
         run: ScanRun,
         context: ScanContext,
+        *,
+        before_request: Callable[[], None] | None,
     ) -> tuple[list[ObservedResource], list[ObservedRequest]]:
         target = run.target
         auth_session = context.auth_session
@@ -149,9 +165,13 @@ class DefaultContextCollectionGateway:
             InventoryBuildControls(
                 max_pages=options.max_pages,
                 max_depth=options.max_depth,
-                max_requests=min(500, max(1, options.max_pages * 10)),
+                max_requests=options.max_resources,
                 delay_ms=0,
+                request_timeout_seconds=options.request_timeout_seconds or 5.0,
+                retry_attempts=options.retry_attempts or 0,
             ),
+            start_url=run.normalized_url,
+            before_request=before_request,
         )
         resources = [
             ObservedResource(
@@ -229,10 +249,19 @@ class ContextCollectionService:
         session: Session,
         run: ScanRun,
         context: ScanContext,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> ContextCollectionSummary:
         if context.scan_run_id != run.id:
             raise ValueError("采集上下文不属于指定验证运行。")
-        resources, requests = self.gateway.collect(run, context)
+        if before_request is None:
+            resources, requests = self.gateway.collect(run, context)
+        else:
+            resources, requests = self.gateway.collect(
+                run,
+                context,
+                before_request=before_request,
+            )
         asset_by_identity: dict[str, ScanAsset] = {}
         for resource in resources:
             asset = self._persist_resource(session, run, context, resource)

--- a/app/services/context_collection.py
+++ b/app/services/context_collection.py
@@ -161,10 +161,14 @@ class DefaultContextCollectionGateway:
                 status_code=page.status_code,
                 title=page.title,
                 attributes={
-                    "content_type": "text/html",
+                    "content_type": page.content_type or "text/html",
                     "cache_control": page.cache_control,
                     "depth": page.depth,
-                    "response_text": page.text_preview or "",
+                    "response_text": (
+                        page.response_text
+                        if page.response_text is not None
+                        else page.text_preview or ""
+                    ),
                 },
             )
             for page in result.pages

--- a/app/services/context_establishment.py
+++ b/app/services/context_establishment.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import urlparse
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.cli.paths import formal_runtime_paths
 from app.core.errors import InputValidationError, ResourceNotFoundError
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import (
@@ -21,6 +23,8 @@ from app.models.scan_context import ScanContext
 from app.models.scan_run import ScanRun
 from app.models.target import Target
 from app.services.audit import AuditService
+from app.services.ephemeral_secret_store import EphemeralSecretStore
+from app.services.secret_resolver import SecretResolver
 from app.services.sessions import AuthSessionService
 
 
@@ -32,9 +36,23 @@ class ContextEstablishmentService:
         *,
         auth_service: AuthSessionService | None = None,
         audit_service: AuditService | None = None,
+        ephemeral_store: EphemeralSecretStore | None = None,
     ) -> None:
-        self.auth_service = auth_service or AuthSessionService()
+        if ephemeral_store is None:
+            formal_paths = formal_runtime_paths()
+            ephemeral_store = EphemeralSecretStore(
+                formal_paths.secrets_dir
+                if formal_paths is not None
+                else Path.cwd() / "data" / "ephemeral-secrets"
+            )
+        if auth_service is not None:
+            self.auth_service = auth_service
+        else:
+            self.auth_service = AuthSessionService(
+                secret_resolver=SecretResolver(ephemeral_store=ephemeral_store)
+            )
         self.audit_service = audit_service or AuditService()
+        self.ephemeral_store = ephemeral_store
 
     def establish(self, session: Session, run: ScanRun) -> list[ScanContext]:
         contexts = self._existing_contexts(session, run)
@@ -42,22 +60,38 @@ class ContextEstablishmentService:
         if run.mode == AssessmentMode.QUICK.value:
             return [anonymous]
 
-        user_profile, admin_profile = self._validate_authenticated_run(session, run, contexts)
-        user = self._establish_authenticated(
-            session,
-            run,
-            contexts[ContextKind.USER.value],
-            user_profile,
-        )
-        admin = self._establish_authenticated(
-            session,
-            run,
-            contexts[ContextKind.ADMIN.value],
-            admin_profile,
-        )
-        self._set_run_completeness(run, user, admin)
-        session.flush()
-        return [anonymous, user, admin]
+        try:
+            user_profile, admin_profile = self._validate_authenticated_run(session, run, contexts)
+            user = self._establish_authenticated(
+                session,
+                run,
+                contexts[ContextKind.USER.value],
+                user_profile,
+            )
+            admin = self._establish_authenticated(
+                session,
+                run,
+                contexts[ContextKind.ADMIN.value],
+                admin_profile,
+            )
+            self._set_run_completeness(run, user, admin)
+            session.flush()
+            return [anonymous, user, admin]
+        finally:
+            self._delete_context_temporary_secrets(session, contexts)
+
+    def _delete_context_temporary_secrets(
+        self,
+        session: Session,
+        contexts: dict[str, ScanContext],
+    ) -> None:
+        if self.ephemeral_store is None:
+            return
+        for kind in (ContextKind.USER.value, ContextKind.ADMIN.value):
+            profile_id = contexts[kind].credential_profile_id
+            profile = session.get(CredentialProfile, profile_id) if profile_id is not None else None
+            if profile is not None and profile.secret_ref.startswith("ephemeral-file://"):
+                self.ephemeral_store.delete(profile.secret_ref)
 
     def _existing_contexts(self, session: Session, run: ScanRun) -> dict[str, ScanContext]:
         contexts = {

--- a/app/services/context_establishment.py
+++ b/app/services/context_establishment.py
@@ -11,7 +11,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.cli.paths import formal_runtime_paths
-from app.core.errors import InputValidationError, ResourceNotFoundError
+from app.core.errors import (
+    InputValidationError,
+    OverallScanTimeout,
+    ResourceNotFoundError,
+    ScanInterrupted,
+)
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import (
     AssessmentMode,
@@ -97,10 +102,9 @@ class ContextEstablishmentService:
         if self.ephemeral_store is None:
             return
         for kind in (ContextKind.USER.value, ContextKind.ADMIN.value):
-            profile_id = contexts[kind].credential_profile_id
-            profile = session.get(CredentialProfile, profile_id) if profile_id is not None else None
-            if profile is not None and profile.secret_ref.startswith("ephemeral-file://"):
-                self.ephemeral_store.delete(profile.secret_ref)
+            reference = contexts[kind].temporary_secret_ref
+            if reference is not None:
+                self.ephemeral_store.delete(reference)
 
     def _existing_contexts(self, session: Session, run: ScanRun) -> dict[str, ScanContext]:
         contexts = {
@@ -127,6 +131,8 @@ class ContextEstablishmentService:
     ) -> tuple[CredentialProfile, CredentialProfile]:
         user = self._profile(session, contexts[ContextKind.USER.value])
         admin = self._profile(session, contexts[ContextKind.ADMIN.value])
+        self._claim_unowned_temporary_secret(contexts[ContextKind.USER.value], user)
+        self._claim_unowned_temporary_secret(contexts[ContextKind.ADMIN.value], admin)
         if user.target_id != admin.target_id:
             raise InputValidationError("user/admin 凭证档案必须属于同一目标。")
         if user.role != ContextKind.USER.value:
@@ -141,6 +147,21 @@ class ContextEstablishmentService:
         if self._origin(run.normalized_url) != self._origin(target.base_url):
             raise InputValidationError("验证运行 URL 必须与 target base URL 同源。")
         return user, admin
+
+    def _claim_unowned_temporary_secret(
+        self,
+        context: ScanContext,
+        profile: CredentialProfile,
+    ) -> None:
+        if context.temporary_secret_ref is not None:
+            return
+        if not profile.secret_ref.startswith("ephemeral-file://"):
+            return
+        try:
+            if self.ephemeral_store.path_for(profile.secret_ref).exists():
+                context.temporary_secret_ref = profile.secret_ref
+        except InputValidationError:
+            return
 
     def _profile(self, session: Session, context: ScanContext) -> CredentialProfile:
         if context.credential_profile_id is None:
@@ -183,7 +204,12 @@ class ContextEstablishmentService:
         context.started_at = context.started_at or now
         try:
             with session.begin_nested():
-                if before_request is None:
+                kwargs = {}
+                if before_request is not None:
+                    kwargs["before_request"] = before_request
+                if context.temporary_secret_ref is not None:
+                    kwargs["secret_ref"] = context.temporary_secret_ref
+                if not kwargs:
                     auth_session = self.auth_service.ensure_valid_for_profile(
                         session,
                         profile.id,
@@ -192,8 +218,10 @@ class ContextEstablishmentService:
                     auth_session = self.auth_service.ensure_valid_for_profile(
                         session,
                         profile.id,
-                        before_request=before_request,
+                        **kwargs,
                     )
+        except (OverallScanTimeout, ScanInterrupted):
+            raise
         except Exception:  # noqa: BLE001 - context boundary persists a redacted failure
             context.auth_session_id = None
             context.status = "failed"

--- a/app/services/context_establishment.py
+++ b/app/services/context_establishment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -54,7 +55,13 @@ class ContextEstablishmentService:
         self.audit_service = audit_service or AuditService()
         self.ephemeral_store = ephemeral_store
 
-    def establish(self, session: Session, run: ScanRun) -> list[ScanContext]:
+    def establish(
+        self,
+        session: Session,
+        run: ScanRun,
+        *,
+        before_request: Callable[[], None] | None = None,
+    ) -> list[ScanContext]:
         contexts = self._existing_contexts(session, run)
         anonymous = self._establish_anonymous(session, run, contexts)
         if run.mode == AssessmentMode.QUICK.value:
@@ -67,12 +74,14 @@ class ContextEstablishmentService:
                 run,
                 contexts[ContextKind.USER.value],
                 user_profile,
+                before_request=before_request,
             )
             admin = self._establish_authenticated(
                 session,
                 run,
                 contexts[ContextKind.ADMIN.value],
                 admin_profile,
+                before_request=before_request,
             )
             self._set_run_completeness(run, user, admin)
             session.flush()
@@ -167,12 +176,24 @@ class ContextEstablishmentService:
         run: ScanRun,
         context: ScanContext,
         profile: CredentialProfile,
+        *,
+        before_request: Callable[[], None] | None,
     ) -> ScanContext:
         now = datetime.now(timezone.utc)
         context.started_at = context.started_at or now
         try:
             with session.begin_nested():
-                auth_session = self.auth_service.ensure_valid_for_profile(session, profile.id)
+                if before_request is None:
+                    auth_session = self.auth_service.ensure_valid_for_profile(
+                        session,
+                        profile.id,
+                    )
+                else:
+                    auth_session = self.auth_service.ensure_valid_for_profile(
+                        session,
+                        profile.id,
+                        before_request=before_request,
+                    )
         except Exception:  # noqa: BLE001 - context boundary persists a redacted failure
             context.auth_session_id = None
             context.status = "failed"

--- a/app/services/coverage_comparison.py
+++ b/app/services/coverage_comparison.py
@@ -1,0 +1,163 @@
+"""Passive three-context coverage comparison."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.coverage_difference import CoverageDifference
+from app.models.scan_context import ScanContext
+from app.models.scan_run import ScanAsset, ScanRun
+from app.services.coverage_identity import redacted_observed_url
+
+CONTEXT_KINDS = ("anonymous", "user", "admin")
+
+
+@dataclass(frozen=True)
+class CoverageComparisonSummary:
+    differences: tuple[CoverageDifference, ...]
+    counts: dict[str, int]
+
+
+class CoverageComparisonService:
+    """Rebuild explainable passive differences for one authenticated run."""
+
+    def compare(self, session: Session, run: ScanRun) -> CoverageComparisonSummary:
+        contexts = {
+            context.kind: context
+            for context in session.scalars(
+                select(ScanContext).where(ScanContext.scan_run_id == run.id)
+            )
+        }
+        assets = list(
+            session.scalars(
+                select(ScanAsset)
+                .where(
+                    ScanAsset.scan_run_id == run.id,
+                    ScanAsset.identity_key.is_not(None),
+                )
+                .order_by(ScanAsset.identity_key, ScanAsset.id)
+            )
+        )
+        assets_by_identity: dict[str, dict[str, ScanAsset]] = {}
+        context_kind_by_id = {context.id: context.kind for context in contexts.values()}
+        for asset in assets:
+            kind = context_kind_by_id.get(asset.context_id)
+            if kind is None or asset.identity_key is None:
+                continue
+            assets_by_identity.setdefault(asset.identity_key, {})[kind] = asset
+
+        for existing in list(
+            session.scalars(
+                select(CoverageDifference).where(CoverageDifference.scan_run_id == run.id)
+            )
+        ):
+            session.delete(existing)
+        session.flush()
+
+        differences: list[CoverageDifference] = []
+        for identity_key in sorted(assets_by_identity):
+            context_assets = assets_by_identity[identity_key]
+            states = {
+                kind: self._state(contexts.get(kind), context_assets.get(kind))
+                for kind in CONTEXT_KINDS
+            }
+            classification = self._classification(states, context_assets)
+            difference = CoverageDifference(
+                scan_run_id=run.id,
+                identity_key=identity_key,
+                classification=classification,
+                anonymous_state=states["anonymous"],
+                user_state=states["user"],
+                admin_state=states["admin"],
+                anonymous_present=self._present_value(states["anonymous"]),
+                user_present=self._present_value(states["user"]),
+                admin_present=self._present_value(states["admin"]),
+                context_summaries={
+                    kind: self._asset_summary(asset) for kind, asset in context_assets.items()
+                },
+                confidence=self._confidence(classification, states),
+                diagnostic=self._diagnostic(classification),
+            )
+            session.add(difference)
+            differences.append(difference)
+        session.flush()
+        counts = dict(Counter(item.classification for item in differences))
+        return CoverageComparisonSummary(differences=tuple(differences), counts=counts)
+
+    def _state(
+        self,
+        context: ScanContext | None,
+        asset: ScanAsset | None,
+    ) -> str:
+        if asset is not None:
+            return "present"
+        if (
+            context is not None
+            and context.collection_status == "completed"
+            and context.completeness == "complete"
+        ):
+            return "absent"
+        return "unknown"
+
+    def _classification(
+        self,
+        states: dict[str, str],
+        context_assets: dict[str, ScanAsset],
+    ) -> str:
+        if "unknown" in states.values():
+            return "unknown"
+        pattern = tuple(states[kind] == "present" for kind in CONTEXT_KINDS)
+        if pattern == (True, True, True):
+            summaries = [self._stable_fields(context_assets[kind]) for kind in CONTEXT_KINDS]
+            return "shared" if summaries[0] == summaries[1] == summaries[2] else "inconsistent"
+        if pattern == (False, False, True):
+            return "admin_only"
+        if pattern == (False, True, True):
+            return "user_only"
+        if pattern == (False, True, False):
+            return "inconsistent"
+        if pattern[0]:
+            return "unexpectedly_anonymous"
+        return "inconsistent"
+
+    def _asset_summary(self, asset: ScanAsset) -> dict[str, object]:
+        return {"asset_id": asset.id, **self._stable_fields(asset)}
+
+    def _stable_fields(self, asset: ScanAsset) -> dict[str, object]:
+        attributes = asset.attributes if isinstance(asset.attributes, dict) else {}
+        return {
+            "status_code": asset.status_code,
+            "url": redacted_observed_url(asset.url),
+            "title": asset.title,
+            "content_type": attributes.get("content_type"),
+            "content_signature": attributes.get("content_signature"),
+        }
+
+    def _present_value(self, state: str) -> bool | None:
+        if state == "unknown":
+            return None
+        return state == "present"
+
+    def _confidence(self, classification: str, states: dict[str, str]) -> str:
+        if classification == "unknown":
+            return "low"
+        if classification == "inconsistent" and all(
+            state == "present" for state in states.values()
+        ):
+            return "medium"
+        return "high"
+
+    def _diagnostic(self, classification: str) -> str:
+        messages = {
+            "shared": "三个完整上下文均观察到相同的稳定资产响应。",
+            "user_only": "匿名上下文未观察到该资产，用户与管理员上下文已观察到。",
+            "admin_only": "仅管理员上下文观察到该资产。",
+            "unexpectedly_anonymous": "匿名上下文观察到该资产，但更高权限上下文存在缺失。",
+            "inconsistent": "上下文间的资产存在顺序或稳定响应属性不一致。",
+            "unknown": "至少一个上下文不完整，无法判断该资产是否缺失。",
+        }
+        return messages[classification]

--- a/app/services/coverage_comparison.py
+++ b/app/services/coverage_comparison.py
@@ -129,11 +129,14 @@ class CoverageComparisonService:
 
     def _stable_fields(self, asset: ScanAsset) -> dict[str, object]:
         attributes = asset.attributes if isinstance(asset.attributes, dict) else {}
+        content_type = attributes.get("content_type")
+        if isinstance(content_type, str):
+            content_type = content_type.split(";", maxsplit=1)[0].strip().lower() or None
         return {
             "status_code": asset.status_code,
             "url": redacted_observed_url(asset.url),
             "title": asset.title,
-            "content_type": attributes.get("content_type"),
+            "content_type": content_type,
             "content_signature": attributes.get("content_signature"),
         }
 

--- a/app/services/credentials.py
+++ b/app/services/credentials.py
@@ -54,6 +54,23 @@ class CredentialProfileService:
             )
         )
 
+    def list_for_target_role(
+        self,
+        session: Session,
+        target_id: int,
+        role: str,
+    ) -> list[CredentialProfile]:
+        return list(
+            session.scalars(
+                select(CredentialProfile)
+                .where(
+                    CredentialProfile.target_id == target_id,
+                    CredentialProfile.role == role,
+                )
+                .order_by(CredentialProfile.name, CredentialProfile.id)
+            )
+        )
+
     def get(self, session: Session, credential_id: int) -> CredentialProfile:
         credential = session.get(CredentialProfile, credential_id)
         if credential is None:

--- a/app/services/ephemeral_secret_store.py
+++ b/app/services/ephemeral_secret_store.py
@@ -1,0 +1,93 @@
+"""Owner-only short-lived storage for interactive coverage secrets."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import time
+from pathlib import Path
+
+from app.core.errors import InputValidationError
+
+
+class EphemeralSecretStore:
+    """Write secret values atomically and expose only opaque local references."""
+
+    _scheme = "ephemeral-file://"
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.expanduser().resolve()
+
+    def write(self, value: str) -> str:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.root.chmod(0o700)
+        token = secrets.token_urlsafe(24)
+        destination = self.root / f"{token}.secret"
+        temporary = self.root / f"{token}.tmp"
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(value)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, destination)
+            destination.chmod(0o600)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return f"{self._scheme}{destination}"
+
+    def path_for(self, reference: str) -> Path:
+        if not reference.startswith(self._scheme):
+            raise InputValidationError("Temporary secret reference scheme is invalid.")
+        root_mode = self.root.stat().st_mode if self.root.exists() else None
+        if root_mode is not None and (
+            not stat.S_ISDIR(root_mode) or stat.S_IMODE(root_mode) & 0o077
+        ):
+            raise InputValidationError("Temporary secret root permissions are too broad.")
+        candidate = Path(reference.removeprefix(self._scheme)).expanduser()
+        absolute = candidate.absolute()
+        try:
+            relative = absolute.relative_to(self.root)
+        except ValueError as error:
+            raise InputValidationError(
+                "Temporary secret reference is outside the private root."
+            ) from error
+        cursor = self.root
+        for part in relative.parts:
+            cursor /= part
+            if cursor.is_symlink():
+                raise InputValidationError("Temporary secret reference cannot use symlinks.")
+        resolved = absolute.resolve(strict=False)
+        if not resolved.is_relative_to(self.root):
+            raise InputValidationError("Temporary secret reference is outside the private root.")
+        if resolved.exists():
+            mode = resolved.stat().st_mode
+            if not stat.S_ISREG(mode):
+                raise InputValidationError("Temporary secret reference is not a regular file.")
+            if stat.S_IMODE(mode) & 0o077:
+                raise InputValidationError("Temporary secret file permissions are too broad.")
+        return resolved
+
+    def read(self, reference: str) -> str:
+        return self.path_for(reference).read_text(encoding="utf-8")
+
+    def delete(self, reference: str) -> None:
+        self.path_for(reference).unlink(missing_ok=True)
+
+    def purge_expired(self, max_age_seconds: int = 900) -> tuple[str, ...]:
+        if not self.root.exists():
+            return ()
+        cutoff = time.time() - max_age_seconds
+        deleted: list[str] = []
+        for candidate in sorted(self.root.glob("*.secret")):
+            if candidate.is_symlink():
+                continue
+            try:
+                if candidate.stat().st_mtime > cutoff:
+                    continue
+                candidate.unlink()
+            except FileNotFoundError:
+                continue
+            deleted.append(f"{self._scheme}{candidate}")
+        return tuple(deleted)

--- a/app/services/ephemeral_secret_store.py
+++ b/app/services/ephemeral_secret_store.py
@@ -70,7 +70,10 @@ class EphemeralSecretStore:
         return resolved
 
     def read(self, reference: str) -> str:
-        return self.path_for(reference).read_text(encoding="utf-8")
+        try:
+            return self.path_for(reference).read_text(encoding="utf-8")
+        except FileNotFoundError as error:
+            raise InputValidationError("Temporary secret reference has expired.") from error
 
     def delete(self, reference: str) -> None:
         self.path_for(reference).unlink(missing_ok=True)

--- a/app/services/inventory_collection.py
+++ b/app/services/inventory_collection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -42,14 +43,21 @@ class InventoryCollectionService:
         target: Target,
         auth_session: AuthSession,
         controls: InventoryBuildControls,
+        *,
+        start_url: str | None = None,
+        before_request: Callable[[], None] | None = None,
     ) -> InventoryCollectionResult:
         context = self.build_collection_context(target, auth_session)
+        kwargs: dict[str, object] = {}
+        if before_request is not None:
+            kwargs["before_request"] = before_request
         return self.gateway.collect(
             target=target,
-            start_url=context.start_url,
+            start_url=start_url or context.start_url,
             controls=controls,
             session_type=context.session_type,
             session_payload=context.session_payload,
+            **kwargs,
         )
 
     def build_collection_context(

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -17,12 +17,17 @@ from sqlalchemy.orm import Session, selectinload
 from app.core.errors import InputValidationError, ResourceNotFoundError
 from app.core.settings import Settings, get_settings
 from app.db.bootstrap import session_scope
+from app.models.coverage_difference import CoverageDifference
 from app.models.credential_profile import CredentialProfile
 from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
 from app.models.scan_context import ScanContext
 from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES, ScanRun, ScanRunStage
 from app.models.target import Target
-from app.schemas.assessment import AssessmentRunView, AssessmentStartRequest
+from app.schemas.assessment import (
+    AssessmentRunView,
+    AssessmentStartRequest,
+    CoverageDifferenceView,
+)
 from app.schemas.scan import (
     ScanContextView,
     ScanFailureView,
@@ -191,6 +196,15 @@ class ScanApplicationService:
                 self._mark_interrupted(run)
             return self._view(run)
 
+    def cancel_assessment(self, scan_run_id: int) -> AssessmentRunView:
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
+                raise InputValidationError("Only authenticated coverage runs are assessments.")
+            if run.status not in TERMINAL_SCAN_RUN_STATUSES:
+                self._mark_interrupted(run)
+            return self._assessment_view(run)
+
     def interrupt_active_scans(self) -> int:
         """在服务启动时收敛上次异常退出遗留的活动扫描。"""
 
@@ -217,6 +231,23 @@ class ScanApplicationService:
         with session_scope() as session:
             run = self._get(session, scan_run_id)
             return self._assessment_view(run)
+
+    def list_coverage_differences(
+        self,
+        scan_run_id: int,
+    ) -> list[CoverageDifferenceView]:
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
+                raise InputValidationError("Only authenticated coverage runs have differences.")
+            differences = list(
+                session.scalars(
+                    select(CoverageDifference)
+                    .where(CoverageDifference.scan_run_id == scan_run_id)
+                    .order_by(CoverageDifference.identity_key)
+                )
+            )
+            return [CoverageDifferenceView.model_validate(item) for item in differences]
 
     def list_scans(self, limit: int = 25) -> list[ScanRunView]:
         with session_scope() as session:

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -173,10 +173,16 @@ class ScanApplicationService:
             create_assessment_stages(session, run)
             session.commit()
             run_id = run.id
-        if request.mode == AssessmentMode.QUICK:
-            self.dispatcher.submit(run_id, self.execute_scan)
-        else:
-            self.dispatcher.submit(run_id, self.execute_authenticated_assessment)
+        callback = (
+            self.execute_scan
+            if request.mode == AssessmentMode.QUICK
+            else self.execute_authenticated_assessment
+        )
+        try:
+            self.dispatcher.submit(run_id, callback)
+        except Exception:
+            self._mark_dispatch_failed(run_id)
+            raise
         return self.get_assessment(run_id)
 
     def execute_scan(self, scan_run_id: int) -> None:
@@ -185,7 +191,10 @@ class ScanApplicationService:
 
     def execute_authenticated_assessment(self, scan_run_id: int) -> None:
         with session_scope() as session:
-            self.pipeline.execute_authenticated(session, scan_run_id)
+            try:
+                self.pipeline.execute_authenticated(session, scan_run_id)
+            finally:
+                self.pipeline.cleanup_temporary_context_secrets(session, scan_run_id)
 
     def cancel_scan(self, scan_run_id: int) -> ScanRunView:
         """立即标记一个尚未结束的扫描为已中断，保留已写入的证据。"""
@@ -203,6 +212,7 @@ class ScanApplicationService:
                 raise InputValidationError("Only authenticated coverage runs are assessments.")
             if run.status not in TERMINAL_SCAN_RUN_STATUSES:
                 self._mark_interrupted(run)
+                self.pipeline.cleanup_temporary_context_secrets(session, run.id)
             return self._assessment_view(run)
 
     def interrupt_active_scans(self) -> int:
@@ -219,7 +229,10 @@ class ScanApplicationService:
                 )
             )
             for scan_run_id in active_ids:
-                self._mark_interrupted(self._get(session, scan_run_id))
+                run = self._get(session, scan_run_id)
+                self._mark_interrupted(run)
+                if run.mode == AssessmentMode.AUTHENTICATED_COVERAGE.value:
+                    self.pipeline.cleanup_temporary_context_secrets(session, run.id)
             return len(active_ids)
 
     def get_scan(self, scan_run_id: int) -> ScanRunView:
@@ -296,6 +309,24 @@ class ScanApplicationService:
         shutdown = getattr(self.dispatcher, "shutdown", None)
         if shutdown is not None:
             shutdown()
+
+    def _mark_dispatch_failed(self, scan_run_id: int) -> None:
+        with session_scope() as session:
+            run = self._get(session, scan_run_id)
+            now = datetime.now(timezone.utc)
+            run.status = ScanRunStatus.FAILED.value
+            run.current_stage = ScanRunStatus.FAILED.value
+            run.error_code = "dispatch_failed"
+            run.error_message = "Scan could not be submitted for execution."
+            run.finished_at = now
+            run.active_key = None
+            for stage in run.stages:
+                if stage.status == "pending":
+                    stage.status = "skipped"
+                    stage.summary = "Skipped because scan dispatch failed."
+                    stage.finished_at = now
+            if run.mode == AssessmentMode.AUTHENTICATED_COVERAGE.value:
+                self.pipeline.cleanup_temporary_context_secrets(session, run.id)
 
     def _get(self, session, scan_run_id: int) -> ScanRun:
         run = session.scalar(

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -170,11 +170,17 @@ class ScanApplicationService:
             run_id = run.id
         if request.mode == AssessmentMode.QUICK:
             self.dispatcher.submit(run_id, self.execute_scan)
+        else:
+            self.dispatcher.submit(run_id, self.execute_authenticated_assessment)
         return self.get_assessment(run_id)
 
     def execute_scan(self, scan_run_id: int) -> None:
         with session_scope() as session:
             self.pipeline.execute(session, scan_run_id)
+
+    def execute_authenticated_assessment(self, scan_run_id: int) -> None:
+        with session_scope() as session:
+            self.pipeline.execute_authenticated(session, scan_run_id)
 
     def cancel_scan(self, scan_run_id: int) -> ScanRunView:
         """立即标记一个尚未结束的扫描为已中断，保留已写入的证据。"""

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
-from app.core.errors import InputValidationError, ResourceNotFoundError
+from app.core.errors import ConflictError, InputValidationError, ResourceNotFoundError
 from app.core.settings import Settings, get_settings
 from app.db.bootstrap import session_scope
 from app.models.coverage_difference import CoverageDifference
@@ -169,7 +169,7 @@ class ScanApplicationService:
                 if existing is not None:
                     return self._assessment_view(existing)
                 raise
-            session.add_all(self._assessment_contexts(run, request))
+            session.add_all(self._assessment_contexts(session, run, request))
             create_assessment_stages(session, run)
             session.commit()
             run_id = run.id
@@ -183,7 +183,7 @@ class ScanApplicationService:
         except Exception:
             self._mark_dispatch_failed(run_id)
             raise
-        return self.get_assessment(run_id)
+        return self._get_assessment_view_unchecked(run_id)
 
     def execute_scan(self, scan_run_id: int) -> None:
         with session_scope() as session:
@@ -235,6 +235,16 @@ class ScanApplicationService:
                     self.pipeline.cleanup_temporary_context_secrets(session, run.id)
             return len(active_ids)
 
+    def purge_expired_temporary_secrets(
+        self,
+        *,
+        max_age_seconds: int = 900,
+    ) -> tuple[str, ...]:
+        store = self.pipeline.ephemeral_secret_store
+        if store is None:
+            return ()
+        return store.purge_expired(max_age_seconds=max_age_seconds)
+
     def get_scan(self, scan_run_id: int) -> ScanRunView:
         with session_scope() as session:
             run = self._get(session, scan_run_id)
@@ -243,7 +253,12 @@ class ScanApplicationService:
     def get_assessment(self, scan_run_id: int) -> AssessmentRunView:
         with session_scope() as session:
             run = self._get(session, scan_run_id)
+            self._ensure_authenticated_assessment(run)
             return self._assessment_view(run)
+
+    def _get_assessment_view_unchecked(self, scan_run_id: int) -> AssessmentRunView:
+        with session_scope() as session:
+            return self._assessment_view(self._get(session, scan_run_id))
 
     def list_coverage_differences(
         self,
@@ -251,8 +266,7 @@ class ScanApplicationService:
     ) -> list[CoverageDifferenceView]:
         with session_scope() as session:
             run = self._get(session, scan_run_id)
-            if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
-                raise InputValidationError("Only authenticated coverage runs have differences.")
+            self._ensure_authenticated_assessment(run)
             differences = list(
                 session.scalars(
                     select(CoverageDifference)
@@ -346,6 +360,10 @@ class ScanApplicationService:
         if run is None:
             raise ResourceNotFoundError(f"Scan run {scan_run_id} was not found.")
         return run
+
+    def _ensure_authenticated_assessment(self, run: ScanRun) -> None:
+        if run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value:
+            raise InputValidationError("Only authenticated coverage runs are assessments.")
 
     def _mark_interrupted(self, run: ScanRun) -> None:
         now = datetime.now(timezone.utc)
@@ -521,7 +539,10 @@ class ScanApplicationService:
             raise InputValidationError("source_run_id 必须引用同一 target 的已终态 quick run。")
 
     def _assessment_contexts(
-        self, run: ScanRun, request: AssessmentStartRequest
+        self,
+        session: Session,
+        run: ScanRun,
+        request: AssessmentStartRequest,
     ) -> list[ScanContext]:
         contexts = [
             ScanContext(
@@ -531,20 +552,51 @@ class ScanApplicationService:
             )
         ]
         if request.mode == AssessmentMode.AUTHENTICATED_COVERAGE:
+            user_secret_ref = self._claim_temporary_secret_ref(session, request.user_profile_id)
+            admin_secret_ref = self._claim_temporary_secret_ref(session, request.admin_profile_id)
+            if user_secret_ref is not None and user_secret_ref == admin_secret_ref:
+                raise ConflictError("user/admin 凭据档案不能共享同一个一次性秘密。")
             contexts.extend(
                 [
                     ScanContext(
                         scan_run_id=run.id,
                         kind=ContextKind.USER.value,
                         credential_profile_id=request.user_profile_id,
+                        temporary_secret_ref=user_secret_ref,
                         status="pending",
                     ),
                     ScanContext(
                         scan_run_id=run.id,
                         kind=ContextKind.ADMIN.value,
                         credential_profile_id=request.admin_profile_id,
+                        temporary_secret_ref=admin_secret_ref,
                         status="pending",
                     ),
                 ]
             )
         return contexts
+
+    def _claim_temporary_secret_ref(
+        self,
+        session: Session,
+        profile_id: int | None,
+    ) -> str | None:
+        if profile_id is None or self.pipeline.ephemeral_secret_store is None:
+            return None
+        profile = session.get(CredentialProfile, profile_id)
+        if profile is None or not profile.secret_ref.startswith("ephemeral-file://"):
+            return None
+        try:
+            path = self.pipeline.ephemeral_secret_store.path_for(profile.secret_ref)
+        except InputValidationError:
+            return None
+        if not path.exists():
+            return None
+        existing = session.scalar(
+            select(ScanContext.id).where(ScanContext.temporary_secret_ref == profile.secret_ref)
+        )
+        if existing is not None:
+            raise ConflictError(
+                "该凭据档案的一次性秘密已由另一个 assessment 接管；请等待或重新补充。"
+            )
+        return profile.secret_ref

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.errors import InputValidationError, TargetPolicyError
+from app.models.credential_profile import CredentialProfile
 from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
 from app.models.scan_context import ScanContext
 from app.models.scan_run import (
@@ -35,7 +36,9 @@ from app.services.context_collection import (
     DefaultContextCollectionGateway,
 )
 from app.services.context_establishment import ContextEstablishmentService
+from app.services.coverage_comparison import CoverageComparisonService
 from app.services.coverage_identity import canonical_asset_identity, redacted_observed_url
+from app.services.ephemeral_secret_store import EphemeralSecretStore
 from app.services.scan_analysis import PassiveScanAnalyzer
 from app.services.scan_failure_classification import is_coverage_warning
 from app.services.scan_network import (
@@ -53,6 +56,7 @@ PROGRESS_AFTER_STAGE = {
     ScanStageName.ESTABLISH_CONTEXTS.value: 18,
     ScanStageName.COLLECT.value: 58,
     ScanStageName.NORMALIZE.value: 68,
+    ScanStageName.COMPARE_COVERAGE.value: 76,
     ScanStageName.ANALYZE.value: 86,
     ScanStageName.REPORT.value: 100,
 }
@@ -77,6 +81,8 @@ class ScanPipeline:
         redaction_service: RedactionService | None = None,
         context_service: ContextEstablishmentService | None = None,
         context_collection_service: ContextCollectionService | None = None,
+        coverage_comparison_service: CoverageComparisonService | None = None,
+        ephemeral_secret_store: EphemeralSecretStore | None = None,
         clock=time.monotonic,
     ) -> None:
         self.policy = policy
@@ -87,6 +93,12 @@ class ScanPipeline:
         self.context_service = context_service or ContextEstablishmentService()
         self.context_collection_service = context_collection_service or ContextCollectionService(
             gateway=DefaultContextCollectionGateway(http_gateway=gateway)
+        )
+        self.coverage_comparison_service = (
+            coverage_comparison_service or CoverageComparisonService()
+        )
+        self.ephemeral_secret_store = ephemeral_secret_store or getattr(
+            self.context_service, "ephemeral_store", None
         )
         self.clock = clock
 
@@ -312,6 +324,174 @@ class ScanPipeline:
             self._finalize_quick_context(session, run)
             session.commit()
             self._try_failure_report(session, run)
+
+    def execute_authenticated(self, session: Session, scan_run_id: int) -> None:
+        """Execute the passive three-context workflow without authorization replay."""
+
+        run = session.get(ScanRun, scan_run_id)
+        if (
+            run is None
+            or run.mode != AssessmentMode.AUTHENTICATED_COVERAGE.value
+            or run.status not in {ScanRunStatus.QUEUED.value, ScanRunStatus.RUNNING.value}
+        ):
+            return
+        options = ScanOptions.model_validate(run.options)
+        deadline = self.clock() + float(options.overall_timeout_seconds or 90)
+        run.status = ScanRunStatus.RUNNING.value
+        run.started_at = run.started_at or datetime.now(timezone.utc)
+        session.commit()
+        try:
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.VALIDATE.value,
+                deadline,
+                lambda: self._validate(run),
+            )
+            self.establish_contexts(session, run.id)
+            self.collect_contexts(session, run.id)
+            run = session.get(ScanRun, run.id)
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.NORMALIZE.value,
+                deadline,
+                lambda: self._normalize(session, run),
+                enforce_deadline=False,
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.COMPARE_COVERAGE.value,
+                deadline,
+                lambda: self._compare_coverage(session, run),
+                enforce_deadline=False,
+            )
+            self._skip_passive_replay(session, run)
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.ANALYZE.value,
+                deadline,
+                lambda: self._analyze(session, run),
+                enforce_deadline=False,
+            )
+            self._run_stage(
+                session,
+                run,
+                ScanStageName.REPORT.value,
+                deadline,
+                lambda: self._report(session, run),
+                enforce_deadline=False,
+            )
+            self._check_interrupted(session, run.id)
+            run = session.get(ScanRun, run.id)
+            incomplete = any(
+                context.collection_status != "completed" or context.completeness != "complete"
+                for context in run.contexts
+            )
+            run.status = (
+                ScanRunStatus.INCOMPLETE.value if incomplete else ScanRunStatus.COMPLETED.value
+            )
+            if incomplete:
+                if run.completeness not in {
+                    CompletenessStatus.MISSING_USER_CONTEXT.value,
+                    CompletenessStatus.MISSING_ADMIN_CONTEXT.value,
+                }:
+                    run.completeness = CompletenessStatus.INCOMPLETE.value
+            else:
+                run.completeness = CompletenessStatus.COMPLETE.value
+            run.current_stage = "finished"
+            run.progress = 100
+            run.finished_at = datetime.now(timezone.utc)
+            run.active_key = None
+            session.commit()
+        except ScanInterrupted:
+            session.rollback()
+            return
+        except Exception:  # noqa: BLE001 - persisted at the orchestration boundary
+            session.rollback()
+            run = session.get(ScanRun, scan_run_id)
+            if run is None:
+                raise
+            stage_name = run.current_stage if run.current_stage in STAGES else "pipeline"
+            safe_message = "Authenticated coverage orchestration failed."
+            stage = self._stage(session, run.id, stage_name)
+            if stage is not None:
+                stage.status = "failed"
+                stage.error_code = "authenticated_pipeline_failed"
+                stage.error_message = safe_message
+                stage.finished_at = datetime.now(timezone.utc)
+            run.status = ScanRunStatus.FAILED.value
+            run.completeness = CompletenessStatus.INCOMPLETE.value
+            run.error_code = "authenticated_pipeline_failed"
+            run.error_message = safe_message
+            run.finished_at = datetime.now(timezone.utc)
+            run.active_key = None
+            self._record_failure(
+                session,
+                run,
+                stage=stage_name,
+                code="authenticated_pipeline_failed",
+                message=safe_message,
+                url=None,
+                retryable=False,
+                attempt=1,
+            )
+            self._skip_pending_authenticated_stages(session, run, stage_name)
+            session.commit()
+            self._try_failure_report(session, run)
+        finally:
+            self._cleanup_temporary_context_secrets(session, scan_run_id)
+
+    def _compare_coverage(self, session: Session, run: ScanRun):
+        summary = self.coverage_comparison_service.compare(session, run)
+        return summary, f"Compared {len(summary.differences)} passive asset identity difference(s)."
+
+    def _skip_passive_replay(self, session: Session, run: ScanRun) -> None:
+        stage = self._stage(session, run.id, ScanStageName.REPLAY_AUTHORIZATION.value)
+        if stage is None:
+            raise RuntimeError("Missing persisted stage 'replay_authorization'.")
+        stage.status = "skipped"
+        stage.summary = "v0.3 仅执行被动认证覆盖；主动权限重放未执行。"
+        stage.finished_at = datetime.now(timezone.utc)
+        session.commit()
+
+    def _skip_pending_authenticated_stages(
+        self,
+        session: Session,
+        run: ScanRun,
+        failed_stage_name: str,
+    ) -> None:
+        failed = self._stage(session, run.id, failed_stage_name)
+        failed_position = failed.position if failed is not None else 0
+        now = datetime.now(timezone.utc)
+        for stage in run.stages:
+            if (
+                stage.position > failed_position
+                and stage.status == "pending"
+                and stage.name != ScanStageName.REPORT.value
+            ):
+                stage.status = "skipped"
+                stage.summary = "Skipped after an earlier authenticated coverage stage failed."
+                stage.finished_at = now
+
+    def _cleanup_temporary_context_secrets(
+        self,
+        session: Session,
+        scan_run_id: int,
+    ) -> None:
+        if self.ephemeral_secret_store is None:
+            return
+        contexts = list(
+            session.scalars(select(ScanContext).where(ScanContext.scan_run_id == scan_run_id))
+        )
+        for context in contexts:
+            if context.credential_profile_id is None:
+                continue
+            profile = session.get(CredentialProfile, context.credential_profile_id)
+            if profile is not None and profile.secret_ref.startswith("ephemeral-file://"):
+                self.ephemeral_secret_store.delete(profile.secret_ref)
 
     def _run_stage(self, session, run, name, deadline, operation, *, enforce_deadline: bool = True):
         self._check_interrupted(session, run.id)
@@ -580,14 +760,12 @@ class ScanPipeline:
         )
         candidates = self.analyzer.analyze(assets, evidence)
         now = datetime.now(timezone.utc)
+        persisted_keys = set(
+            session.scalars(select(ScanFinding.dedup_key).where(ScanFinding.scan_run_id == run.id))
+        )
+        created_count = 0
         for candidate in candidates:
-            existing = session.scalar(
-                select(ScanFinding).where(
-                    ScanFinding.scan_run_id == run.id,
-                    ScanFinding.dedup_key == candidate.dedup_key,
-                )
-            )
-            if existing is not None:
+            if candidate.dedup_key in persisted_keys:
                 continue
             session.add(
                 ScanFinding(
@@ -596,8 +774,10 @@ class ScanPipeline:
                     **candidate.model_dump(),
                 )
             )
+            persisted_keys.add(candidate.dedup_key)
+            created_count += 1
         session.flush()
-        return None, f"Created {len(candidates)} passive, explainable finding(s)."
+        return None, f"Created {created_count} passive, explainable finding(s)."
 
     def _report(self, session: Session, run: ScanRun):
         path = self.report_service.generate(session, run.id)

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -10,8 +10,12 @@ from urllib.parse import urlparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core.errors import InputValidationError, TargetPolicyError
-from app.models.credential_profile import CredentialProfile
+from app.core.errors import (
+    InputValidationError,
+    OverallScanTimeout,
+    ScanInterrupted,
+    TargetPolicyError,
+)
 from app.models.enums import AssessmentMode, CompletenessStatus, ContextKind
 from app.models.scan_context import ScanContext
 from app.models.scan_run import (
@@ -60,14 +64,6 @@ PROGRESS_AFTER_STAGE = {
     ScanStageName.ANALYZE.value: 86,
     ScanStageName.REPORT.value: 100,
 }
-
-
-class OverallScanTimeout(RuntimeError):
-    pass
-
-
-class ScanInterrupted(RuntimeError):
-    """A persisted cancellation signal observed at a safe pipeline boundary."""
 
 
 class ScanPipeline:
@@ -448,6 +444,37 @@ class ScanPipeline:
         except ScanInterrupted:
             session.rollback()
             return
+        except OverallScanTimeout as error:
+            session.rollback()
+            run = session.get(ScanRun, scan_run_id)
+            if run is None:
+                raise
+            stage_name = run.current_stage if run.current_stage in STAGES else "pipeline"
+            stage = self._stage(session, run.id, stage_name)
+            if stage is not None:
+                stage.status = "failed"
+                stage.error_code = "overall_timeout"
+                stage.error_message = str(error)
+                stage.finished_at = datetime.now(timezone.utc)
+            self._record_failure(
+                session,
+                run,
+                stage=stage_name,
+                code="overall_timeout",
+                message=str(error),
+                url=run.normalized_url,
+                retryable=False,
+                attempt=1,
+            )
+            run.status = ScanRunStatus.INCOMPLETE.value
+            run.completeness = CompletenessStatus.INCOMPLETE.value
+            run.error_code = "overall_timeout"
+            run.error_message = str(error)
+            run.finished_at = datetime.now(timezone.utc)
+            run.active_key = None
+            self._skip_pending_authenticated_stages(session, run, stage_name)
+            session.commit()
+            self._try_failure_report(session, run)
         except Exception:  # noqa: BLE001 - persisted at the orchestration boundary
             session.rollback()
             run = session.get(ScanRun, scan_run_id)
@@ -528,11 +555,8 @@ class ScanPipeline:
             session.scalars(select(ScanContext).where(ScanContext.scan_run_id == scan_run_id))
         )
         for context in contexts:
-            if context.credential_profile_id is None:
-                continue
-            profile = session.get(CredentialProfile, context.credential_profile_id)
-            if profile is not None and profile.secret_ref.startswith("ephemeral-file://"):
-                self.ephemeral_secret_store.delete(profile.secret_ref)
+            if context.temporary_secret_ref is not None:
+                self.ephemeral_secret_store.delete(context.temporary_secret_ref)
 
     def _run_stage(self, session, run, name, deadline, operation, *, enforce_deadline: bool = True):
         self._check_interrupted(session, run.id)

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -102,7 +102,13 @@ class ScanPipeline:
         )
         self.clock = clock
 
-    def establish_contexts(self, session: Session, scan_run_id: int) -> list[ScanContext]:
+    def establish_contexts(
+        self,
+        session: Session,
+        scan_run_id: int,
+        *,
+        before_request=None,
+    ) -> list[ScanContext]:
         """Execute only the authenticated context-establishment stage."""
 
         run = session.get(ScanRun, scan_run_id)
@@ -120,7 +126,11 @@ class ScanPipeline:
         run.current_stage = ScanStageName.ESTABLISH_CONTEXTS.value
         session.flush()
         try:
-            contexts = self.context_service.establish(session, run)
+            contexts = self.context_service.establish(
+                session,
+                run,
+                before_request=before_request,
+            )
         except Exception as error:
             session.rollback()
             run = session.get(ScanRun, scan_run_id)
@@ -156,6 +166,8 @@ class ScanPipeline:
         self,
         session: Session,
         scan_run_id: int,
+        *,
+        before_request=None,
     ) -> list[ContextCollectionSummary]:
         """Execute context collection independently so one failure retains other results."""
 
@@ -188,7 +200,16 @@ class ScanPipeline:
                 continue
             try:
                 with session.begin_nested():
-                    summaries.append(self.context_collection_service.collect(session, run, context))
+                    summaries.append(
+                        self.context_collection_service.collect(
+                            session,
+                            run,
+                            context,
+                            before_request=before_request,
+                        )
+                    )
+            except (OverallScanTimeout, ScanInterrupted):
+                raise
             except Exception:  # noqa: BLE001 - context boundary persists only a safe diagnostic
                 context = session.get(ScanContext, context.id)
                 context.status = "failed"
@@ -348,8 +369,20 @@ class ScanPipeline:
                 deadline,
                 lambda: self._validate(run),
             )
-            self.establish_contexts(session, run.id)
-            self.collect_contexts(session, run.id)
+
+            def request_guard() -> None:
+                self._guard_network_request(session, run.id, deadline)
+
+            self.establish_contexts(
+                session,
+                run.id,
+                before_request=request_guard,
+            )
+            self.collect_contexts(
+                session,
+                run.id,
+                before_request=request_guard,
+            )
             run = session.get(ScanRun, run.id)
             self._run_stage(
                 session,

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -475,7 +475,7 @@ class ScanPipeline:
             session.commit()
             self._try_failure_report(session, run)
         finally:
-            self._cleanup_temporary_context_secrets(session, scan_run_id)
+            self.cleanup_temporary_context_secrets(session, scan_run_id)
 
     def _compare_coverage(self, session: Session, run: ScanRun):
         summary = self.coverage_comparison_service.compare(session, run)
@@ -509,11 +509,13 @@ class ScanPipeline:
                 stage.summary = "Skipped after an earlier authenticated coverage stage failed."
                 stage.finished_at = now
 
-    def _cleanup_temporary_context_secrets(
+    def cleanup_temporary_context_secrets(
         self,
         session: Session,
         scan_run_id: int,
     ) -> None:
+        """Delete short-lived credential material linked to an assessment."""
+
         if self.ephemeral_secret_store is None:
             return
         contexts = list(

--- a/app/services/scan_pipeline.py
+++ b/app/services/scan_pipeline.py
@@ -423,9 +423,15 @@ class ScanPipeline:
                 context.collection_status != "completed" or context.completeness != "complete"
                 for context in run.contexts
             )
-            run.status = (
-                ScanRunStatus.INCOMPLETE.value if incomplete else ScanRunStatus.COMPLETED.value
+            coverage_warnings = any(
+                is_coverage_warning(failure.stage, failure.code) for failure in run.failures
             )
+            if incomplete:
+                run.status = ScanRunStatus.INCOMPLETE.value
+            elif coverage_warnings:
+                run.status = ScanRunStatus.COMPLETED_WITH_WARNINGS.value
+            else:
+                run.status = ScanRunStatus.COMPLETED.value
             if incomplete:
                 if run.completeness not in {
                     CompletenessStatus.MISSING_USER_CONTEXT.value,

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -14,6 +14,7 @@ from app.cli.paths import formal_runtime_paths
 from app.core.errors import ResourceNotFoundError
 from app.models.enums import AssessmentMode
 from app.models.scan_run import ScanRun
+from app.services.coverage_identity import redacted_observed_url
 from app.services.scan_failure_classification import is_coverage_warning
 from app.services.scan_report_quality import project_finding_groups, report_version_values
 
@@ -67,14 +68,30 @@ class ScanReportService:
         differences = sorted(run.coverage_differences, key=lambda item: item.identity_key)
         classification_counts = Counter(item.classification for item in differences)
         stages = sorted(run.stages, key=lambda item: item.position)
+        entry_url = redacted_observed_url(run.normalized_url)
+        summary_status = run.status
+        if summary_status == "running":
+            incomplete = any(
+                context.collection_status != "completed" or context.completeness != "complete"
+                for context in contexts
+            )
+            coverage_warnings = any(
+                is_coverage_warning(failure.stage, failure.code) for failure in run.failures
+            )
+            if incomplete:
+                summary_status = "incomplete"
+            elif coverage_warnings:
+                summary_status = "completed_with_warnings"
+            else:
+                summary_status = "completed"
         lines = [
             f"# Garden 认证覆盖报告 #{run.id}",
             "",
             "## 执行摘要",
             "",
-            f"- 任务状态：{run.status}",
+            f"- 任务状态：{summary_status}",
             f"- 完整性：{run.completeness}",
-            f"- 入口 URL：{self._inline(run.normalized_url)}",
+            f"- 入口 URL：{self._inline(entry_url)}",
             f"- 上下文：{len(contexts)}",
             f"- 覆盖差异：{len(differences)}",
             "- 模式：anonymous / user / admin 三上下文，仅执行被动采集。",
@@ -256,6 +273,7 @@ class ScanReportService:
         findings = sorted(run.findings, key=lambda item: item.id)
         finding_groups = project_finding_groups(findings)
         stages = sorted(run.stages, key=lambda item: item.position)
+        entry_url = redacted_observed_url(run.normalized_url)
         summary_status = run.status
         if summary_status == "running":
             summary_status = "completed_with_warnings" if failures else "completed"
@@ -265,7 +283,7 @@ class ScanReportService:
             "## 执行摘要",
             "",
             f"- 任务状态：{summary_status}",
-            f"- 入口 URL：{run.normalized_url}",
+            f"- 入口 URL：{entry_url}",
             f"- 发现资产：{len(assets)}",
             f"- 证据记录：{len(evidence)}",
             f"- 风险或关注项：{len(finding_groups)} 类（{len(findings)} 条原始观察）",
@@ -274,7 +292,7 @@ class ScanReportService:
             "",
             "## 扫描范围",
             "",
-            f"- 起始地址：{run.normalized_url}",
+            f"- 起始地址：{entry_url}",
             f"- 最大页面数：{run.options.get('max_pages', '-')}",
             f"- 最大静态资源数：{run.options.get('max_resources', '-')}",
             f"- 最大深度：{run.options.get('max_depth', '-')}",

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.cli.paths import formal_runtime_paths
 from app.core.errors import ResourceNotFoundError
+from app.models.enums import AssessmentMode
 from app.models.scan_run import ScanRun
 from app.services.scan_failure_classification import is_coverage_warning
 from app.services.scan_report_quality import project_finding_groups, report_version_values
@@ -39,12 +41,19 @@ class ScanReportService:
                 selectinload(ScanRun.evidence),
                 selectinload(ScanRun.findings),
                 selectinload(ScanRun.failures),
+                selectinload(ScanRun.contexts),
+                selectinload(ScanRun.coverage_differences),
+                selectinload(ScanRun.replay_executions),
             )
         )
         if run is None:
             raise ResourceNotFoundError(f"Scan run {scan_run_id} was not found.")
         generated_at = datetime.now(timezone.utc)
-        lines = self._render(run, generated_at)
+        lines = (
+            self._render_authenticated(run, generated_at)
+            if run.mode == AssessmentMode.AUTHENTICATED_COVERAGE.value
+            else self._render(run, generated_at)
+        )
         self.output_root.mkdir(parents=True, exist_ok=True)
         path = self.output_root / f"scan-{run.id}.md"
         path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
@@ -52,6 +61,187 @@ class ScanReportService:
         run.report_generated_at = generated_at
         session.flush()
         return str(path)
+
+    def _render_authenticated(self, run: ScanRun, generated_at: datetime) -> list[str]:
+        contexts = sorted(run.contexts, key=lambda item: item.id)
+        differences = sorted(run.coverage_differences, key=lambda item: item.identity_key)
+        classification_counts = Counter(item.classification for item in differences)
+        stages = sorted(run.stages, key=lambda item: item.position)
+        lines = [
+            f"# Garden 认证覆盖报告 #{run.id}",
+            "",
+            "## 执行摘要",
+            "",
+            f"- 任务状态：{run.status}",
+            f"- 完整性：{run.completeness}",
+            f"- 入口 URL：{self._inline(run.normalized_url)}",
+            f"- 上下文：{len(contexts)}",
+            f"- 覆盖差异：{len(differences)}",
+            "- 模式：anonymous / user / admin 三上下文，仅执行被动采集。",
+            "- 主动权限重放未执行；本报告不包含利用、写入或破坏性操作。",
+            "",
+            "## 三上下文健康与完整性",
+            "",
+            "| 上下文 | 状态 | 登录 | 会话验证 | 采集 | 完整性 | 资产 | 失败 |",
+            "|---|---|---|---|---|---|---:|---:|",
+        ]
+        for context in contexts:
+            lines.append(
+                f"| {self._cell(context.kind)} | {self._cell(context.status)} | "
+                f"{self._cell(context.login_status)} | "
+                f"{self._cell(context.session_validation_status)} | "
+                f"{self._cell(context.collection_status)} | "
+                f"{self._cell(context.completeness)} | {context.asset_count} | "
+                f"{context.failure_count} |"
+            )
+        if not contexts:
+            lines.append("| - | unknown | unknown | unknown | unknown | unknown | 0 | 0 |")
+
+        lines.extend(
+            [
+                "",
+                "## 覆盖差异分类计数",
+                "",
+                "| 分类 | 数量 |",
+                "|---|---:|",
+            ]
+        )
+        for classification, count in sorted(classification_counts.items()):
+            lines.append(f"| {self._cell(classification)} | {count} |")
+        if not classification_counts:
+            lines.append("| 无 | 0 |")
+
+        lines.extend(
+            [
+                "",
+                "## 被动覆盖差异",
+                "",
+                "覆盖差异不是已确认漏洞；它们是需要结合业务授权模型复核的被动观察。",
+                "",
+                "| 资产身份 | anonymous | user | admin | 分类 | 置信度 |",
+                "|---|---|---|---|---|---|",
+            ]
+        )
+        for difference in differences:
+            lines.append(
+                f"| `{self._cell(difference.identity_key)}` | "
+                f"{self._cell(difference.anonymous_state)} | "
+                f"{self._cell(difference.user_state)} | "
+                f"{self._cell(difference.admin_state)} | "
+                f"{self._cell(difference.classification)} | "
+                f"{self._cell(difference.confidence)} |"
+            )
+        if not differences:
+            lines.append("| - | unknown | unknown | unknown | 无可比较差异 | low |")
+
+        lines.extend(["", "## 属性不一致详情", ""])
+        inconsistent = [item for item in differences if item.classification == "inconsistent"]
+        for difference in inconsistent:
+            lines.extend(
+                [
+                    f"### `{self._inline(difference.identity_key)}`",
+                    "",
+                    "| 上下文 | 状态 | URL | 标题 | Content-Type | 内容签名 |",
+                    "|---|---:|---|---|---|---|",
+                ]
+            )
+            summaries = difference.context_summaries or {}
+            for kind in ("anonymous", "user", "admin"):
+                summary = summaries.get(kind)
+                if not isinstance(summary, dict):
+                    continue
+                lines.append(
+                    f"| {kind} | {self._cell(str(summary.get('status_code') or '-'))} | "
+                    f"{self._cell(str(summary.get('url') or '-'))} | "
+                    f"{self._cell(str(summary.get('title') or '-'))} | "
+                    f"{self._cell(str(summary.get('content_type') or '-'))} | "
+                    f"{self._cell(str(summary.get('content_signature') or '-'))} |"
+                )
+        if not inconsistent:
+            lines.append("未观察到三上下文均存在但稳定属性不一致的资产。")
+
+        lines.extend(
+            [
+                "",
+                "## 被动观察与证据索引",
+                "",
+                "| 资产身份 | anonymous | user | admin |",
+                "|---|---|---|---|",
+            ]
+        )
+        for difference in differences:
+            summaries = difference.context_summaries or {}
+            asset_refs: list[str] = []
+            for kind in ("anonymous", "user", "admin"):
+                summary = summaries.get(kind)
+                asset_id = summary.get("asset_id") if isinstance(summary, dict) else None
+                asset_refs.append(f"A{asset_id}" if isinstance(asset_id, int) else "-")
+            lines.append(
+                f"| `{self._cell(difference.identity_key)}` | "
+                f"{asset_refs[0]} | {asset_refs[1]} | {asset_refs[2]} |"
+            )
+        if not differences:
+            lines.append("| - | - | - | - |")
+
+        lines.extend(["", "## 分类说明", ""])
+        for difference in differences:
+            lines.append(
+                f"- `{self._inline(difference.identity_key)}`："
+                f"{self._inline(difference.diagnostic or '无额外诊断。')}"
+            )
+        if not differences:
+            lines.append("未生成覆盖分类。")
+
+        lines.extend(["", "## 失败与未覆盖部分", ""])
+        incomplete_contexts = [
+            context
+            for context in contexts
+            if context.collection_status != "completed" or context.completeness != "complete"
+        ]
+        for context in incomplete_contexts:
+            lines.append(
+                f"- {self._inline(context.kind)}："
+                f"采集={self._inline(context.collection_status)}，"
+                f"完整性={self._inline(context.completeness)}，"
+                f"代码={self._inline(context.error_code or '-')}"
+            )
+        for failure in sorted(run.failures, key=lambda item: item.id):
+            lines.append(
+                f"- 阶段={self._inline(failure.stage)}，"
+                f"代码={self._inline(failure.code)}，尝试={failure.attempt}"
+            )
+        if not incomplete_contexts and not run.failures:
+            lines.append("未记录上下文缺失或阶段失败。")
+
+        lines.extend(["", "## 阶段记录", ""])
+        for stage in stages:
+            status = (
+                "completed"
+                if stage.name == "report" and stage.status == "running"
+                else stage.status
+            )
+            summary = (
+                "本认证覆盖报告已生成。"
+                if stage.name == "report" and stage.status == "running"
+                else stage.summary
+            )
+            lines.append(
+                f"- {self._inline(stage.name)}：{self._inline(status)}；"
+                f"{self._inline(summary or '-')}"
+            )
+
+        lines.extend(
+            [
+                "",
+                "## 生成时间",
+                "",
+                f"- {generated_at.isoformat()}",
+                "",
+                "---",
+                "本报告仅反映已授权边界内的被动认证覆盖结果。",
+            ]
+        )
+        return lines
 
     def _render(self, run: ScanRun, generated_at: datetime) -> list[str]:
         failures = sorted(run.failures, key=lambda item: item.id)

--- a/app/services/secret_resolver.py
+++ b/app/services/secret_resolver.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import os
 
 from app.core.errors import InputValidationError
+from app.services.ephemeral_secret_store import EphemeralSecretStore
 
 
 class SecretResolver:
     """Resolve secret references without exposing raw secrets in UI or CLI output."""
+
+    def __init__(self, *, ephemeral_store: EphemeralSecretStore | None = None) -> None:
+        self.ephemeral_store = ephemeral_store
 
     def resolve(self, secret_ref: str) -> str:
         if secret_ref.startswith("env://"):
@@ -23,6 +27,10 @@ class SecretResolver:
             return value
         if secret_ref.startswith("literal://"):
             return secret_ref.removeprefix("literal://")
+        if secret_ref.startswith("ephemeral-file://"):
+            if self.ephemeral_store is None:
+                raise InputValidationError("Temporary secret storage is not configured.")
+            return self.ephemeral_store.read(secret_ref)
         raise InputValidationError(
             "Unsupported secret_ref scheme. Use env://VAR_NAME or literal://value for local demos."
         )

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -65,7 +66,13 @@ class AuthSessionService:
         result, _auth_session = self._login_profile(session, credential)
         return result
 
-    def ensure_valid_for_profile(self, session: Session, profile_id: int) -> AuthSession:
+    def ensure_valid_for_profile(
+        self,
+        session: Session,
+        profile_id: int,
+        *,
+        before_request: Callable[[], None] | None = None,
+    ) -> AuthSession:
         """Return a storage-backed session after adapter validation, logging in if needed."""
 
         credential = self.credential_service.get(session, profile_id)
@@ -81,31 +88,67 @@ class AuthSessionService:
         )
         for candidate in candidates:
             try:
-                validation = self.validate(session, candidate.id)
+                validation = self.validate(
+                    session,
+                    candidate.id,
+                    before_request=before_request,
+                )
                 if validation.valid:
                     return candidate
                 if candidate.refresh_supported:
-                    refreshed = self.refresh(session, candidate.id)
-                    if refreshed.success and self.validate(session, candidate.id).valid:
+                    refreshed = self.refresh(
+                        session,
+                        candidate.id,
+                        before_request=before_request,
+                    )
+                    if (
+                        refreshed.success
+                        and self.validate(
+                            session,
+                            candidate.id,
+                            before_request=before_request,
+                        ).valid
+                    ):
                         return candidate
             except GardenError:
                 continue
 
-        login_result, auth_session = self._login_profile(session, credential)
+        login_result, auth_session = self._login_profile(
+            session,
+            credential,
+            before_request=before_request,
+        )
         if not login_result.success or auth_session is None:
             raise ConflictError("Authentication login failed for the credential profile.")
-        if not self.validate(session, auth_session.id).valid:
+        if not self.validate(
+            session,
+            auth_session.id,
+            before_request=before_request,
+        ).valid:
             raise ConflictError("The newly created authentication session was not valid.")
         return auth_session
 
     def _login_profile(
-        self, session: Session, credential: CredentialProfile
+        self,
+        session: Session,
+        credential: CredentialProfile,
+        *,
+        before_request: Callable[[], None] | None = None,
     ) -> tuple[LoginExecutionResult, AuthSession | None]:
         target = self.target_service.get(session, credential.target_id)
         config = self.login_config_service.load(credential.login_config_path)
         secret_value = self.secret_resolver.resolve(credential.secret_ref)
         adapter = self._get_adapter(config)
-        result = adapter.login(target, credential, secret_value, config)
+        if before_request is None:
+            result = adapter.login(target, credential, secret_value, config)
+        else:
+            result = adapter.login(
+                target,
+                credential,
+                secret_value,
+                config,
+                before_request=before_request,
+            )
         auth_session = None
         if result.success:
             auth_session = self._persist_session(
@@ -163,7 +206,13 @@ class AuthSessionService:
             )
         )
 
-    def validate(self, session: Session, session_id: int):
+    def validate(
+        self,
+        session: Session,
+        session_id: int,
+        *,
+        before_request: Callable[[], None] | None = None,
+    ):
         auth_session = self.get(session, session_id)
         credential = session.get(CredentialProfile, auth_session.credential_profile_id)
         target = self.target_service.get(session, auth_session.target_id)
@@ -174,7 +223,16 @@ class AuthSessionService:
         config = self.login_config_service.load(credential.login_config_path)
         payload = self.storage_service.read_payload(auth_session.storage_ref)
         adapter = self._get_adapter(config)
-        result = adapter.validate(target, credential, config, payload)
+        if before_request is None:
+            result = adapter.validate(target, credential, config, payload)
+        else:
+            result = adapter.validate(
+                target,
+                credential,
+                config,
+                payload,
+                before_request=before_request,
+            )
         auth_session.status = result.status.value
         auth_session.last_validated_at = datetime.now(timezone.utc)
         auth_session.expires_at = result.expires_at or auth_session.expires_at
@@ -203,7 +261,13 @@ class AuthSessionService:
         )
         return result
 
-    def refresh(self, session: Session, session_id: int) -> LoginExecutionResult:
+    def refresh(
+        self,
+        session: Session,
+        session_id: int,
+        *,
+        before_request: Callable[[], None] | None = None,
+    ) -> LoginExecutionResult:
         auth_session = self.get(session, session_id)
         if not auth_session.refresh_supported:
             raise ConflictError(f"Session {session_id} does not support refresh.")
@@ -217,7 +281,17 @@ class AuthSessionService:
         payload = self.storage_service.read_payload(auth_session.storage_ref)
         secret_value = self.secret_resolver.resolve(credential.secret_ref)
         adapter = self._get_adapter(config)
-        result = adapter.refresh(target, credential, secret_value, config, payload)
+        if before_request is None:
+            result = adapter.refresh(target, credential, secret_value, config, payload)
+        else:
+            result = adapter.refresh(
+                target,
+                credential,
+                secret_value,
+                config,
+                payload,
+                before_request=before_request,
+            )
         if result.success:
             auth_session.status = result.status.value
             auth_session.expires_at = result.expires_at

--- a/app/services/sessions.py
+++ b/app/services/sessions.py
@@ -72,6 +72,7 @@ class AuthSessionService:
         profile_id: int,
         *,
         before_request: Callable[[], None] | None = None,
+        secret_ref: str | None = None,
     ) -> AuthSession:
         """Return a storage-backed session after adapter validation, logging in if needed."""
 
@@ -100,6 +101,7 @@ class AuthSessionService:
                         session,
                         candidate.id,
                         before_request=before_request,
+                        secret_ref=secret_ref,
                     )
                     if (
                         refreshed.success
@@ -117,6 +119,7 @@ class AuthSessionService:
             session,
             credential,
             before_request=before_request,
+            secret_ref=secret_ref,
         )
         if not login_result.success or auth_session is None:
             raise ConflictError("Authentication login failed for the credential profile.")
@@ -134,10 +137,11 @@ class AuthSessionService:
         credential: CredentialProfile,
         *,
         before_request: Callable[[], None] | None = None,
+        secret_ref: str | None = None,
     ) -> tuple[LoginExecutionResult, AuthSession | None]:
         target = self.target_service.get(session, credential.target_id)
         config = self.login_config_service.load(credential.login_config_path)
-        secret_value = self.secret_resolver.resolve(credential.secret_ref)
+        secret_value = self.secret_resolver.resolve(secret_ref or credential.secret_ref)
         adapter = self._get_adapter(config)
         if before_request is None:
             result = adapter.login(target, credential, secret_value, config)
@@ -267,6 +271,7 @@ class AuthSessionService:
         session_id: int,
         *,
         before_request: Callable[[], None] | None = None,
+        secret_ref: str | None = None,
     ) -> LoginExecutionResult:
         auth_session = self.get(session, session_id)
         if not auth_session.refresh_supported:
@@ -279,7 +284,7 @@ class AuthSessionService:
             )
         config = self.login_config_service.load(credential.login_config_path)
         payload = self.storage_service.read_payload(auth_session.storage_ref)
-        secret_value = self.secret_resolver.resolve(credential.secret_ref)
+        secret_value = self.secret_resolver.resolve(secret_ref or credential.secret_ref)
         adapter = self._get_adapter(config)
         if before_request is None:
             result = adapter.refresh(target, credential, secret_value, config, payload)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,6 +63,33 @@ garden stop
 
 配置文件由新安装器创建时会带有托管版本标记。升级遇到旧安装器原样生成、仍带旧版 guardrail 注释的 `GARDEN_ALLOW_NON_LOCAL_TARGETS=false` 时，会迁移为当前默认的公网目标策略；没有旧版生成特征的自定义 local-only 配置保持不变。
 
+### 被动认证覆盖（可选高级入口）
+
+默认 quick 体验保持不变；只有需要比较匿名、普通用户和管理员可见面时才运行：
+
+```bash
+garden coverage URL
+```
+
+交互式向导会选择或创建同源 Target，并依次选择或创建角色精确为 `user`、`admin` 的凭据档案。敏感值通过隐藏输入读取，短期保存在 Garden 私有目录中权限为 `0600` 的文件；档案只记录 `ephemeral-file://` 引用，会话建立和验证结束后立即消费删除。原始密码、令牌、Cookie 和 Authorization 不进入命令参数、普通数据库字段、日志或报告。
+
+非交互环境必须同时提供两个档案 ID：
+
+```bash
+garden coverage https://app.example/ \
+  --user-profile 12 \
+  --admin-profile 13 \
+  --non-interactive
+```
+
+该版本只执行 anonymous/user/admin 三上下文的有界被动采集，主动权限重放未执行。覆盖差异不是已确认漏洞；上下文不完整时，未观察到的资产标记为 `unknown`，需要先修复认证或采集完整性再判断。
+
+认证 coverage 使用 Playwright 建立和复用浏览器会话。开发环境首次运行前安装 Chromium：
+
+```bash
+.venv/bin/python -m playwright install chromium --no-shell
+```
+
 ## 三、本地开发部署
 
 ### 1. 克隆仓库

--- a/docs/superpowers/plans/2026-08-26-v0-3-passive-authenticated-coverage.md
+++ b/docs/superpowers/plans/2026-08-26-v0-3-passive-authenticated-coverage.md
@@ -1,0 +1,491 @@
+# Garden v0.3.0 Passive Authenticated Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 保持 quick scan 终端、HTTP、Web 和报告体验不变，新增由 `garden coverage URL` 引导的安全凭据向导、三上下文被动覆盖比较和认证覆盖报告。
+
+**Architecture:** `garden coverage` 使用独立向导选择或创建同源 Target 与 user/admin 凭据档案；原始秘密只进入短生命周期 `EphemeralSecretStore`，会话建立后清理。认证运行继续从 `ScanApplicationService.start_assessment(request)` 创建，由独立 `ScanPipeline.execute_authenticated(session, assessment_id)` 编排；`CoverageComparisonService.compare(contexts)` 集中处理三态覆盖语义和分类，CLI/API 只做适配。
+
+**Tech Stack:** Python 3.10+、FastAPI、Typer、Rich、SQLAlchemy 2、Pydantic 2、Playwright、pytest、Ruff、Hatchling。
+
+**Spec:** `docs/superpowers/specs/2026-08-26-v0-3-passive-authenticated-coverage-design.md`
+
+## Global Constraints
+
+- `garden scan`、`garden scan --url`、`POST /api/scans`、首页单 URL 表单和 quick 报告结构不变。
+- `ScanOptions.user_agent` 保持 `Garden-Authorized-Asset-Scanner/0.2`。
+- coverage 固定为 `anonymous`、`user`、`admin`；不公开 N 角色和主动重放。
+- 已观察资产为 `present`；只有完整上下文才能把未观察资产判为 `absent`，否则为 `unknown`。
+- 任一上下文为 `unknown` 时整体分类为 `unknown`。
+- 原始密码、令牌、Cookie 和 Authorization 不进入命令参数、普通数据库、日志、HTTP、报告或异常消息。
+- 每个功能切片执行一条失败测试、最小实现、同一测试转绿，再进入下一切片。
+- 不修改用户已有 `.gitignore`、`.coverage` 和 `interview.md`。
+
+---
+
+### Task 1: Freeze quick scan UX before feature work
+
+**Files:**
+- Create: `tests/test_v030_quick_compatibility.py`
+- Read only: `app/cli/scan.py`
+- Read only: `app/api/routes/scans.py`
+- Read only: `app/templates/index.html`
+- Read only: `app/services/scan_reporting.py`
+
+**Interfaces:**
+- Consumes: existing `garden scan`, `/api/scans`, `/`, and quick report generation.
+- Produces: compatibility gates every later task must keep green.
+
+- [ ] **Step 1: Characterize the quick CLI seam**
+
+```python
+def test_v030_keeps_quick_scan_command_contract() -> None:
+    result = CliRunner().invoke(app, ["scan", "--help"])
+    assert result.exit_code == 0
+    for token in (
+        "ENTRY_URL", "--url", "--max-pages", "--max-resources", "--max-depth",
+        "--request-timeout", "--overall-timeout", "--retries", "--detach", "--ui-port",
+    ):
+        assert token in result.stdout
+    assert "--user-profile" not in result.stdout
+    assert "--admin-profile" not in result.stdout
+```
+
+- [ ] **Step 2: Characterize quick HTTP, homepage and report headings**
+
+Use a fake `app.state.scan_service.start_scan` returning a real `ScanRunView`; assert `POST /api/scans` remains 202 with mode `quick`, homepage form remains `action="/scans"`, and the current ordered quick report headings remain unchanged.
+
+- [ ] **Step 3: Run the compatibility baseline**
+
+Run: `.venv/bin/pytest tests/test_v030_quick_compatibility.py tests/test_quick_scan_cli.py tests/test_formal_scan_cli.py tests/test_api.py -v`
+
+Expected: PASS before implementation. These are characterization tests, so they begin green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_v030_quick_compatibility.py
+git commit -m "test: freeze quick scan experience for v0.3"
+```
+
+### Task 2: Add short-lived secret storage and consume-after-use cleanup
+
+**Files:**
+- Create: `app/services/ephemeral_secret_store.py`
+- Modify: `app/services/secret_resolver.py`
+- Modify: `app/cli/paths.py`
+- Modify: `app/services/context_establishment.py`
+- Create: `tests/test_ephemeral_secret_store.py`
+- Modify: `tests/test_context_establishment.py`
+
+**Interfaces:**
+- Produces: `EphemeralSecretStore.write/read/delete/purge_expired`.
+- Consumes: only `ephemeral-file://` references rooted under the configured private directory.
+- Preserves: existing `env://` and demo-only `literal://` resolver behavior.
+
+- [ ] **Step 1: Write the failing owner-only atomic storage test**
+
+```python
+def test_ephemeral_secret_is_private_atomic_and_not_in_reference(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    secret = "coverage-user-secret"
+    ref = store.write(secret)
+    path = store.path_for(ref)
+    assert ref.startswith("ephemeral-file://")
+    assert secret not in ref
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert store.read(ref) == secret
+    assert not list(path.parent.glob("*.tmp"))
+```
+
+Run: `.venv/bin/pytest tests/test_ephemeral_secret_store.py::test_ephemeral_secret_is_private_atomic_and_not_in_reference -v`
+
+Expected red: module does not exist.
+
+- [ ] **Step 2: Implement the minimal store**
+
+Use `secrets.token_urlsafe`, exclusive file creation, `os.replace`, `chmod(0o700/0o600)`, and canonical resolved paths. `path_for` must reject non-matching schemes, symlinks, paths outside the root, non-regular files and group/world-readable permissions.
+
+- [ ] **Step 3: Add red slices for deletion, expiry and path attacks**
+
+```python
+def test_delete_and_expiry_are_idempotent(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("expired")
+    path = store.path_for(ref)
+    os.utime(path, (0, 0))
+
+    assert store.purge_expired(max_age_seconds=900) == (ref,)
+    store.delete(ref)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("ref", ["ephemeral-file:///etc/passwd", "env://SECRET"])
+def test_store_rejects_outside_or_wrong_scheme(tmp_path, ref) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    with pytest.raises(InputValidationError):
+        store.read(ref)
+
+
+def test_store_rejects_symlink_even_when_target_is_inside_root(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    real_ref = store.write("hidden")
+    real_path = store.path_for(real_ref)
+    link = real_path.parent / "link.secret"
+    link.symlink_to(real_path)
+
+    with pytest.raises(InputValidationError):
+        store.read(f"ephemeral-file://{link}")
+```
+
+Implement one failing slice at a time. `purge_expired(900)` returns sorted deleted refs and never follows symlinks.
+
+- [ ] **Step 4: Extend SecretResolver through the store seam**
+
+```python
+def test_secret_resolver_reads_ephemeral_reference(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path)
+    ref = store.write("hidden-value")
+    assert SecretResolver(ephemeral_store=store).resolve(ref) == "hidden-value"
+```
+
+Keep current resolver messages for `env://` and `literal://` unchanged.
+
+- [ ] **Step 5: Prove secrets are deleted after context establishment**
+
+Add a context-establishment test with user/admin ephemeral refs. Assert both files are deleted after `establish(...)` succeeds and after one authentication adapter fails. Cleanup belongs in a `finally` path and only deletes `ephemeral-file://` refs created for those contexts.
+
+- [ ] **Step 6: Run focused security tests and commit**
+
+Run: `.venv/bin/pytest tests/test_ephemeral_secret_store.py tests/test_context_establishment.py tests/test_session_lifecycle.py -v`
+
+```bash
+git add app/services/ephemeral_secret_store.py app/services/secret_resolver.py app/cli/paths.py app/services/context_establishment.py tests/test_ephemeral_secret_store.py tests/test_context_establishment.py
+git commit -m "feat: consume temporary coverage secrets safely"
+```
+
+### Task 3: Build the coverage credential wizard without touching `garden scan`
+
+**Files:**
+- Create: `app/cli/coverage_wizard.py`
+- Modify: `app/services/credentials.py`
+- Create: `tests/test_coverage_wizard.py`
+
+**Interfaces:**
+- Produces: `CoverageSetupWizard.run(entry_url, user_profile_id=None, admin_profile_id=None) -> PassiveCoverageStartRequest`.
+- Consumes: `TargetService`, `CredentialProfileService`, login-config validation, `EphemeralSecretStore`, and an injected prompt adapter.
+- Non-interactive callers bypass the wizard and must supply both profile IDs.
+
+- [ ] **Step 1: Write the failing existing-profile selection test**
+
+```python
+def test_wizard_selects_same_origin_target_and_exact_roles(setup_records) -> None:
+    prompts = ScriptedPrompts([str(setup_records.target_id), str(setup_records.user_id), str(setup_records.admin_id), "yes"])
+    request = CoverageSetupWizard(prompts=prompts).run(setup_records.url)
+    assert request.user_profile_id == setup_records.user_id
+    assert request.admin_profile_id == setup_records.admin_id
+    assert request.active_checks_enabled is False
+    assert prompts.hidden_values == []
+```
+
+Run red, then implement only selection and summary confirmation. Filter targets by normalized origin and credentials by exact role.
+
+- [ ] **Step 2: Add the create-missing-profile slice**
+
+Script prompts for target name/owner, login URL, validation URL, username and a hidden secret. Assert the created profiles have exact `user`/`admin` roles, share one target, use generated secret-free login configs, and store only `ephemeral-file://` refs.
+
+```python
+assert created_user.secret_ref.startswith("ephemeral-file://")
+assert "entered-password" not in json.dumps(created_user.__dict__, default=str)
+assert "entered-password" not in prompts.rendered_text
+```
+
+- [ ] **Step 3: Add cancellation and rollback cleanup**
+
+If the user declines the final summary or profile creation fails, delete every temporary secret created in this draft and do not submit an assessment. Existing selected profiles remain unchanged.
+
+- [ ] **Step 4: Add strict non-interactive behavior**
+
+```python
+def test_noninteractive_coverage_requires_both_profiles(runner) -> None:
+    result = runner.invoke(app, ["coverage", "https://app.test/", "--non-interactive"])
+    assert result.exit_code == 2
+    assert "--user-profile 和 --admin-profile" in result.stdout
+    assert "Select target" not in result.stdout
+```
+
+- [ ] **Step 5: Run wizard tests and commit**
+
+Run: `.venv/bin/pytest tests/test_coverage_wizard.py tests/test_cli.py tests/test_v030_quick_compatibility.py -v`
+
+```bash
+git add app/cli/coverage_wizard.py app/services/credentials.py tests/test_coverage_wizard.py
+git commit -m "feat: guide coverage credential setup in terminal"
+```
+
+### Task 4: Implement tri-state coverage comparison
+
+**Files:**
+- Create: `app/services/coverage_comparison.py`
+- Create: `tests/test_coverage_comparison.py`
+- Modify: `tests/helpers/assessment.py`
+
+**Interfaces:**
+- Produces: `CoverageComparisonService.compare(session, run) -> CoverageComparisonSummary`.
+- Persists: one `CoverageDifference` per `identity_key`, rebuilt idempotently for one run.
+
+- [ ] **Step 1: Red/green admin-only**
+
+```python
+def test_complete_contexts_classify_admin_only(db_session, three_context_run) -> None:
+    add_asset(db_session, three_context_run, kind="admin", identity="GET:/admin")
+    summary = CoverageComparisonService().compare(db_session, three_context_run)
+    item = summary.differences[0]
+    assert item.classification == "admin_only"
+    assert (item.anonymous_state, item.user_state, item.admin_state) == ("absent", "absent", "present")
+```
+
+- [ ] **Step 2: Red/green unknown-not-absent**
+
+```python
+def test_failed_user_context_is_unknown(db_session, three_context_run) -> None:
+    fail_context(three_context_run, "user")
+    add_asset(db_session, three_context_run, kind="admin", identity="GET:/admin")
+    item = CoverageComparisonService().compare(db_session, three_context_run).differences[0]
+    assert item.user_state == "unknown"
+    assert item.user_present is None
+    assert item.classification == "unknown"
+```
+
+- [ ] **Step 3: Complete the classification table one slice at a time**
+
+Cover `shared`, `user_only`, `admin_only`, `unexpectedly_anonymous`, presence-order `inconsistent`, response-signature `inconsistent`, and `unknown`. Compare only status, redacted URL, title, content type and stable content signature.
+
+- [ ] **Step 4: Prove idempotency and summary allowlisting**
+
+Call `compare` twice and assert one row per identity. Put fake `authorization`, `cookie` and response text keys in asset attributes; assert none appear in `context_summaries` or diagnostics.
+
+- [ ] **Step 5: Run and commit**
+
+Run: `.venv/bin/pytest tests/test_coverage_comparison.py tests/test_coverage_identity.py tests/test_assessment_models.py -v`
+
+```bash
+git add app/services/coverage_comparison.py tests/test_coverage_comparison.py tests/helpers/assessment.py
+git commit -m "feat: compare passive coverage across three contexts"
+```
+
+### Task 5: Orchestrate authenticated assessments and preserve partial truth
+
+**Files:**
+- Modify: `app/services/scan_pipeline.py`
+- Modify: `app/services/scan_application.py`
+- Create: `tests/test_authenticated_coverage_pipeline.py`
+- Modify: `tests/test_assessment_application.py`
+
+**Interfaces:**
+- Produces: `ScanPipeline.execute_authenticated(session, scan_run_id)`.
+- Preserves: `ScanPipeline.execute(session, scan_run_id)` quick path.
+- Dispatches: quick and authenticated runs through a mode-aware application adapter.
+
+- [ ] **Step 1: Red/green authenticated dispatch**
+
+Start one authenticated and one quick run with the recording dispatcher. Expected submitted IDs are `[authenticated.id, quick.id]`; an active-key duplicate is not resubmitted.
+
+- [ ] **Step 2: Red/green complete passive stage execution**
+
+Assert persisted stages finish as:
+
+```python
+{
+    "validate": "completed",
+    "establish_contexts": "completed",
+    "collect": "completed",
+    "normalize": "completed",
+    "compare_coverage": "completed",
+    "replay_authorization": "skipped",
+    "analyze": "completed",
+    "report": "completed",
+}
+```
+
+The skipped summary must state that v0.3.0 is passive. No `ReplayExecution` row may be created.
+
+- [ ] **Step 3: Red/green partial context continuation**
+
+Make user authentication fail while anonymous/admin succeed. The run must finish `incomplete`, comparison must contain `unknown`, report must still exist, and `active_key` must be cleared.
+
+- [ ] **Step 4: Red/green fatal orchestration cleanup**
+
+Force comparison to raise a safe test error. Assert current stage failed, later pending stages skipped, run failed, temporary secrets deleted, and diagnostic report attempted without raw exception secrets.
+
+- [ ] **Step 5: Run and commit**
+
+Run: `.venv/bin/pytest tests/test_authenticated_coverage_pipeline.py tests/test_assessment_application.py tests/test_context_establishment.py tests/test_context_collection.py tests/test_url_scan_pipeline.py tests/test_scan_cancellation.py -v`
+
+```bash
+git add app/services/scan_pipeline.py app/services/scan_application.py tests/test_authenticated_coverage_pipeline.py tests/test_assessment_application.py
+git commit -m "feat: orchestrate passive authenticated assessments"
+```
+
+### Task 6: Expose coverage through separate HTTP and CLI adapters
+
+**Files:**
+- Modify: `app/schemas/assessment.py`
+- Create: `app/api/routes/assessments.py`
+- Modify: `app/api/router.py`
+- Create: `app/cli/coverage.py`
+- Modify: `app/cli/local_api.py`
+- Modify: `app/cli/main.py`
+- Create: `tests/test_assessments_api.py`
+- Create: `tests/test_coverage_cli.py`
+
+**Interfaces:**
+- HTTP: start/read/differences/cancel/report under `/api/assessments`.
+- CLI: `garden coverage URL`; interactive by default on TTY, explicit IDs required with `--non-interactive`.
+- Public start schema omits active replay fields and uses `extra="forbid"`.
+
+- [ ] **Step 1: Red/green passive HTTP start and difference read**
+
+```python
+response = client.post("/api/assessments", json={
+    "url": "https://app.test/", "user_profile_id": 12, "admin_profile_id": 13,
+})
+assert response.status_code == 202
+assert service.started.mode.value == "authenticated_coverage"
+assert service.started.active_checks_enabled is False
+```
+
+Add GET status, differences, report and POST cancel using existing application interfaces.
+
+- [ ] **Step 2: Red/green reject active fields**
+
+Posting `active_checks_enabled` or `authorization_confirmed` returns 422 before the application interface is called.
+
+- [ ] **Step 3: Red/green coverage CLI interactive path**
+
+Inject a scripted wizard and fake loopback adapter. Assert `garden coverage URL` invokes the wizard, submits its `PassiveCoverageStartRequest`, and renders three context states, classification counts and report path.
+
+- [ ] **Step 4: Prove quick command isolation**
+
+Run `garden scan URL` with a wizard object that raises if called. Assert the quick command completes its existing fake flow without calling the wizard or secret store.
+
+- [ ] **Step 5: Run and commit**
+
+Run: `.venv/bin/pytest tests/test_assessments_api.py tests/test_coverage_cli.py tests/test_quick_scan_cli.py tests/test_formal_scan_cli.py tests/test_v030_quick_compatibility.py -v`
+
+```bash
+git add app/schemas/assessment.py app/api/routes/assessments.py app/api/router.py app/cli/coverage.py app/cli/local_api.py app/cli/main.py tests/test_assessments_api.py tests/test_coverage_cli.py
+git commit -m "feat: expose guided passive coverage workflow"
+```
+
+### Task 7: Generate the authenticated report and prove localhost E2E
+
+**Files:**
+- Modify: `app/services/scan_reporting.py`
+- Create: `tests/test_authenticated_coverage_reporting.py`
+- Create: `tests/fixtures/auth_coverage_site/app.py`
+- Create: `tests/fixtures/auth_coverage_site/login-config-user.yaml`
+- Create: `tests/fixtures/auth_coverage_site/login-config-admin.yaml`
+- Create: `tests/test_authenticated_coverage_e2e.py`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Preserves: `ScanReportService.generate(session, scan_run_id)` and quick renderer.
+- Adds: authenticated renderer selected only when `run.mode=authenticated_coverage`.
+- E2E: localhost FastAPI fixture plus real Playwright Chromium.
+
+- [ ] **Step 1: Red/green report matrix**
+
+```python
+assert text.startswith(f"# Garden 认证覆盖报告 #{run.id}")
+assert "## 三上下文健康与完整性" in text
+assert "| 资产身份 | anonymous | user | admin | 分类 | 置信度 |" in text
+assert "主动权限重放未执行" in text
+assert "覆盖差异不是已确认漏洞" in text
+```
+
+Load contexts and differences in `generate`, branch internally by run mode, and keep the existing quick `_render` path byte-behaviorally unchanged.
+
+- [ ] **Step 2: Red/green unknown and secret omission**
+
+Render anonymous=`present`, user=`unknown`, admin=`present`; assert the literal matrix state is `unknown`, never blank/absent. Seed forbidden attribute keys and assert their values are absent from the report.
+
+- [ ] **Step 3: Build the localhost fixture**
+
+Expose `/`, `/login`, `/account`, `/admin/users`, `/anonymous-banner` and `/api/profile`. Use fixture-only HMAC-signed role cookies, hidden form passwords from environment variables, exact user/admin roles, and an ephemeral `127.0.0.1` port.
+
+- [ ] **Step 4: Run the real E2E red, then close one seam at a time**
+
+The E2E creates a target and two profiles through public services, calls `start_assessment`, waits through `get_assessment`, reads `list_coverage_differences`, and checks the report. It must observe `shared`, `user_only`, `admin_only`, `unexpectedly_anonymous` and role-specific response inconsistency without external network access.
+
+Run: `.venv/bin/pytest tests/test_authenticated_coverage_e2e.py -v`
+
+- [ ] **Step 5: Add the existing-browser CI job and commit**
+
+Run: `.venv/bin/pytest tests/test_authenticated_coverage_reporting.py tests/test_authenticated_coverage_e2e.py tests/test_playwright_contract.py tests/test_scan_report_quality.py -v`
+
+```bash
+git add app/services/scan_reporting.py tests/test_authenticated_coverage_reporting.py tests/fixtures/auth_coverage_site tests/test_authenticated_coverage_e2e.py .github/workflows/ci.yml
+git commit -m "test: verify authenticated coverage report end to end"
+```
+
+### Task 8: Release and full regression gate
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `app/core/settings.py`
+- Modify: `README.md`
+- Modify: `docs/deployment.md`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_install_script.py`
+- Create: `tests/test_v030_release.py`
+
+**Interfaces:**
+- Produces: version `0.3.0` and guided coverage documentation.
+- Preserves: installer Python discovery, public-policy migration and source-shadowing-safe launcher.
+
+- [x] **Step 1: Red/green release metadata**
+
+Assert `pyproject.toml` and `Settings.project_version` are `0.3.0`; update exact version output assertions but keep quick user-agent and installer logic unchanged.
+
+- [x] **Step 2: Document the exact interactive and automated flows**
+
+Document `garden coverage URL`, the guided Target/user/admin creation, hidden temporary-secret lifecycle, `--non-interactive` usage, passive-only meaning and difference disclaimer.
+
+- [x] **Step 3: Run focused release gates**
+
+```bash
+.venv/bin/pytest tests/test_install_script.py tests/test_migrations.py::test_built_wheel_installs_with_loadable_migration_assets tests/test_v020_compatibility.py tests/test_v030_release.py -v
+```
+
+- [x] **Step 4: Run full verification**
+
+```bash
+.venv/bin/ruff format --check .
+.venv/bin/ruff check .
+.venv/bin/pytest
+git diff --check
+```
+
+Expected: every command exits 0; quick compatibility, secret lifecycle, browser E2E, wheel migration and installer tests all pass.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add pyproject.toml app/core/settings.py README.md docs/deployment.md tests/test_cli.py tests/test_install_script.py tests/test_v030_release.py
+git commit -m "release: prepare Garden v0.3.0"
+```
+
+## Execution gate
+
+Before product implementation, confirm these public test seams:
+
+1. existing quick CLI/HTTP/Web/report compatibility;
+2. `EphemeralSecretStore` lifecycle;
+3. `CoverageSetupWizard.run(request)`;
+4. `CoverageComparisonService.compare(contexts)`;
+5. `ScanApplicationService` assessment start/read;
+6. `/api/assessments` and `garden coverage` adapters;
+7. `ScanReportService.generate(session, scan_run_id)`;
+8. localhost-only real authentication E2E.

--- a/docs/superpowers/specs/2026-08-26-v0-3-passive-authenticated-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-26-v0-3-passive-authenticated-coverage-design.md
@@ -1,0 +1,335 @@
+# Garden v0.3.0 被动认证覆盖对比设计
+
+**日期：** 2026-08-26
+**状态：** 已批准、已实施并通过发布前验证
+**上位设计：** `docs/superpowers/specs/2026-08-11-authenticated-coverage-platform-design.md`
+**版本定位：** 在不改变现有 quick 用户体验的前提下，交付固定三上下文的被动认证覆盖差异；主动权限重放继续关闭。
+
+## 1. 决策摘要
+
+v0.3.0 新增一个独立的高级工作流：对同一个已授权目标，分别以 `anonymous`、`user`、`admin` 三种上下文执行有界被动采集，并按规范化资产身份生成覆盖矩阵。
+
+本版本不改变以下现有入口及其默认行为：
+
+- `garden scan URL`；
+- `garden scan --url URL`；
+- `POST /api/scans`；
+- 首页单 URL 表单；
+- quick 扫描详情页和既有 Markdown 资产报告结构。
+
+认证覆盖通过新的 `garden coverage` 命令和 `/api/assessments` HTTP 接口进入。两个适配器调用同一个 `ScanApplicationService.start_assessment(request)` 应用接口，不复制认证、采集或分类规则。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 一个高级命令或 HTTP 请求可以启动固定三上下文的被动 assessment。
+2. 三种上下文在相同 URL、网络策略和采集预算下执行。
+3. 资产通过 `identity_key` 对齐，并输出可解释、可追溯的三列覆盖矩阵。
+4. 失败或不完整上下文不会制造“角色不可见”的假象。
+5. 报告明确区分上下文健康、覆盖状态、差异分类和普通被动观察。
+6. quick 的命令、HTTP、网页和报告体验由兼容性测试锁定。
+
+### 2.2 非目标
+
+- 不执行主动权限重放；
+- 不公开 `active_checks_enabled` 或授权确认参数；
+- 不支持任意 N 角色；
+- 不增加定时扫描、历史基线漂移或外部工单集成；
+- 不重新设计首页、quick 详情页或默认导航；
+- 不改动安装器的 Python 发现、策略迁移或正式启动器行为；
+- 不把覆盖差异自动升级为漏洞 finding。
+
+## 3. 不可破坏的兼容约束
+
+### 3.1 Quick CLI
+
+`garden scan` 的参数名、默认值、前台等待、`--detach`、结果标题、覆盖告警与请求失败分栏保持不变。顶层 CLI 可以新增 `coverage`，但不能改变 `scan` 子命令的帮助和行为。
+
+现有 `ScanOptions.user_agent=Garden-Authorized-Asset-Scanner/0.2` 继续作为 quick 网络兼容标识，本版本不借产品版本升级改变目标侧可观察的 quick 请求身份。
+
+### 3.2 Quick HTTP
+
+`POST /api/scans` 继续接受 `ScanStartRequest` 并返回 `ScanRunView`；`GET /api/scans/{id}`、取消和报告下载路径不变。
+
+### 3.3 Quick Web
+
+首页仍然是单 URL quick 表单；表单字段、提交路径和默认预算不变。v0.3.0 不在首页插入凭证选择器，也不把高级认证工作流设为默认。
+
+### 3.4 Quick 报告
+
+`ScanReportService.generate(session, scan_run_id)` 保持单一接口。内部可以按 `run.mode` 选择渲染实现，但 quick 必须继续使用当前渲染路径，标题、章节顺序和失败分类不因认证覆盖而改变。
+
+## 4. 用户工作流
+
+### 4.1 前置条件
+
+用户已经通过现有命令创建：
+
+- 一个 `Target`；
+- 一个 `role=user` 的凭证档案；
+- 一个 `role=admin` 的凭证档案；
+- 两个能够通过现有会话验证模块验证的认证配置。
+
+两个凭证档案必须属于同一目标，assessment URL 必须与目标 `base_url` 同源。
+
+### 4.2 CLI
+
+交互式终端的默认入口为：
+
+```bash
+garden coverage https://app.example/
+```
+
+该命令必须进入认证覆盖准备向导，而不是要求用户预先退出并拼接多条 `target`、`cred`、`login` 命令。向导按以下顺序执行：
+
+1. 按 assessment URL 的同源信息查找已有 Target；存在多个时显示编号、名称和 owner 供选择，没有时原地创建；
+2. 只显示所选 Target 下角色精确为 `user` 的凭据档案；允许选择已有档案或原地创建；
+3. 以相同方式处理角色精确为 `admin` 的凭据档案；
+4. 检查登录配置文件存在、可解析且属于支持的 HTTP 或 Playwright 适配器；
+5. 显示不含秘密的准备摘要，确认后提交 assessment；
+6. 前台模式持续显示三个上下文的登录、会话验证、采集和比较状态。
+
+已有档案完整时，向导仍显示选择和确认步骤，但不重复创建。自动化环境可以显式提供：
+
+```bash
+garden coverage https://app.example/ \
+  --user-profile 12 \
+  --admin-profile 13 \
+  --non-interactive
+```
+
+`--non-interactive` 缺少任一档案 ID 时立即失败，不等待终端输入。是否交互以显式参数和 TTY 检测共同决定，不能在 CI、管道或重定向输入中悬挂。
+
+可选参数复用 quick 的有界采集参数：`--max-pages`、`--max-resources`、`--max-depth`、`--request-timeout`、`--overall-timeout`、`--retries`、`--detach` 和 `--ui-port`。可选 `--source-run` 只接受同一 target 的终态 quick run。
+
+命令输出上下文健康摘要、分类计数和报告位置。它不接受主动检查开关。
+
+### 4.3 敏感输入生命周期
+
+向导使用隐藏输入读取密码或令牌，必要时二次确认。原始值不进入命令参数、shell history、Rich 渲染对象、普通数据库字段或异常消息。
+
+新建或需要重新补充秘密的凭据档案使用 `ephemeral-file://` 引用：
+
+1. `EphemeralSecretStore` 在 Garden 私有运行目录中原子创建随机文件，目录权限 `0700`、文件权限 `0600`；
+2. 解析器只接受该私有目录内的普通文件，拒绝符号链接、目录穿越、宽松权限和目录外路径；
+3. 凭据档案只保存不可复用的引用路径，UI/CLI 继续使用统一引用脱敏；
+4. `establish_contexts` 在 user/admin 会话建立和验证结束后，于 `finally` 中删除本次向导创建的原始秘密文件；成功、失败、取消都执行；
+5. 向导启动和服务启动时清理超过 15 分钟的崩溃遗留文件；
+6. 已建立会话继续使用现有受保护会话存储；下一次需要重新登录且临时引用已消费时，coverage 向导重新隐藏提示并轮换引用。
+
+如果用户选择已有 `env://VAR` 引用且变量在 Garden Web 运行进程中可用，向导不创建临时文件。`literal://` 仅保留现有本地 demo 兼容，不由 coverage 向导创建或推荐。
+
+### 4.4 HTTP
+
+```http
+POST /api/assessments
+Content-Type: application/json
+
+{
+  "url": "https://app.example/",
+  "user_profile_id": 12,
+  "admin_profile_id": 13,
+  "options": {
+    "max_pages": 50,
+    "max_resources": 200,
+    "max_depth": 2
+  }
+}
+```
+
+v0.3.0 的公共请求模型不包含主动重放字段。读取接口为：
+
+- `GET /api/assessments/{id}`；
+- `GET /api/assessments/{id}/differences`；
+- `POST /api/assessments/{id}/cancel`；
+- `GET /api/assessments/{id}/report`。
+
+## 5. 深模块与接口
+
+### 5.1 覆盖比较模块
+
+模块位于 `app/services/coverage_comparison.py`，外部接口只有：
+
+```python
+CoverageComparisonService.compare(
+    session: Session,
+    run: ScanRun,
+) -> CoverageComparisonSummary
+```
+
+调用者不需要知道集合连接、上下文可用性、属性摘要、分类优先级、置信度或幂等重建细节。该接口同时是模块的公共测试接缝。
+
+`CoverageComparisonSummary` 只返回稳定的运行级结果：运行 ID、生成记录 ID 和分类计数；持久化细节通过 `CoverageDifference` 读取。
+
+### 5.2 认证编排模块
+
+`ScanPipeline.execute_authenticated(session, scan_run_id)` 是阶段执行接缝。它复用现有上下文建立、上下文采集、规范化、分析和报告能力，并插入覆盖比较阶段。
+
+`ScanPipeline.execute(session, scan_run_id)` 继续只承载现有 quick 行为，不通过大范围条件分支重写 quick 流水线。
+
+### 5.3 应用接口
+
+`ScanApplicationService.start_assessment(request)` 继续是唯一创建接口。认证模式创建并提交后台执行；quick 的 `start_scan(request)` 兼容接口保持不变。
+
+新增只读接口：
+
+```python
+ScanApplicationService.list_coverage_differences(
+    scan_run_id: int,
+) -> list[CoverageDifferenceView]
+```
+
+### 5.4 适配器
+
+- `app/api/routes/assessments.py`：HTTP 适配器；
+- `app/cli/coverage.py`：Typer 适配器；
+- `app/cli/coverage_wizard.py`：只负责终端步骤、选择、隐藏输入和确认；
+- `app/cli/local_api.py`：本机 HTTP 客户端适配器。
+
+适配器只负责校验传输模型、调用应用接口和渲染结果，不包含差异分类实现。
+
+### 5.5 临时秘密深模块
+
+`app/services/ephemeral_secret_store.py` 提供：
+
+```python
+EphemeralSecretStore.write(secret: str) -> str
+EphemeralSecretStore.read(secret_ref: str) -> str
+EphemeralSecretStore.delete(secret_ref: str) -> None
+EphemeralSecretStore.purge_expired(max_age_seconds: int = 900) -> tuple[str, ...]
+```
+
+调用者不需要了解随机命名、权限、原子写入、路径约束或过期清理。该接口是敏感输入生命周期的公共测试接缝。
+
+## 6. 覆盖状态与分类
+
+### 6.1 上下文状态
+
+对每个 `identity_key` 和每个上下文计算：
+
+- `present`：该上下文已持久化该身份资产；即使上下文后来不完整，已观察到的存在性仍然可信；
+- `absent`：该上下文 `collection_status=completed` 且 `completeness=complete`，但没有该身份资产；
+- `unknown`：没有该身份资产，并且该上下文失败、缺失、中断或采集不完整。
+
+因此“不完整上下文中已经观察到的资产”可以是 `present`，但“不完整上下文中没有观察到的资产”只能是 `unknown`。
+
+### 6.2 分类优先级
+
+任何一个上下文为 `unknown` 时，整体分类必须是 `unknown`。其余状态按以下顺序分类：
+
+| anonymous | user | admin | 分类 |
+|---|---|---|---|
+| present | present | present | 属性一致为 `shared`，属性不同为 `inconsistent` |
+| absent | absent | present | `admin_only` |
+| absent | present | present | `user_only` |
+| absent | present | absent | `inconsistent` |
+| present | absent/present | 任一缺失 | `unexpectedly_anonymous` |
+
+不存在于任何上下文的身份不会进入比较集合。
+
+### 6.3 属性一致性
+
+只有三个上下文都为 `present` 时比较属性。比较字段固定为：
+
+- `status_code`；
+- 规范化、脱敏 URL；
+- `title`；
+- `attributes.content_type`；
+- `attributes.content_signature`。
+
+其中任一稳定字段不同则分类为 `inconsistent`。`context_summaries` 只保存上述脱敏字段和资产 ID，不保存响应正文、Cookie、Authorization、查询值或受保护存储内容。
+
+### 6.4 置信度与诊断
+
+- 完整上下文的存在性差异：`high`；
+- 三上下文均存在但稳定响应属性不同：`medium`；
+- 包含未知状态：`low`。
+
+诊断使用稳定中文句子说明分类依据，不把 `admin_only`、`user_only` 或 `unexpectedly_anonymous` 直接称为漏洞。
+
+## 7. 阶段与终态
+
+认证覆盖执行：
+
+```text
+validate
+→ establish_contexts
+→ collect
+→ normalize
+→ compare_coverage
+→ replay_authorization(skipped)
+→ analyze
+→ report
+```
+
+规则：
+
+- `replay_authorization` 必须持久化为 `skipped`，摘要说明 v0.3.0 为被动版本；
+- 某个认证上下文失败时，其他可用上下文继续采集，后续比较和报告继续执行；
+- 上下文不完整时运行终态为 `incomplete`，但仍生成报告；
+- 全部上下文完整且无失败时为 `completed`；
+- 全部上下文完整但存在非致命覆盖告警时为 `completed_with_warnings`；
+- 编排器自身发生致命错误时为 `failed`，未执行阶段明确标记 `skipped`；
+- 终态运行清除 `active_key`，允许用户修复凭证后重试。
+
+## 8. 报告
+
+认证报告标题为 `Garden 认证覆盖报告 #<id>`，至少包含：
+
+1. 执行摘要；
+2. 三上下文健康与完整性；
+3. 覆盖差异分类计数；
+4. anonymous/user/admin 三列矩阵；
+5. 属性不一致详情；
+6. 被动观察与证据索引；
+7. 阶段状态、失败和未覆盖部分；
+8. 明确声明“差异不是已确认漏洞，主动权限重放未执行”。
+
+`unknown` 必须在矩阵中直观展示，不能渲染为空白或 `absent`。
+
+## 9. 公共测试接缝
+
+TDD 只从以下已定义接缝观察行为，不测试私有辅助函数：
+
+1. `EphemeralSecretStore`：权限、路径约束、消费删除和过期清理；
+2. `CoverageSetupWizard.run(request)`：目标/档案选择与创建、隐藏输入、非交互失败和安全摘要；
+3. `CoverageComparisonService.compare(contexts)`：分类、unknown 语义、属性不一致、幂等性和脱敏；
+4. `ScanApplicationService.start_assessment/get_assessment/list_coverage_differences`：调度、状态和读取；
+5. `/api/assessments` 接口族：HTTP 传输协议与主动字段不可达；
+6. `garden coverage`：高级 CLI 提交、等待、摘要和错误显示；
+7. `ScanReportService.generate(session, scan_run_id)`：认证报告矩阵与 quick 报告兼容；
+8. 现有 `garden scan`、`/api/scans` 和首页表单：兼容性门禁；
+9. 本地真实认证 fixture：端到端三上下文采集，不访问外部目标。
+
+数据库查询只用于比较模块的持久化结果验证；CLI/API/编排测试不绕过其公共接口查询内部状态。
+
+## 10. 安全与隐私
+
+- 只执行现有被动采集允许的方法和边界策略；
+- v0.3.0 公共入口无法开启主动重放；
+- quick CLI 不调用 coverage 向导，也不读取、创建或清理 coverage 临时秘密；
+- 每个网络连接与重定向继续执行目标策略校验；
+- 普通数据库字段、日志、CLI、HTTP、报告不出现可复用会话材料；
+- 报告只使用脱敏 URL、标题、内容类型和稳定指纹；
+- 上下文错误对外只返回安全诊断，不传播底层异常中的秘密；
+- 受保护请求载荷仍沿用现有权限和保留策略，本版本不读取它们做比较。
+
+## 11. 验收标准
+
+- [x] `garden scan`、`POST /api/scans`、首页和 quick 报告兼容门禁通过；
+- [x] `garden coverage URL` 在 TTY 中可以选择或原地创建同源 Target、user 档案和 admin 档案；
+- [x] 隐藏输入不出现在参数、数据库、日志、CLI、HTTP 或报告中，临时秘密在使用后删除；
+- [x] 非交互模式参数不足时立即失败，不等待提示；
+- [x] `garden coverage` 可以启动并完成固定三上下文被动 assessment；
+- [x] 三上下文资产按 `identity_key` 生成确定、幂等的矩阵；
+- [x] 失败或不完整上下文的未观察资产始终为 `unknown`；
+- [x] `replay_authorization` 明确为 `skipped`，且没有重放请求；
+- [x] 认证报告显示上下文健康、分类计数、矩阵和诊断；
+- [x] CLI、HTTP、报告和日志脱敏测试通过；
+- [x] 本地真实认证 E2E、全量 pytest、Ruff、format、wheel、迁移和安装回归通过；
+- [x] 项目版本更新为 `0.3.0`，文档明确 quick 是默认入口、认证覆盖是高级被动工作流。
+
+## 12. 后续版本
+
+只有 v0.3.x 收敛上下文稳定性、误判和报告解释后，才进入主动权限重放版本。主动重放需要独立设计、显式授权、候选策略、审计、应用级操作者权限和更严格的副作用门禁，不属于本设计。

--- a/migrations/versions/0002_unified_assessment.py
+++ b/migrations/versions/0002_unified_assessment.py
@@ -185,7 +185,7 @@ def upgrade() -> None:
         sa.Column("scan_run_id", sa.Integer(), nullable=False),
         sa.Column("kind", sa.String(length=32), nullable=False),
         sa.Column("credential_profile_id", sa.Integer(), nullable=True),
-        sa.Column("temporary_secret_ref", sa.String(length=1000), nullable=True),
+        sa.Column("temporary_secret_ref", sa.String(length=255), nullable=True),
         sa.Column("auth_session_id", sa.Integer(), nullable=True),
         sa.Column("status", sa.String(length=40), server_default="pending", nullable=False),
         sa.Column("login_status", sa.String(length=40), server_default="pending", nullable=False),

--- a/migrations/versions/0002_unified_assessment.py
+++ b/migrations/versions/0002_unified_assessment.py
@@ -185,6 +185,7 @@ def upgrade() -> None:
         sa.Column("scan_run_id", sa.Integer(), nullable=False),
         sa.Column("kind", sa.String(length=32), nullable=False),
         sa.Column("credential_profile_id", sa.Integer(), nullable=True),
+        sa.Column("temporary_secret_ref", sa.String(length=1000), nullable=True),
         sa.Column("auth_session_id", sa.Integer(), nullable=True),
         sa.Column("status", sa.String(length=40), server_default="pending", nullable=False),
         sa.Column("login_status", sa.String(length=40), server_default="pending", nullable=False),
@@ -217,6 +218,10 @@ def upgrade() -> None:
         ),
         sa.UniqueConstraint("scan_run_id", "kind", name="uq_scan_contexts_run_kind"),
         sa.UniqueConstraint("scan_run_id", "id", name="uq_scan_contexts_run_id_id"),
+        sa.UniqueConstraint(
+            "temporary_secret_ref",
+            name="uq_scan_contexts_temporary_secret_ref",
+        ),
     )
     op.create_index("ix_scan_contexts_scan_run_id", "scan_contexts", ["scan_run_id"])
     op.create_index("ix_scan_contexts_kind", "scan_contexts", ["kind"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
   "pre-commit>=4.2.0,<5.0.0",
   "pytest>=8.3.0,<9.0.0",
   "pytest-cov>=6.1.0,<7.0.0",
-  "ruff>=0.11.0,<1.0.0",
+  "ruff==0.15.8",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
   "alembic>=1.14.0,<2.0.0",
+  "click==8.3.1",
   "fastapi>=0.116.0,<1.0.0",
   "httpx>=0.28.0,<1.0.0",
   "jinja2>=3.1.0,<4.0.0",
@@ -23,7 +24,7 @@ dependencies = [
   "python-multipart>=0.0.20,<1.0.0",
   "rich>=13.0.0,<14.0.0",
   "sqlalchemy>=2.0.0,<3.0.0",
-  "typer>=0.16.0,<1.0.0",
+  "typer==0.24.1",
   "uvicorn[standard]>=0.35.0,<1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garden"
-version = "0.2.0"
+version = "0.3.0"
 description = "One-URL automated asset discovery, analysis, and evidence reporting service."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/fixtures/auth_coverage_site/__init__.py
+++ b/tests/fixtures/auth_coverage_site/__init__.py
@@ -1,0 +1,1 @@
+"""Local-only authenticated coverage test site."""

--- a/tests/fixtures/auth_coverage_site/app.py
+++ b/tests/fixtures/auth_coverage_site/app.py
@@ -42,15 +42,19 @@ def _page(title: str, heading: str, links: list[tuple[str, str]]) -> HTMLRespons
 
 
 @app.get("/", response_class=HTMLResponse)
-def anonymous_home() -> HTMLResponse:
+def coverage_home(request: Request) -> HTMLResponse:
+    role = _role(request)
+    links = [("/shared", "Shared"), ("/api/profile", "Profile API")]
+    if role == "anonymous":
+        links.append(("/anonymous-banner", "Anonymous banner"))
+    if role in {"user", "admin"}:
+        links.append(("/account", "Account"))
+    if role == "admin":
+        links.append(("/admin/users", "Admin users"))
     return _page(
         "Coverage Home",
-        "Anonymous coverage",
-        [
-            ("/shared", "Shared"),
-            ("/anonymous-banner", "Anonymous banner"),
-            ("/api/profile", "Profile API"),
-        ],
+        f"{role.title()} coverage",
+        links,
     )
 
 

--- a/tests/fixtures/auth_coverage_site/app.py
+++ b/tests/fixtures/auth_coverage_site/app.py
@@ -1,0 +1,127 @@
+"""Deterministic localhost site for real-browser authenticated coverage tests."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from urllib.parse import parse_qs
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+app = FastAPI()
+
+_SIGNING_KEY = b"garden-localhost-e2e-only"
+_USERS = {
+    "coverage-user": ("GARDEN_E2E_USER_PASSWORD", "user"),
+    "coverage-admin": ("GARDEN_E2E_ADMIN_PASSWORD", "admin"),
+}
+
+
+def _sign(role: str) -> str:
+    digest = hmac.new(_SIGNING_KEY, role.encode(), hashlib.sha256).hexdigest()
+    return f"{role}.{digest}"
+
+
+def _role(request: Request) -> str:
+    raw = request.cookies.get("garden_e2e_role", "")
+    role, separator, signature = raw.partition(".")
+    if not separator or role not in {"user", "admin"}:
+        return "anonymous"
+    expected = _sign(role).partition(".")[2]
+    return role if hmac.compare_digest(signature, expected) else "anonymous"
+
+
+def _page(title: str, heading: str, links: list[tuple[str, str]]) -> HTMLResponse:
+    anchors = "".join(f'<li><a href="{href}">{label}</a></li>' for href, label in links)
+    return HTMLResponse(
+        "<!doctype html><html><head>"
+        f"<title>{title}</title></head><body><h1>{heading}</h1><ul>{anchors}</ul></body></html>"
+    )
+
+
+@app.get("/", response_class=HTMLResponse)
+def anonymous_home() -> HTMLResponse:
+    return _page(
+        "Coverage Home",
+        "Anonymous coverage",
+        [
+            ("/shared", "Shared"),
+            ("/anonymous-banner", "Anonymous banner"),
+            ("/api/profile", "Profile API"),
+        ],
+    )
+
+
+@app.get("/login", response_class=HTMLResponse)
+def login_form() -> HTMLResponse:
+    return HTMLResponse(
+        "<!doctype html><html><head><title>Sign in</title></head><body>"
+        '<form method="post" action="/login">'
+        '<input name="username" autocomplete="username">'
+        '<input name="password" type="password" autocomplete="current-password">'
+        '<button type="submit">Sign in</button>'
+        "</form></body></html>"
+    )
+
+
+@app.post("/login")
+async def login(request: Request):
+    fields = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
+    username = fields.get("username", [""])[0]
+    password = fields.get("password", [""])[0]
+    configured = _USERS.get(username)
+    if configured is None or password != os.environ.get(configured[0]):
+        return HTMLResponse("Invalid credentials", status_code=401)
+    role = configured[1]
+    destination = "/admin/users" if role == "admin" else "/account"
+    response = RedirectResponse(destination, status_code=303)
+    response.set_cookie(
+        "garden_e2e_role",
+        _sign(role),
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+@app.get("/shared", response_class=HTMLResponse)
+def shared() -> HTMLResponse:
+    return _page("Shared", "Same shared content", [])
+
+
+@app.get("/anonymous-banner", response_class=HTMLResponse)
+def anonymous_banner() -> HTMLResponse:
+    return _page("Anonymous Banner", "Visible without authentication", [])
+
+
+@app.get("/account", response_class=HTMLResponse)
+def account(request: Request):
+    role = _role(request)
+    if role not in {"user", "admin"}:
+        return RedirectResponse("/login", status_code=303)
+    links = [("/shared", "Shared"), ("/account", "Account"), ("/api/profile", "Profile API")]
+    return _page("Account", "Authenticated account", links)
+
+
+@app.get("/admin/users", response_class=HTMLResponse)
+def admin_users(request: Request):
+    if _role(request) != "admin":
+        return RedirectResponse("/login", status_code=303)
+    return _page(
+        "Admin Users",
+        "Administrative users",
+        [
+            ("/shared", "Shared"),
+            ("/account", "Account"),
+            ("/admin/users", "Admin users"),
+            ("/api/profile", "Profile API"),
+        ],
+    )
+
+
+@app.get("/api/profile")
+def profile(request: Request) -> JSONResponse:
+    role = _role(request)
+    return JSONResponse({"surface": "profile", "role": role})

--- a/tests/fixtures/auth_coverage_site/app.py
+++ b/tests/fixtures/auth_coverage_site/app.py
@@ -128,4 +128,10 @@ def admin_users(request: Request):
 @app.get("/api/profile")
 def profile(request: Request) -> JSONResponse:
     role = _role(request)
-    return JSONResponse({"surface": "profile", "role": role})
+    return JSONResponse(
+        {
+            "surface": "profile",
+            "padding": "x" * 1000,
+            "role": role,
+        }
+    )

--- a/tests/fixtures/auth_coverage_site/login-config-admin.yaml
+++ b/tests/fixtures/auth_coverage_site/login-config-admin.yaml
@@ -1,0 +1,8 @@
+adapter: playwright
+login_url: /login
+validate_url: /admin/users
+username_selector: input[name="username"]
+password_selector: input[name="password"]
+submit_selector: button[type="submit"]
+success_text: Administrative users
+request_timeout_seconds: 10

--- a/tests/fixtures/auth_coverage_site/login-config-user.yaml
+++ b/tests/fixtures/auth_coverage_site/login-config-user.yaml
@@ -1,0 +1,8 @@
+adapter: playwright
+login_url: /login
+validate_url: /account
+username_selector: input[name="username"]
+password_selector: input[name="password"]
+submit_selector: button[type="submit"]
+success_text: Authenticated account
+request_timeout_seconds: 10

--- a/tests/helpers/assessment.py
+++ b/tests/helpers/assessment.py
@@ -64,6 +64,9 @@ def add_asset(
     url: str = "http://127.0.0.1:8000/",
     context_id: int | None = None,
     identity_key: str = "GET:/",
+    status_code: int | None = None,
+    title: str | None = None,
+    attributes: dict[str, object] | None = None,
 ) -> ScanAsset:
     asset = ScanAsset(
         scan_run_id=run.id,
@@ -72,7 +75,9 @@ def add_asset(
         asset_type="page",
         url=url,
         method="GET",
-        attributes={},
+        status_code=status_code,
+        title=title,
+        attributes=attributes or {},
         discovered_at=datetime.now(timezone.utc),
     )
     session.add(asset)

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -7,7 +8,7 @@ import httpx
 import pytest
 from sqlalchemy import select
 
-from app.core.errors import InputValidationError
+from app.core.errors import ConflictError, InputValidationError
 from app.core.settings import get_settings
 from app.db.bootstrap import get_session
 from app.models.credential_profile import CredentialProfile
@@ -202,6 +203,14 @@ def test_start_assessment_creates_three_contexts(assessment_profiles, tmp_path):
     assert dispatcher.ids == [view.id]
 
 
+def test_quick_run_is_not_readable_through_assessment_interface(tmp_path) -> None:
+    service, _dispatcher = build_holding_service(tmp_path)
+    quick = service.start_scan("http://127.0.0.1:8080/")
+
+    with pytest.raises(InputValidationError, match="authenticated coverage"):
+        service.get_assessment(quick.id)
+
+
 def test_cancelling_queued_assessment_deletes_temporary_profile_secrets(
     assessment_profiles,
     tmp_path,
@@ -241,6 +250,92 @@ def test_cancelling_queued_assessment_deletes_temporary_profile_secrets(
     assert all(not store.path_for(reference).exists() for reference in references)
 
 
+def test_assessment_owns_ephemeral_secret_snapshots_and_rejects_reuse(
+    assessment_profiles,
+    tmp_path,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    references = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = references[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = references[1]
+        session.commit()
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            report_service=ScanReportService(tmp_path / "reports"),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=HoldingDispatcher(),
+    )
+    request = AssessmentStartRequest(
+        url=assessment_profiles.url,
+        mode="authenticated_coverage",
+        user_profile_id=assessment_profiles.user_id,
+        admin_profile_id=assessment_profiles.admin_id,
+    )
+
+    view = service.start_assessment(request)
+
+    with get_session() as session:
+        run = session.get(ScanRun, view.id)
+        snapshots = {
+            context.kind: context.temporary_secret_ref
+            for context in run.contexts
+            if context.kind != "anonymous"
+        }
+    assert snapshots == {"user": references[0], "admin": references[1]}
+
+    with pytest.raises(ConflictError, match="一次性秘密"):
+        service.start_assessment(request.model_copy(update={"options": ScanOptions(max_pages=51)}))
+
+
+def test_assessment_cleanup_does_not_delete_a_later_profile_rotation(
+    assessment_profiles,
+    tmp_path,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    owned_refs = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = owned_refs[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = owned_refs[1]
+        session.commit()
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            report_service=ScanReportService(tmp_path / "reports"),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=HoldingDispatcher(),
+    )
+    view = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+    rotated_refs = [store.write("rotated-user"), store.write("rotated-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = rotated_refs[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = rotated_refs[1]
+        session.commit()
+
+    service.cancel_assessment(view.id)
+
+    assert all(not store.path_for(reference).exists() for reference in owned_refs)
+    assert all(store.path_for(reference).exists() for reference in rotated_refs)
+
+
 def test_startup_interrupt_deletes_temporary_assessment_secrets(
     assessment_profiles,
     tmp_path,
@@ -277,6 +372,30 @@ def test_startup_interrupt_deletes_temporary_assessment_secrets(
 
     assert interrupted == 1
     assert all(not store.path_for(reference).exists() for reference in references)
+
+
+def test_service_startup_purges_expired_temporary_secrets(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    expired = store.write("expired")
+    fresh = store.write("fresh")
+    os.utime(store.path_for(expired), (0, 0))
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=HoldingDispatcher(),
+    )
+
+    deleted = service.purge_expired_temporary_secrets(max_age_seconds=900)
+
+    assert deleted == (expired,)
+    assert not store.path_for(expired).exists()
+    assert store.path_for(fresh).exists()
 
 
 def test_dispatch_failure_marks_assessment_failed_and_deletes_temporary_secrets(

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -170,7 +170,8 @@ def test_completed_quick_context_reflects_real_collection(completed_quick_run):
     assert all(asset.identity_key for asset in assets)
 
 
-def test_start_assessment_creates_three_contexts(assessment_profiles, inline_service):
+def test_start_assessment_creates_three_contexts(assessment_profiles, tmp_path):
+    service, dispatcher = build_holding_service(tmp_path)
     request = AssessmentStartRequest(
         url=assessment_profiles.url,
         mode="authenticated_coverage",
@@ -178,7 +179,7 @@ def test_start_assessment_creates_three_contexts(assessment_profiles, inline_ser
         admin_profile_id=assessment_profiles.admin_id,
     )
 
-    view = inline_service.start_assessment(request)
+    view = service.start_assessment(request)
 
     assert [item.kind for item in view.contexts] == ["anonymous", "user", "admin"]
     assert [stage.name for stage in view.stages] == [
@@ -192,12 +193,36 @@ def test_start_assessment_creates_three_contexts(assessment_profiles, inline_ser
         "report",
     ]
     assert view.status == "queued"
+    assert dispatcher.ids == [view.id]
+
+
+def test_new_authenticated_and_quick_runs_are_dispatched_once(
+    tmp_path,
+    assessment_profiles,
+) -> None:
+    service, dispatcher = build_holding_service(tmp_path)
+    request = AssessmentStartRequest(
+        url=assessment_profiles.url,
+        mode="authenticated_coverage",
+        user_profile_id=assessment_profiles.user_id,
+        admin_profile_id=assessment_profiles.admin_id,
+    )
+
+    authenticated = service.start_assessment(request)
+    duplicate = service.start_assessment(request)
+    quick = service.start_assessment(
+        AssessmentStartRequest(url=assessment_profiles.url, mode="quick")
+    )
+
+    assert duplicate.id == authenticated.id
+    assert dispatcher.ids == [authenticated.id, quick.id]
 
 
 def test_authenticated_assessment_can_reference_quick_source_run(
-    inline_service, completed_quick_run, assessment_profiles
+    completed_quick_run, assessment_profiles, tmp_path
 ):
-    view = inline_service.start_assessment(
+    service, _dispatcher = build_holding_service(tmp_path)
+    view = service.start_assessment(
         AssessmentStartRequest(
             url=completed_quick_run.normalized_url,
             mode="authenticated_coverage",
@@ -382,7 +407,13 @@ def test_active_key_distinguishes_mode_profiles_active_flag_and_full_options(
         len({base.id, changed_profile.id, changed_active_flag.id, changed_options.id, quick.id})
         == 5
     )
-    assert dispatcher.ids == [quick.id]
+    assert dispatcher.ids == [
+        base.id,
+        changed_profile.id,
+        changed_active_flag.id,
+        changed_options.id,
+        quick.id,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_assessment_application.py
+++ b/tests/test_assessment_application.py
@@ -15,6 +15,7 @@ from app.models.scan_run import ScanAsset, ScanRun
 from app.models.target import Target
 from app.schemas.assessment import AssessmentStartRequest
 from app.schemas.scan import ScanOptions
+from app.services.ephemeral_secret_store import EphemeralSecretStore
 from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
 from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_pipeline import ScanPipeline
@@ -55,6 +56,11 @@ class HoldingDispatcher:
 
     def submit(self, scan_run_id: int, callback) -> None:
         self.ids.append(scan_run_id)
+
+
+class FailingDispatcher:
+    def submit(self, scan_run_id: int, callback) -> None:
+        raise RuntimeError("dispatcher unavailable")
 
 
 def build_holding_service(tmp_path) -> tuple[ScanApplicationService, HoldingDispatcher]:
@@ -194,6 +200,170 @@ def test_start_assessment_creates_three_contexts(assessment_profiles, tmp_path):
     ]
     assert view.status == "queued"
     assert dispatcher.ids == [view.id]
+
+
+def test_cancelling_queued_assessment_deletes_temporary_profile_secrets(
+    assessment_profiles,
+    tmp_path,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    references = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = references[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = references[1]
+        session.commit()
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    dispatcher = HoldingDispatcher()
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            report_service=ScanReportService(tmp_path / "reports"),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=dispatcher,
+    )
+    view = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+
+    cancelled = service.cancel_assessment(view.id)
+
+    assert cancelled.status == "interrupted"
+    assert all(not store.path_for(reference).exists() for reference in references)
+
+
+def test_startup_interrupt_deletes_temporary_assessment_secrets(
+    assessment_profiles,
+    tmp_path,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    references = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = references[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = references[1]
+        session.commit()
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            report_service=ScanReportService(tmp_path / "reports"),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=HoldingDispatcher(),
+    )
+    service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+
+    interrupted = service.interrupt_active_scans()
+
+    assert interrupted == 1
+    assert all(not store.path_for(reference).exists() for reference in references)
+
+
+def test_dispatch_failure_marks_assessment_failed_and_deletes_temporary_secrets(
+    assessment_profiles,
+    tmp_path,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    references = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = references[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = references[1]
+        session.commit()
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=ScanPipeline(
+            policy=policy,
+            gateway=HttpScanGateway(policy),
+            report_service=ScanReportService(tmp_path / "reports"),
+            ephemeral_secret_store=store,
+        ),
+        dispatcher=FailingDispatcher(),
+    )
+
+    with pytest.raises(RuntimeError, match="dispatcher unavailable"):
+        service.start_assessment(
+            AssessmentStartRequest(
+                url=assessment_profiles.url,
+                mode="authenticated_coverage",
+                user_profile_id=assessment_profiles.user_id,
+                admin_profile_id=assessment_profiles.admin_id,
+            )
+        )
+
+    assert all(not store.path_for(reference).exists() for reference in references)
+    with get_session() as session:
+        run = session.scalar(select(ScanRun).order_by(ScanRun.id.desc()))
+        assert run.status == "failed"
+        assert run.error_code == "dispatch_failed"
+        assert run.active_key is None
+
+
+def test_runtime_wrapper_deletes_temporary_secrets_when_pipeline_raises_early(
+    assessment_profiles,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    references = [store.write("temporary-user"), store.write("temporary-admin")]
+    with get_session() as session:
+        session.get(CredentialProfile, assessment_profiles.user_id).secret_ref = references[0]
+        session.get(CredentialProfile, assessment_profiles.admin_id).secret_ref = references[1]
+        session.commit()
+
+    settings = get_settings()
+    policy = TargetNetworkPolicy(settings, resolver=_loopback_resolver)
+    pipeline = ScanPipeline(
+        policy=policy,
+        gateway=HttpScanGateway(policy),
+        report_service=ScanReportService(tmp_path / "reports"),
+        ephemeral_secret_store=store,
+    )
+    service = ScanApplicationService(
+        settings=settings,
+        pipeline=pipeline,
+        dispatcher=HoldingDispatcher(),
+    )
+    view = service.start_assessment(
+        AssessmentStartRequest(
+            url=assessment_profiles.url,
+            mode="authenticated_coverage",
+            user_profile_id=assessment_profiles.user_id,
+            admin_profile_id=assessment_profiles.admin_id,
+        )
+    )
+
+    def fail_before_pipeline_guard(session, scan_run_id):
+        raise RuntimeError("early runtime failure")
+
+    monkeypatch.setattr(pipeline, "execute_authenticated", fail_before_pipeline_guard)
+
+    with pytest.raises(RuntimeError, match="early runtime failure"):
+        service.execute_authenticated_assessment(view.id)
+
+    assert all(not store.path_for(reference).exists() for reference in references)
 
 
 def test_new_authenticated_and_quick_runs_are_dispatched_once(

--- a/tests/test_assessments_api.py
+++ b/tests/test_assessments_api.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from app.schemas.assessment import AssessmentRunView, CoverageDifferenceView
+
+
+def _assessment_view() -> AssessmentRunView:
+    return AssessmentRunView(
+        id=31,
+        mode="authenticated_coverage",
+        input_url="http://127.0.0.1:8080/",
+        normalized_url="http://127.0.0.1:8080/",
+        status="queued",
+        current_stage="queued",
+        progress=0,
+        retry_count=0,
+        created_at=datetime.now(timezone.utc),
+        completeness="pending",
+        active_checks_enabled=False,
+    )
+
+
+class RecordingAssessmentService:
+    def __init__(self) -> None:
+        self.started = None
+
+    def start_assessment(self, request):
+        self.started = request
+        return _assessment_view()
+
+    def get_assessment(self, assessment_id):
+        assert assessment_id == 31
+        return _assessment_view()
+
+    def list_coverage_differences(self, assessment_id):
+        assert assessment_id == 31
+        return [
+            CoverageDifferenceView(
+                id=7,
+                identity_key="GET:/admin",
+                classification="admin_only",
+                anonymous_state="absent",
+                user_state="absent",
+                admin_state="present",
+                anonymous_present=False,
+                user_present=False,
+                admin_present=True,
+            )
+        ]
+
+    def cancel_assessment(self, assessment_id):
+        assert assessment_id == 31
+        return _assessment_view().model_copy(update={"status": "interrupted"})
+
+    def read_report(self, assessment_id):
+        assert assessment_id == 31
+        return "# Garden 认证覆盖报告 #31\n"
+
+
+def test_passive_assessment_http_start_and_read_interfaces(app) -> None:
+    service = RecordingAssessmentService()
+    with TestClient(app) as client:
+        original_service = app.state.scan_service
+        app.state.scan_service = service
+        try:
+            started = client.post(
+                "/api/assessments",
+                json={
+                    "url": "http://127.0.0.1:8080/",
+                    "user_profile_id": 12,
+                    "admin_profile_id": 13,
+                },
+            )
+            status = client.get("/api/assessments/31")
+            differences = client.get("/api/assessments/31/differences")
+            cancelled = client.post("/api/assessments/31/cancel")
+            report = client.get("/api/assessments/31/report")
+        finally:
+            app.state.scan_service = original_service
+
+    assert started.status_code == 202
+    assert service.started.mode.value == "authenticated_coverage"
+    assert service.started.active_checks_enabled is False
+    assert service.started.authorization_confirmed is False
+    assert status.status_code == 200
+    assert differences.status_code == 200
+    assert differences.json()[0]["classification"] == "admin_only"
+    assert cancelled.json()["status"] == "interrupted"
+    assert report.status_code == 200
+    assert "Garden 认证覆盖报告" in report.text
+
+
+def test_assessment_http_rejects_active_replay_fields_before_application_call(app) -> None:
+    for forbidden_field in ("active_checks_enabled", "authorization_confirmed"):
+        service = RecordingAssessmentService()
+        with TestClient(app) as client:
+            original_service = app.state.scan_service
+            app.state.scan_service = service
+            try:
+                response = client.post(
+                    "/api/assessments",
+                    json={
+                        "url": "http://127.0.0.1:8080/",
+                        "user_profile_id": 12,
+                        "admin_profile_id": 13,
+                        forbidden_field: True,
+                    },
+                )
+            finally:
+                app.state.scan_service = original_service
+
+        assert response.status_code == 422
+        assert service.started is None

--- a/tests/test_assessments_api.py
+++ b/tests/test_assessments_api.py
@@ -68,8 +68,10 @@ def test_passive_assessment_http_start_and_read_interfaces(app) -> None:
                 "/api/assessments",
                 json={
                     "url": "http://127.0.0.1:8080/",
+                    "source_run_id": 9,
                     "user_profile_id": 12,
                     "admin_profile_id": 13,
+                    "options": {"max_pages": 8, "max_resources": 15},
                 },
             )
             status = client.get("/api/assessments/31")
@@ -83,6 +85,9 @@ def test_passive_assessment_http_start_and_read_interfaces(app) -> None:
     assert service.started.mode.value == "authenticated_coverage"
     assert service.started.active_checks_enabled is False
     assert service.started.authorization_confirmed is False
+    assert service.started.source_run_id == 9
+    assert service.started.options.max_pages == 8
+    assert service.started.options.max_resources == 15
     assert status.status_code == 200
     assert differences.status_code == 200
     assert differences.json()[0]["classification"] == "admin_only"

--- a/tests/test_authenticated_coverage_e2e.py
+++ b/tests/test_authenticated_coverage_e2e.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import uvicorn
+
+from app.core.settings import Settings
+from app.db.bootstrap import session_scope
+from app.models.enums import AssessmentMode, AuthType, TargetStatus, TargetType
+from app.schemas.assessment import AssessmentStartRequest
+from app.schemas.credential import CredentialProfileCreate
+from app.schemas.scan import ScanOptions
+from app.schemas.target import TargetCreate
+from app.services.context_collection import (
+    ContextCollectionService,
+    DefaultContextCollectionGateway,
+)
+from app.services.context_establishment import ContextEstablishmentService
+from app.services.credentials import CredentialProfileService
+from app.services.inventory_collection import InventoryCollectionService
+from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
+from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_pipeline import ScanPipeline
+from app.services.scan_reporting import ScanReportService
+from app.services.session_storage import SessionStorageService
+from app.services.sessions import AuthSessionService
+from app.services.targets import TargetService
+from tests.fixtures.auth_coverage_site.app import app as fixture_app
+
+
+def _reserve_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+@pytest.fixture
+def auth_coverage_site(monkeypatch):
+    monkeypatch.setenv("GARDEN_E2E_USER_PASSWORD", "local-user-secret")
+    monkeypatch.setenv("GARDEN_E2E_ADMIN_PASSWORD", "local-admin-secret")
+    port = _reserve_port()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            fixture_app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=2)
+        pytest.fail("localhost coverage fixture did not start")
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def _login_config(role: str) -> str:
+    return str(
+        (
+            Path(__file__).parent / "fixtures" / "auth_coverage_site" / f"login-config-{role}.yaml"
+        ).resolve()
+    )
+
+
+def _application(tmp_path: Path) -> ScanApplicationService:
+    settings = Settings(
+        GARDEN_ALLOW_NON_LOCAL_TARGETS=False,
+        GARDEN_ALLOW_PRIVATE_TARGETS=False,
+        GARDEN_SCAN_OVERALL_TIMEOUT_SECONDS=60,
+    )
+    policy = TargetNetworkPolicy(settings)
+    http_gateway = HttpScanGateway(policy)
+    session_storage = SessionStorageService(tmp_path / "session-payloads")
+    auth_service = AuthSessionService(storage_service=session_storage)
+    context_service = ContextEstablishmentService(auth_service=auth_service)
+    inventory_service = InventoryCollectionService(storage_service=session_storage)
+    collection_service = ContextCollectionService(
+        gateway=DefaultContextCollectionGateway(
+            http_gateway=http_gateway,
+            inventory_service=inventory_service,
+        ),
+        storage_service=session_storage,
+    )
+    pipeline = ScanPipeline(
+        policy=policy,
+        gateway=http_gateway,
+        context_service=context_service,
+        context_collection_service=collection_service,
+        report_service=ScanReportService(tmp_path / "reports"),
+    )
+    return ScanApplicationService(
+        settings=settings,
+        pipeline=pipeline,
+        dispatcher=InlineScanDispatcher(),
+    )
+
+
+def test_real_browser_three_context_coverage_is_passive_and_role_aware(
+    auth_coverage_site: str,
+    tmp_path: Path,
+) -> None:
+    with session_scope() as session:
+        target = TargetService().create(
+            session,
+            TargetCreate(
+                name="localhost-auth-coverage",
+                base_url=auth_coverage_site,
+                type=TargetType.WEB,
+                owner="pytest",
+                tags=["localhost", "e2e"],
+                status=TargetStatus.ACTIVE,
+            ),
+        )
+        profiles = CredentialProfileService()
+        user = profiles.create(
+            session,
+            CredentialProfileCreate(
+                target_id=target.id,
+                name="coverage-user",
+                role="user",
+                auth_type=AuthType.PASSWORD,
+                username="coverage-user",
+                secret_ref="env://GARDEN_E2E_USER_PASSWORD",
+                login_config_path=_login_config("user"),
+            ),
+        )
+        admin = profiles.create(
+            session,
+            CredentialProfileCreate(
+                target_id=target.id,
+                name="coverage-admin",
+                role="admin",
+                auth_type=AuthType.PASSWORD,
+                username="coverage-admin",
+                secret_ref="env://GARDEN_E2E_ADMIN_PASSWORD",
+                login_config_path=_login_config("admin"),
+            ),
+        )
+        target_id, user_id, admin_id = target.id, user.id, admin.id
+
+    service = _application(tmp_path)
+    result = service.start_assessment(
+        AssessmentStartRequest(
+            url=auth_coverage_site,
+            mode=AssessmentMode.AUTHENTICATED_COVERAGE,
+            target_id=target_id,
+            user_profile_id=user_id,
+            admin_profile_id=admin_id,
+            options=ScanOptions(max_pages=10, max_depth=2, overall_timeout_seconds=60),
+        )
+    )
+
+    assert result.status == "completed", (
+        result.error_code,
+        result.error_message,
+        [
+            (context.kind, context.status, context.error_code, context.error_message)
+            for context in result.contexts
+        ],
+    )
+    assert result.completeness == "complete"
+    assert result.context_counts == {"anonymous": 1, "user": 1, "admin": 1}
+    assert result.replay_count == 0
+    differences = {item.identity_key: item for item in service.list_coverage_differences(result.id)}
+    shared = differences["GET:/shared"]
+    stable_fields = ("status_code", "url", "title", "content_type", "content_signature")
+    shared_field_matches = {
+        field: len({summary.get(field) for summary in shared.context_summaries.values()}) == 1
+        for field in stable_fields
+    }
+    assert shared.classification == "shared", shared_field_matches
+    assert differences["GET:/account"].classification == "user_only"
+    assert differences["GET:/admin/users"].classification == "admin_only"
+    assert differences["GET:/anonymous-banner"].classification == "unexpectedly_anonymous"
+    assert differences["GET:/api/profile"].classification == "inconsistent"
+    report = service.read_report(result.id)
+    assert "主动权限重放未执行" in report
+    assert "覆盖差异不是已确认漏洞" in report
+    assert "local-user-secret" not in report
+    assert "local-admin-secret" not in report

--- a/tests/test_authenticated_coverage_pipeline.py
+++ b/tests/test_authenticated_coverage_pipeline.py
@@ -32,7 +32,7 @@ def _loopback_resolver(host, port, **kwargs):
 
 
 class ReadyContextService:
-    def establish(self, session, run):
+    def establish(self, session, run, *, before_request=None):
         for context in run.contexts:
             context.status = "ready"
             context.login_status = "not_applicable" if context.kind == "anonymous" else "succeeded"
@@ -44,7 +44,7 @@ class ReadyContextService:
 
 
 class CompleteContextCollectionService:
-    def collect(self, session, run, context):
+    def collect(self, session, run, context, *, before_request=None):
         add_asset(
             session,
             run,
@@ -71,9 +71,31 @@ class CompleteContextCollectionService:
         )
 
 
+class GuardedReadyContextService(ReadyContextService):
+    def __init__(self) -> None:
+        self.guard_calls = 0
+
+    def establish(self, session, run, *, before_request=None):
+        assert before_request is not None
+        before_request()
+        self.guard_calls += 1
+        return super().establish(session, run)
+
+
+class GuardedCompleteContextCollectionService(CompleteContextCollectionService):
+    def __init__(self) -> None:
+        self.guard_calls = 0
+
+    def collect(self, session, run, context, *, before_request=None):
+        assert before_request is not None
+        before_request()
+        self.guard_calls += 1
+        return super().collect(session, run, context)
+
+
 class MissingUserContextService(ReadyContextService):
-    def establish(self, session, run):
-        contexts = super().establish(session, run)
+    def establish(self, session, run, *, before_request=None):
+        contexts = super().establish(session, run, before_request=before_request)
         user = next(context for context in contexts if context.kind == "user")
         user.status = "failed"
         user.login_status = "failed"
@@ -147,6 +169,24 @@ def test_authenticated_pipeline_completes_all_passive_stages(db_session, tmp_pat
     assert "v0.3" in replay_stage.summary
     assert "被动" in replay_stage.summary
     assert db_session.query(ReplayExecution).filter_by(scan_run_id=run.id).count() == 0
+
+
+def test_authenticated_pipeline_guards_establishment_and_every_context_collection(
+    db_session,
+    tmp_path,
+) -> None:
+    run = _queued_authenticated_run(db_session)
+    context_service = GuardedReadyContextService()
+    collection_service = GuardedCompleteContextCollectionService()
+
+    _pipeline(
+        tmp_path,
+        context_service=context_service,
+        collection_service=collection_service,
+    ).execute_authenticated(db_session, run.id)
+
+    assert context_service.guard_calls == 1
+    assert collection_service.guard_calls == 3
 
 
 def test_failed_user_context_continues_with_unknown_and_report(db_session, tmp_path) -> None:

--- a/tests/test_authenticated_coverage_pipeline.py
+++ b/tests/test_authenticated_coverage_pipeline.py
@@ -1,0 +1,252 @@
+from pathlib import Path
+
+import pytest
+
+from app.core.settings import get_settings
+from app.db.bootstrap import get_session
+from app.models.credential_profile import CredentialProfile
+from app.models.replay_execution import ReplayExecution
+from app.models.target import Target
+from app.schemas.scan import ScanOptions
+from app.services.context_collection import ContextCollectionSummary
+from app.services.ephemeral_secret_store import EphemeralSecretStore
+from app.services.scan_application import create_assessment_stages
+from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
+from app.services.scan_pipeline import ScanPipeline
+from app.services.scan_reporting import ScanReportService
+from tests.helpers.assessment import add_asset, make_authenticated_run
+
+
+@pytest.fixture
+def db_session():
+    session = get_session()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def _loopback_resolver(host, port, **kwargs):
+    return [(2, 1, 6, "", ("127.0.0.1", port))]
+
+
+class ReadyContextService:
+    def establish(self, session, run):
+        for context in run.contexts:
+            context.status = "ready"
+            context.login_status = "not_applicable" if context.kind == "anonymous" else "succeeded"
+            context.session_validation_status = (
+                "not_applicable" if context.kind == "anonymous" else "valid"
+            )
+        session.flush()
+        return list(run.contexts)
+
+
+class CompleteContextCollectionService:
+    def collect(self, session, run, context):
+        add_asset(
+            session,
+            run,
+            context_id=context.id,
+            identity_key="GET:/shared",
+            url="http://127.0.0.1:8080/shared",
+            status_code=200,
+            title="Shared",
+            attributes={
+                "content_type": "text/html",
+                "content_signature": "same-signature",
+            },
+        )
+        context.status = "completed"
+        context.collection_status = "completed"
+        context.completeness = "complete"
+        context.asset_count = 1
+        session.flush()
+        return ContextCollectionSummary(
+            context_id=context.id,
+            asset_count=1,
+            request_count=0,
+            failure_count=0,
+        )
+
+
+class MissingUserContextService(ReadyContextService):
+    def establish(self, session, run):
+        contexts = super().establish(session, run)
+        user = next(context for context in contexts if context.kind == "user")
+        user.status = "failed"
+        user.login_status = "failed"
+        user.session_validation_status = "invalid"
+        user.collection_status = "failed"
+        user.completeness = "incomplete"
+        user.error_code = "authentication_session_unavailable"
+        user.error_message = "Authentication session could not be established and validated."
+        run.status = "incomplete"
+        run.completeness = "missing_user_context"
+        run.error_code = "context_establishment_failed"
+        run.error_message = "One or more required authentication contexts failed."
+        session.flush()
+        return contexts
+
+
+def _pipeline(
+    tmp_path: Path,
+    *,
+    context_service=None,
+    collection_service=None,
+    comparison_service=None,
+    secret_store=None,
+):
+    policy = TargetNetworkPolicy(get_settings(), resolver=_loopback_resolver)
+    return ScanPipeline(
+        policy=policy,
+        gateway=HttpScanGateway(policy),
+        context_service=context_service or ReadyContextService(),
+        context_collection_service=collection_service or CompleteContextCollectionService(),
+        coverage_comparison_service=comparison_service,
+        ephemeral_secret_store=secret_store,
+        report_service=ScanReportService(tmp_path / "reports"),
+    )
+
+
+def _queued_authenticated_run(db_session):
+    run = make_authenticated_run(db_session)
+    run.input_url = "http://127.0.0.1:8080/"
+    run.normalized_url = run.input_url
+    run.options = ScanOptions().model_dump()
+    create_assessment_stages(db_session, run)
+    db_session.flush()
+    return run
+
+
+def test_authenticated_pipeline_completes_all_passive_stages(db_session, tmp_path) -> None:
+    run = _queued_authenticated_run(db_session)
+
+    _pipeline(tmp_path).execute_authenticated(db_session, run.id)
+
+    db_session.refresh(run)
+    assert run.status == "completed", (
+        run.error_message,
+        {stage.name: stage.status for stage in run.stages},
+    )
+    assert run.active_checks_enabled is False
+    assert run.report_path is not None
+    assert Path(run.report_path).exists()
+    assert {stage.name: stage.status for stage in run.stages} == {
+        "validate": "completed",
+        "establish_contexts": "completed",
+        "collect": "completed",
+        "normalize": "completed",
+        "compare_coverage": "completed",
+        "replay_authorization": "skipped",
+        "analyze": "completed",
+        "report": "completed",
+    }
+    replay_stage = next(stage for stage in run.stages if stage.name == "replay_authorization")
+    assert "v0.3" in replay_stage.summary
+    assert "被动" in replay_stage.summary
+    assert db_session.query(ReplayExecution).filter_by(scan_run_id=run.id).count() == 0
+
+
+def test_failed_user_context_continues_with_unknown_and_report(db_session, tmp_path) -> None:
+    run = _queued_authenticated_run(db_session)
+    run.active_key = "partial-context-active-key"
+    db_session.flush()
+
+    _pipeline(tmp_path, context_service=MissingUserContextService()).execute_authenticated(
+        db_session, run.id
+    )
+
+    db_session.refresh(run)
+    assert run.status == "incomplete"
+    assert run.completeness == "missing_user_context"
+    assert run.active_key is None
+    assert run.report_path is not None
+    assert Path(run.report_path).exists()
+    assert len(run.coverage_differences) == 1
+    difference = run.coverage_differences[0]
+    assert difference.user_state == "unknown"
+    assert difference.user_present is None
+    assert difference.classification == "unknown"
+    assert next(stage for stage in run.stages if stage.name == "report").status == "completed"
+
+
+class FailingComparisonService:
+    def __init__(self, secret: str) -> None:
+        self.secret = secret
+
+    def compare(self, session, run):
+        raise RuntimeError(f"comparison exploded with {self.secret}")
+
+
+def test_fatal_comparison_cleans_secrets_skips_later_stages_and_writes_safe_diagnostic(
+    db_session,
+    tmp_path,
+) -> None:
+    raw_secret = "never-persist-this-comparison-secret"
+    secret_store = EphemeralSecretStore(tmp_path / "secrets")
+    target = Target(
+        name="fatal-target",
+        base_url="http://127.0.0.1:8080/",
+        type="web",
+        owner="appsec",
+        tags=[],
+        status="active",
+    )
+    db_session.add(target)
+    db_session.flush()
+    user_ref = secret_store.write(raw_secret)
+    admin_ref = secret_store.write(f"admin-{raw_secret}")
+    profiles = [
+        CredentialProfile(
+            target_id=target.id,
+            name=f"fatal-{role}",
+            role=role,
+            auth_type="password",
+            username=role,
+            secret_ref=reference,
+            login_config_path="inline://unused-by-orchestration-test",
+        )
+        for role, reference in (("user", user_ref), ("admin", admin_ref))
+    ]
+    db_session.add_all(profiles)
+    db_session.flush()
+    run = _queued_authenticated_run(db_session)
+    run.target_id = target.id
+    run.active_key = "fatal-comparison-active-key"
+    for context in run.contexts:
+        if context.kind == "user":
+            context.credential_profile_id = profiles[0].id
+        elif context.kind == "admin":
+            context.credential_profile_id = profiles[1].id
+    db_session.flush()
+
+    _pipeline(
+        tmp_path,
+        comparison_service=FailingComparisonService(raw_secret),
+        secret_store=secret_store,
+    ).execute_authenticated(db_session, run.id)
+
+    db_session.refresh(run)
+    stages = {stage.name: stage for stage in run.stages}
+    assert run.status == "failed"
+    assert run.active_key is None
+    assert stages["compare_coverage"].status == "failed"
+    assert stages["replay_authorization"].status == "skipped"
+    assert stages["analyze"].status == "skipped"
+    assert stages["report"].status == "completed"
+    assert run.report_path is not None
+    report_text = Path(run.report_path).read_text(encoding="utf-8")
+    persisted_text = " ".join(
+        filter(
+            None,
+            [
+                run.error_message,
+                stages["compare_coverage"].error_message,
+                report_text,
+            ],
+        )
+    )
+    assert raw_secret not in persisted_text
+    assert list(secret_store.root.glob("*.secret")) == []

--- a/tests/test_authenticated_coverage_pipeline.py
+++ b/tests/test_authenticated_coverage_pipeline.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from app.core.errors import OverallScanTimeout
 from app.core.settings import get_settings
 from app.db.bootstrap import get_session
 from app.models.credential_profile import CredentialProfile
@@ -114,6 +115,11 @@ class MissingUserContextService(ReadyContextService):
         return contexts
 
 
+class TimingOutContextService:
+    def establish(self, session, run, *, before_request=None):
+        raise OverallScanTimeout("The overall scan timeout was exceeded.")
+
+
 def _pipeline(
     tmp_path: Path,
     *,
@@ -219,6 +225,25 @@ def test_authenticated_pipeline_guards_establishment_and_every_context_collectio
     assert collection_service.guard_calls == 3
 
 
+def test_authenticated_timeout_preserves_partial_report_and_specific_failure(
+    db_session,
+    tmp_path,
+) -> None:
+    run = _queued_authenticated_run(db_session)
+
+    _pipeline(tmp_path, context_service=TimingOutContextService()).execute_authenticated(
+        db_session, run.id
+    )
+
+    db_session.refresh(run)
+    assert run.status == "incomplete"
+    assert run.completeness == "incomplete"
+    assert run.error_code == "overall_timeout"
+    assert any(failure.code == "overall_timeout" for failure in run.failures)
+    assert all(failure.code != "authenticated_pipeline_failed" for failure in run.failures)
+    assert Path(run.report_path).exists()
+
+
 def test_failed_user_context_continues_with_unknown_and_report(db_session, tmp_path) -> None:
     run = _queued_authenticated_run(db_session)
     run.active_key = "partial-context-active-key"
@@ -288,8 +313,10 @@ def test_fatal_comparison_cleans_secrets_skips_later_stages_and_writes_safe_diag
     for context in run.contexts:
         if context.kind == "user":
             context.credential_profile_id = profiles[0].id
+            context.temporary_secret_ref = user_ref
         elif context.kind == "admin":
             context.credential_profile_id = profiles[1].id
+            context.temporary_secret_ref = admin_ref
     db_session.flush()
 
     _pipeline(

--- a/tests/test_authenticated_coverage_pipeline.py
+++ b/tests/test_authenticated_coverage_pipeline.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -6,6 +7,7 @@ from app.core.settings import get_settings
 from app.db.bootstrap import get_session
 from app.models.credential_profile import CredentialProfile
 from app.models.replay_execution import ReplayExecution
+from app.models.scan_run import ScanFailure
 from app.models.target import Target
 from app.schemas.scan import ScanOptions
 from app.services.context_collection import ContextCollectionSummary
@@ -169,6 +171,34 @@ def test_authenticated_pipeline_completes_all_passive_stages(db_session, tmp_pat
     assert "v0.3" in replay_stage.summary
     assert "被动" in replay_stage.summary
     assert db_session.query(ReplayExecution).filter_by(scan_run_id=run.id).count() == 0
+
+
+def test_complete_authenticated_pipeline_preserves_coverage_warning_status(
+    db_session,
+    tmp_path,
+) -> None:
+    run = _queued_authenticated_run(db_session)
+    db_session.add(
+        ScanFailure(
+            scan_run_id=run.id,
+            stage="collect",
+            code="coverage_limit_reached",
+            message="Collection reached its configured resource limit.",
+            url=run.normalized_url,
+            retryable=False,
+            attempt=1,
+            occurred_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.flush()
+
+    _pipeline(tmp_path).execute_authenticated(db_session, run.id)
+
+    db_session.refresh(run)
+    assert run.status == "completed_with_warnings"
+    assert run.completeness == "complete"
+    report = Path(run.report_path).read_text(encoding="utf-8")
+    assert "任务状态：completed_with_warnings" in report
 
 
 def test_authenticated_pipeline_guards_establishment_and_every_context_collection(

--- a/tests/test_authenticated_coverage_reporting.py
+++ b/tests/test_authenticated_coverage_reporting.py
@@ -86,6 +86,22 @@ def test_authenticated_report_renders_context_health_and_difference_matrix(
     assert "覆盖差异不是已确认漏洞" in text
 
 
+def test_authenticated_report_redacts_entry_url_query_values(
+    db_session,
+    tmp_path: Path,
+) -> None:
+    run = _reported_run(db_session)
+    run.input_url = "http://127.0.0.1:8080/?token=entry-secret&id=7#fragment"
+    run.normalized_url = run.input_url
+
+    path = ScanReportService(tmp_path / "reports").generate(db_session, run.id)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert "入口 URL：http://127.0.0.1:8080/?id=[REDACTED]&token=[REDACTED]" in text
+    assert "entry-secret" not in text
+    assert "#fragment" not in text
+
+
 def test_authenticated_report_preserves_unknown_and_omits_forbidden_asset_values(
     db_session,
     tmp_path: Path,

--- a/tests/test_authenticated_coverage_reporting.py
+++ b/tests/test_authenticated_coverage_reporting.py
@@ -1,0 +1,192 @@
+from pathlib import Path
+
+import pytest
+
+from app.db.bootstrap import get_session
+from app.models.coverage_difference import CoverageDifference
+from app.services.scan_application import create_assessment_stages
+from app.services.scan_reporting import ScanReportService
+from tests.helpers.assessment import add_asset, make_authenticated_run
+
+
+@pytest.fixture
+def db_session():
+    session = get_session()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def _reported_run(db_session):
+    run = make_authenticated_run(db_session)
+    run.input_url = "http://127.0.0.1:8080/"
+    run.normalized_url = run.input_url
+    run.status = "completed"
+    run.current_stage = "finished"
+    run.progress = 100
+    run.completeness = "complete"
+    run.options = {"max_pages": 50, "max_resources": 200, "max_depth": 2}
+    for context in run.contexts:
+        context.status = "completed"
+        context.collection_status = "completed"
+        context.completeness = "complete"
+    create_assessment_stages(db_session, run)
+    db_session.flush()
+    db_session.expire(run, ["stages"])
+    replay_stage = next(stage for stage in run.stages if stage.name == "replay_authorization")
+    replay_stage.status = "skipped"
+    replay_stage.summary = "v0.3 仅执行被动认证覆盖；主动权限重放未执行。"
+    db_session.add(
+        CoverageDifference(
+            scan_run_id=run.id,
+            identity_key="GET:/admin",
+            classification="admin_only",
+            anonymous_state="absent",
+            user_state="absent",
+            admin_state="present",
+            anonymous_present=False,
+            user_present=False,
+            admin_present=True,
+            context_summaries={
+                "admin": {
+                    "asset_id": 7,
+                    "status_code": 200,
+                    "url": "http://127.0.0.1:8080/admin",
+                    "title": "Admin",
+                    "content_type": "text/html",
+                    "content_signature": "safe-signature",
+                }
+            },
+            confidence="high",
+            diagnostic="仅管理员上下文观察到该资产。",
+        )
+    )
+    db_session.flush()
+    return run
+
+
+def test_authenticated_report_renders_context_health_and_difference_matrix(
+    db_session,
+    tmp_path: Path,
+) -> None:
+    run = _reported_run(db_session)
+
+    path = ScanReportService(tmp_path / "reports").generate(db_session, run.id)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert text.startswith(f"# Garden 认证覆盖报告 #{run.id}")
+    assert "## 三上下文健康与完整性" in text
+    assert "## 覆盖差异分类计数" in text
+    assert "| admin_only | 1 |" in text
+    assert "| 资产身份 | anonymous | user | admin | 分类 | 置信度 |" in text
+    assert "| `GET:/admin` | absent | absent | present | admin_only | high |" in text
+    assert "主动权限重放未执行" in text
+    assert "覆盖差异不是已确认漏洞" in text
+
+
+def test_authenticated_report_preserves_unknown_and_omits_forbidden_asset_values(
+    db_session,
+    tmp_path: Path,
+) -> None:
+    run = _reported_run(db_session)
+    contexts = {context.kind: context for context in run.contexts}
+    contexts["user"].status = "failed"
+    contexts["user"].collection_status = "failed"
+    contexts["user"].completeness = "incomplete"
+    contexts["user"].error_code = "authentication_session_unavailable"
+    difference = run.coverage_differences[0]
+    difference.classification = "unknown"
+    difference.user_state = "unknown"
+    difference.user_present = None
+    difference.confidence = "low"
+    difference.diagnostic = "至少一个上下文不完整，无法判断该资产是否缺失。"
+    raw_values = [
+        "Bearer report-secret",
+        "session=report-secret",
+        "private response report-secret",
+        "vault://report-secret",
+    ]
+    add_asset(
+        db_session,
+        run,
+        context_id=contexts["admin"].id,
+        identity_key="GET:/private",
+        attributes={
+            "authorization": raw_values[0],
+            "cookie": raw_values[1],
+            "response_text": raw_values[2],
+            "protected_storage_ref": raw_values[3],
+        },
+    )
+    db_session.flush()
+
+    path = ScanReportService(tmp_path / "reports").generate(db_session, run.id)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert "| `GET:/admin` | absent | unknown | present | unknown | low |" in text
+    assert "unknown" in text
+    assert "## 失败与未覆盖部分" in text
+    assert "user：采集=failed，完整性=incomplete，代码=authentication_session_unavailable" in text
+    assert all(value not in text for value in raw_values)
+
+
+def test_authenticated_report_indexes_evidence_and_allowlists_inconsistent_details(
+    db_session,
+    tmp_path: Path,
+) -> None:
+    run = _reported_run(db_session)
+    forbidden = "cookie=report-must-not-render"
+    db_session.add(
+        CoverageDifference(
+            scan_run_id=run.id,
+            identity_key="GET:/profile",
+            classification="inconsistent",
+            anonymous_state="present",
+            user_state="present",
+            admin_state="present",
+            anonymous_present=True,
+            user_present=True,
+            admin_present=True,
+            context_summaries={
+                "anonymous": {
+                    "asset_id": 11,
+                    "status_code": 200,
+                    "url": "http://127.0.0.1:8080/profile",
+                    "title": "Profile",
+                    "content_type": "application/json",
+                    "content_signature": "anonymous-signature",
+                    "cookie": forbidden,
+                },
+                "user": {
+                    "asset_id": 12,
+                    "status_code": 200,
+                    "url": "http://127.0.0.1:8080/profile",
+                    "title": "Profile",
+                    "content_type": "application/json",
+                    "content_signature": "user-signature",
+                },
+                "admin": {
+                    "asset_id": 13,
+                    "status_code": 200,
+                    "url": "http://127.0.0.1:8080/profile",
+                    "title": "Profile",
+                    "content_type": "application/json",
+                    "content_signature": "admin-signature",
+                },
+            },
+            confidence="medium",
+            diagnostic="三个上下文的稳定响应属性不一致。",
+        )
+    )
+    db_session.flush()
+
+    path = ScanReportService(tmp_path / "reports").generate(db_session, run.id)
+    text = Path(path).read_text(encoding="utf-8")
+
+    assert "## 属性不一致详情" in text
+    assert "| anonymous | 200 | http://127.0.0.1:8080/profile |" in text
+    assert "## 被动观察与证据索引" in text
+    assert "| `GET:/profile` | A11 | A12 | A13 |" in text
+    assert forbidden not in text

--- a/tests/test_authenticated_network_boundaries.py
+++ b/tests/test_authenticated_network_boundaries.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from app.core.errors import TargetPolicyError
+from app.core.settings import Settings
+from app.integrations.auth.http_adapter import HttpLoginAdapter
+from app.integrations.auth.playwright_adapter import SyncPlaywrightGateway
+from app.integrations.inventory.playwright_gateway import SyncPlaywrightInventoryGateway
+from app.models.credential_profile import CredentialProfile
+from app.models.enums import SessionType
+from app.models.target import Target
+from app.schemas.auth import HttpLoginConfig, PlaywrightLoginConfig
+from app.schemas.inventory import InventoryBuildControls
+from app.services.authenticated_network import AuthenticatedNetworkGuard
+from app.services.scan_network import TargetNetworkPolicy
+
+
+class _RedirectHandler(BaseHTTPRequestHandler):
+    redirect_to = ""
+    hits: list[str] = []
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        type(self).hits.append(self.path)
+        if self.path in {"/", "/login"} and self.redirect_to:
+            self.send_response(302)
+            self.send_header("Location", self.redirect_to)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(
+            b'<form><input name="username"><input type="password" name="password">'
+            b'<button type="submit">Login</button></form>'
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+@contextmanager
+def _server(handler_type: type[_RedirectHandler]):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_type)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _target(base_url: str) -> Target:
+    return Target(id=1, name="boundary", base_url=base_url, type="web", owner="appsec")
+
+
+def _credential() -> CredentialProfile:
+    return CredentialProfile(
+        id=1,
+        target_id=1,
+        name="user",
+        role="user",
+        auth_type="password",
+        username="user@example.test",
+        secret_ref="ephemeral-file:///redacted",
+        login_config_path="inline://redacted",
+    )
+
+
+def test_http_login_blocks_cross_origin_redirect_before_secret_replay() -> None:
+    attacker_hits: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "127.0.0.1":
+            return httpx.Response(307, headers={"location": "http://attacker.test/steal"})
+        attacker_hits.append(request.content.decode("utf-8", errors="replace"))
+        return httpx.Response(200, json={"authenticated": True})
+
+    adapter = HttpLoginAdapter(transport=httpx.MockTransport(handler))
+    config = HttpLoginConfig.model_validate(
+        {
+            "adapter": "http",
+            "login_request": {
+                "method": "POST",
+                "url": "/login",
+                "body": {"password": "{{ password }}"},
+                "expected_status": 200,
+            },
+            "validate_request": {"method": "GET", "url": "/me"},
+        }
+    )
+
+    result = adapter.login(
+        _target("http://127.0.0.1:9400"),
+        _credential(),
+        "do-not-forward",
+        config,
+    )
+
+    assert result.success is False
+    assert attacker_hits == []
+    assert "do-not-forward" not in (result.last_error or "")
+
+
+def test_authenticated_guard_rejects_link_local_destination() -> None:
+    guard = AuthenticatedNetworkGuard(
+        TargetNetworkPolicy(Settings(allow_private_targets=True, allow_non_local_targets=True))
+    )
+
+    with pytest.raises(TargetPolicyError):
+        guard.ensure_allowed("http://169.254.169.254/", "http://169.254.169.254/latest")
+
+
+def test_playwright_login_blocks_cross_origin_redirect_before_loading_form() -> None:
+    class Attacker(_RedirectHandler):
+        hits = []
+
+    class Origin(_RedirectHandler):
+        hits = []
+
+    with _server(Attacker) as attacker_url:
+        Origin.redirect_to = f"{attacker_url}/steal"
+        with _server(Origin) as origin_url:
+            gateway = SyncPlaywrightGateway()
+            config = PlaywrightLoginConfig.model_validate(
+                {
+                    "adapter": "playwright",
+                    "login_url": "/login",
+                    "validate_url": "/",
+                    "auto_detect_selectors": True,
+                }
+            )
+            with pytest.raises(TargetPolicyError):
+                gateway.login(config, _target(origin_url), "user", "do-not-forward")
+
+    assert Attacker.hits == []
+
+
+def test_authenticated_inventory_blocks_cross_origin_redirect_before_request() -> None:
+    class Attacker(_RedirectHandler):
+        hits = []
+
+    class Origin(_RedirectHandler):
+        hits = []
+
+    with _server(Attacker) as attacker_url:
+        Origin.redirect_to = f"{attacker_url}/outside"
+        with _server(Origin) as origin_url:
+            gateway = SyncPlaywrightInventoryGateway()
+            with pytest.raises(TargetPolicyError):
+                gateway.collect(
+                    _target(origin_url),
+                    f"{origin_url}/",
+                    InventoryBuildControls(max_pages=1),
+                    SessionType.PLAYWRIGHT_STORAGE_STATE,
+                    {"storage_state": {"cookies": [], "origins": []}},
+                )
+
+    assert Attacker.hits == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ runner = CliRunner()
 def test_version_command() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
-    assert "Garden 0.2.0" in result.stdout
+    assert "Garden 0.3.0" in result.stdout
 
 
 def test_healthcheck_command() -> None:

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,3 +1,5 @@
+import stat
+
 from app.core.settings import clear_settings_cache, get_settings
 
 
@@ -29,6 +31,17 @@ def test_formal_runtime_paths_use_garden_home(monkeypatch, tmp_path):
     assert paths.reports_dir == home / "reports"
     assert paths.logs_dir == home / "logs"
     assert paths.runtime_dir == home / "runtime"
+
+
+def test_formal_runtime_creates_private_temporary_secret_directory(tmp_path):
+    from app.cli.paths import GardenPaths
+
+    paths = GardenPaths(tmp_path / "garden-home")
+
+    paths.ensure_directories()
+
+    assert paths.secrets_dir.is_dir()
+    assert stat.S_IMODE(paths.secrets_dir.stat().st_mode) == 0o700
 
 
 def test_formal_runtime_reads_home_config_not_working_directory_dotenv(monkeypatch, tmp_path):

--- a/tests/test_context_collection.py
+++ b/tests/test_context_collection.py
@@ -338,6 +338,34 @@ def test_default_gateway_preserves_authenticated_request_only_in_observation() -
     assert controls.retry_attempts == 2
 
 
+def test_authenticated_endpoint_signature_uses_body_beyond_the_display_preview() -> None:
+    full_response = '{"prefix":"' + ("x" * 950) + '","tail":"role-specific"}'
+
+    class LongResponseInventoryService(FakeInventoryService):
+        def collect(self, target, auth_session, controls, **kwargs):
+            result = super().collect(target, auth_session, controls, **kwargs)
+            result.endpoints[0].response_preview = full_response[:900]
+            result.endpoints[0].response_text = full_response
+            return result
+
+    gateway = DefaultContextCollectionGateway(
+        http_gateway=FakeHttpGateway(),
+        inventory_service=LongResponseInventoryService(),
+    )
+    run = SimpleNamespace(
+        target=SimpleNamespace(base_url="https://app.example/"),
+        normalized_url="https://app.example/assessment-entry",
+        options=ScanOptions().model_dump(),
+    )
+    context = SimpleNamespace(kind="user", auth_session=SimpleNamespace(id=12))
+
+    resources, requests = gateway.collect(run, context)
+
+    endpoint = next(resource for resource in resources if resource.asset_type == "endpoint")
+    assert endpoint.attributes["response_text"] == full_response
+    assert requests[0].response_text == full_response
+
+
 def test_pipeline_continues_other_contexts_after_one_collection_failure(db_session) -> None:
     run = make_authenticated_run(db_session)
     for context in run.contexts:

--- a/tests/test_context_collection.py
+++ b/tests/test_context_collection.py
@@ -132,8 +132,16 @@ class FakeInventoryService:
     def __init__(self) -> None:
         self.calls = []
 
-    def collect(self, target, auth_session, controls):
-        self.calls.append((target, auth_session, controls))
+    def collect(
+        self,
+        target,
+        auth_session,
+        controls,
+        *,
+        start_url=None,
+        before_request=None,
+    ):
+        self.calls.append((target, auth_session, controls, start_url, before_request))
         return InventoryCollectionResult(
             start_url=target.base_url,
             pages=[
@@ -173,7 +181,7 @@ class FailingOneContextCollectionService:
     def __init__(self) -> None:
         self.kinds: list[str] = []
 
-    def collect(self, session, run, context):
+    def collect(self, session, run, context, *, before_request=None):
         self.kinds.append(context.kind)
         if context.kind == "user":
             raise RuntimeError("raw-user-collection-secret")
@@ -305,7 +313,14 @@ def test_default_gateway_preserves_authenticated_request_only_in_observation() -
     auth_session = SimpleNamespace(id=11)
     run = SimpleNamespace(
         target=target,
-        options=ScanOptions(max_pages=3, max_depth=2).model_dump(),
+        normalized_url="https://app.example/assessment-entry",
+        options=ScanOptions(
+            max_pages=3,
+            max_resources=7,
+            max_depth=2,
+            request_timeout_seconds=4,
+            retry_attempts=2,
+        ).model_dump(),
     )
     context = SimpleNamespace(kind="admin", auth_session=auth_session)
 
@@ -317,7 +332,10 @@ def test_default_gateway_preserves_authenticated_request_only_in_observation() -
     assert requests[0].headers == {"authorization": "Bearer exact-source-token"}
     assert requests[0].response_headers == {"content-type": "application/json"}
     controls = inventory_service.calls[0][2]
-    assert (controls.max_pages, controls.max_depth) == (3, 2)
+    assert inventory_service.calls[0][3] == run.normalized_url
+    assert (controls.max_pages, controls.max_depth, controls.max_requests) == (3, 2, 7)
+    assert controls.request_timeout_seconds == 4
+    assert controls.retry_attempts == 2
 
 
 def test_pipeline_continues_other_contexts_after_one_collection_failure(db_session) -> None:

--- a/tests/test_context_establishment.py
+++ b/tests/test_context_establishment.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import pytest
 from sqlalchemy import select
 
+from app.cli.paths import GardenPaths
 from app.core.errors import InputValidationError
 from app.db.bootstrap import get_session
 from app.models.audit_event import AuditEvent
@@ -17,6 +18,7 @@ from app.models.scan_run import ScanRunStage
 from app.models.target import Target
 from app.schemas.auth import LoginExecutionResult, SessionValidationResult
 from app.services.context_establishment import ContextEstablishmentService
+from app.services.ephemeral_secret_store import EphemeralSecretStore
 from app.services.login_configs import encode_inline_login_config
 from app.services.scan_pipeline import ScanPipeline
 from app.services.session_storage import SessionStorageService
@@ -308,6 +310,110 @@ def test_establish_updates_existing_contexts_and_writes_redacted_audit(db_sessio
     assert "cookie" not in serialized
     assert "authorization" not in serialized
     assert "payload" not in serialized
+
+
+def test_establish_consumes_temporary_profile_secrets(db_session, profiles, tmp_path):
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    refs = []
+    for profile_id in (profiles.user_id, profiles.admin_id):
+        profile = db_session.get(CredentialProfile, profile_id)
+        profile.secret_ref = store.write(f"secret-{profile.role}")
+        refs.append(profile.secret_ref)
+    run = make_profile_run(db_session, profiles)
+
+    ContextEstablishmentService(
+        auth_service=SuccessfulAuthService(),
+        ephemeral_store=store,
+    ).establish(db_session, run)
+
+    assert all(not store.path_for(ref).exists() for ref in refs)
+
+
+def test_failed_establishment_still_consumes_temporary_profile_secrets(
+    db_session, profiles, tmp_path
+):
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    refs = []
+    for profile_id in (profiles.user_id, profiles.admin_id):
+        profile = db_session.get(CredentialProfile, profile_id)
+        profile.secret_ref = store.write(f"secret-{profile.role}")
+        refs.append(profile.secret_ref)
+    run = make_profile_run(db_session, profiles)
+
+    ContextEstablishmentService(
+        auth_service=FailingAuthService(profiles.user_id),
+        ephemeral_store=store,
+    ).establish(db_session, run)
+
+    assert all(not store.path_for(ref).exists() for ref in refs)
+
+
+def test_invalid_authenticated_context_still_consumes_temporary_secrets(
+    db_session, profiles, tmp_path
+):
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    refs = []
+    for profile_id in (profiles.user_id, profiles.wrong_role_id):
+        profile = db_session.get(CredentialProfile, profile_id)
+        profile.secret_ref = store.write(f"secret-{profile.role}")
+        refs.append(profile.secret_ref)
+    run = make_profile_run(db_session, profiles, profiles.wrong_role_id)
+
+    with pytest.raises(InputValidationError, match="admin"):
+        ContextEstablishmentService(
+            auth_service=SuccessfulAuthService(),
+            ephemeral_store=store,
+        ).establish(db_session, run)
+
+    assert all(not store.path_for(ref).exists() for ref in refs)
+
+
+def test_default_establishment_resolves_temporary_profile_secrets(db_session, profiles, tmp_path):
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    refs = []
+    for profile_id in (profiles.user_id, profiles.admin_id):
+        profile = db_session.get(CredentialProfile, profile_id)
+        profile.secret_ref = store.write("never-audited-secret")
+        refs.append(profile.secret_ref)
+    run = make_profile_run(db_session, profiles)
+    adapter = RecordingHttpAdapter()
+    service = ContextEstablishmentService(ephemeral_store=store)
+    service.auth_service.http_adapter = adapter
+    service.auth_service.storage_service = SessionStorageService(tmp_path / "session-payloads")
+
+    contexts = service.establish(db_session, run)
+
+    assert context_by_kind(contexts, "user").status == "ready"
+    assert context_by_kind(contexts, "admin").status == "ready"
+    assert adapter.login_count == 2
+    assert all(not store.path_for(ref).exists() for ref in refs)
+
+
+def test_formal_runtime_default_establishment_uses_private_secret_root(
+    db_session, profiles, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("GARDEN_HOME", str(tmp_path / "garden-home"))
+    monkeypatch.setenv("GARDEN_CLI_RUNTIME", "1")
+    paths = GardenPaths.from_environment()
+    paths.ensure_directories()
+    store = EphemeralSecretStore(paths.secrets_dir)
+    refs = []
+    for profile_id in (profiles.user_id, profiles.admin_id):
+        profile = db_session.get(CredentialProfile, profile_id)
+        profile.secret_ref = store.write("never-audited-secret")
+        refs.append(profile.secret_ref)
+    run = make_profile_run(db_session, profiles)
+    adapter = RecordingHttpAdapter()
+    service = ContextEstablishmentService()
+    service.auth_service.http_adapter = adapter
+    service.auth_service.storage_service = SessionStorageService(tmp_path / "session-payloads")
+
+    contexts = service.establish(db_session, run)
+
+    assert context_by_kind(contexts, "user").status == "ready"
+    assert context_by_kind(contexts, "admin").status == "ready"
+    assert adapter.login_count == 2
+    assert all(not store.path_for(ref).exists() for ref in refs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_context_establishment.py
+++ b/tests/test_context_establishment.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import select
 
 from app.cli.paths import GardenPaths
-from app.core.errors import InputValidationError
+from app.core.errors import InputValidationError, OverallScanTimeout
 from app.db.bootstrap import get_session
 from app.models.audit_event import AuditEvent
 from app.models.auth_session import AuthSession
@@ -129,6 +129,11 @@ class FailingAuthService(SuccessfulAuthService):
         if profile_id in self.failing_profile_ids:
             raise InputValidationError("login rejected")
         return super().ensure_valid_for_profile(session, profile_id)
+
+
+class TimingOutAuthService:
+    def ensure_valid_for_profile(self, session, profile_id, *, before_request=None):
+        raise OverallScanTimeout("assessment deadline reached")
 
 
 class RecordingHttpAdapter:
@@ -272,6 +277,17 @@ def test_run_url_must_share_target_origin(db_session, profiles):
 
     with pytest.raises(InputValidationError, match="同源"):
         ContextEstablishmentService(auth_service=SuccessfulAuthService()).establish(db_session, run)
+
+
+def test_establishment_propagates_overall_timeout_control_flow(db_session, profiles) -> None:
+    run = make_profile_run(db_session, profiles)
+
+    with pytest.raises(OverallScanTimeout, match="deadline"):
+        ContextEstablishmentService(auth_service=TimingOutAuthService()).establish(db_session, run)
+
+    user = context_by_kind(list(run.contexts), "user")
+    assert user.status == "pending"
+    assert user.error_code is None
 
 
 def test_establish_updates_existing_contexts_and_writes_redacted_audit(db_session, profiles):

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 import app.cli.coverage as coverage_cli
 import app.cli.scan as scan_cli
 from app.cli.main import app
+from app.cli.web_runtime import WebRuntimeError
 from app.schemas.assessment import (
     AssessmentRunView,
     CoverageDifferenceView,
@@ -137,6 +138,43 @@ def test_coverage_command_refuses_to_prompt_without_an_interactive_terminal(
     assert "--non-interactive" in result.stdout
 
 
+def test_coverage_command_cleans_wizard_secrets_when_runtime_fails_before_submit(
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+
+    class Wizard:
+        def __init__(self, *, prompts):
+            pass
+
+        def run(self, url):
+            return PassiveCoverageStartRequest(
+                url=url,
+                target_id=4,
+                user_profile_id=12,
+                admin_profile_id=13,
+            )
+
+        def cleanup_unsubmitted_secrets(self):
+            calls.append("cleanup")
+
+    class Manager:
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            raise WebRuntimeError("runtime failed")
+
+    monkeypatch.setattr(coverage_cli, "CoverageSetupWizard", Wizard)
+    monkeypatch.setattr(coverage_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(coverage_cli, "_is_interactive_terminal", lambda: True, raising=False)
+
+    result = runner.invoke(app, ["coverage", "http://127.0.0.1:8080/"])
+
+    assert result.exit_code == 1
+    assert calls == ["cleanup"]
+
+
 def test_noninteractive_coverage_requires_both_profile_ids() -> None:
     result = runner.invoke(
         app,
@@ -198,7 +236,7 @@ def test_noninteractive_coverage_forwards_bounded_options_and_source_run(
             "4",
             "--overall-timeout",
             "80",
-            "--retry-attempts",
+            "--retries",
             "2",
             "--detach",
         ],
@@ -217,6 +255,41 @@ def test_noninteractive_coverage_forwards_bounded_options_and_source_run(
         "max_redirects": 5,
         "user_agent": "Garden-Authorized-Asset-Scanner/0.2",
     }
+
+
+def test_coverage_help_reuses_quick_retries_option_name() -> None:
+    result = runner.invoke(app, ["coverage", "--help"])
+
+    assert result.exit_code == 0
+    assert "--retries" in result.stdout
+    assert "--retry-attempts" not in result.stdout
+
+
+def test_waiting_coverage_renders_context_health_changes(monkeypatch, capsys) -> None:
+    initial = _assessment_view(status="queued", stage="establish_contexts", progress=18)
+    user_ready = _assessment_view(status="running", stage="collect", progress=30)
+    user_context = next(context for context in user_ready.contexts if context.kind.value == "user")
+    user_context.status = "ready"
+    user_context.login_status = "succeeded"
+    user_context.session_validation_status = "valid"
+    completed = _assessment_view(status="completed", stage="finished", progress=100)
+
+    class Api:
+        def __init__(self) -> None:
+            self.results = [user_ready, completed]
+
+        def get_assessment(self, assessment_id):
+            return self.results.pop(0)
+
+    monkeypatch.setattr(coverage_cli.time, "sleep", lambda _seconds: None)
+
+    result = coverage_cli._wait_for_assessment(Api(), initial)
+
+    output = capsys.readouterr().out
+    assert result.status == "completed"
+    assert "登录=succeeded" in output
+    assert "验证=valid" in output
+    assert "采集=pending" in output
 
 
 def test_quick_scan_never_invokes_coverage_wizard(monkeypatch) -> None:

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+import app.cli.coverage as coverage_cli
+import app.cli.scan as scan_cli
+from app.cli.main import app
+from app.schemas.assessment import (
+    AssessmentRunView,
+    CoverageDifferenceView,
+    PassiveCoverageStartRequest,
+)
+from app.schemas.scan import ScanContextView, ScanRunView
+
+runner = CliRunner()
+
+
+def _assessment_view(*, status="queued", stage="queued", progress=0):
+    return AssessmentRunView(
+        id=51,
+        mode="authenticated_coverage",
+        input_url="http://127.0.0.1:8080/",
+        normalized_url="http://127.0.0.1:8080/",
+        status=status,
+        current_stage=stage,
+        progress=progress,
+        retry_count=0,
+        report_path=("exports/scan-reports/assessment-51.md" if status == "completed" else None),
+        created_at=datetime.now(timezone.utc),
+        completeness="complete" if status == "completed" else "pending",
+        active_checks_enabled=False,
+        contexts=[
+            ScanContextView(
+                id=index,
+                kind=kind,
+                status="completed" if status == "completed" else "pending",
+                collection_status="completed" if status == "completed" else "pending",
+                completeness="complete" if status == "completed" else "pending",
+            )
+            for index, kind in enumerate(("anonymous", "user", "admin"), start=1)
+        ],
+        difference_count=2 if status == "completed" else 0,
+    )
+
+
+def test_coverage_command_invokes_guided_wizard_and_renders_contexts(monkeypatch) -> None:
+    calls = []
+
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class Manager:
+        started_by_this_command = False
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            assert ui_port is None
+            return Runtime()
+
+    class Wizard:
+        def __init__(self, *, prompts):
+            calls.append("wizard-created")
+
+        def run(self, url):
+            calls.append(("wizard-run", url))
+            return PassiveCoverageStartRequest(
+                url=url,
+                target_id=4,
+                user_profile_id=12,
+                admin_profile_id=13,
+            )
+
+    class Api:
+        def __init__(self, base_url):
+            assert base_url == Runtime.base_url
+
+        def start_assessment(self, request):
+            calls.append(("start", request.user_profile_id, request.admin_profile_id))
+            return _assessment_view()
+
+        def get_assessment(self, assessment_id):
+            assert assessment_id == 51
+            return _assessment_view(status="completed", stage="finished", progress=100)
+
+        def list_coverage_differences(self, assessment_id):
+            assert assessment_id == 51
+            return [
+                CoverageDifferenceView(
+                    id=1,
+                    identity_key="GET:/account",
+                    classification="user_only",
+                ),
+                CoverageDifferenceView(
+                    id=2,
+                    identity_key="GET:/admin",
+                    classification="admin_only",
+                ),
+            ]
+
+    monkeypatch.setattr(coverage_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(coverage_cli, "CoverageSetupWizard", Wizard)
+    monkeypatch.setattr(coverage_cli, "LocalScanApi", Api)
+
+    result = runner.invoke(app, ["coverage", "http://127.0.0.1:8080/"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        "wizard-created",
+        ("wizard-run", "http://127.0.0.1:8080/"),
+        ("start", 12, 13),
+    ]
+    assert "anonymous" in result.stdout
+    assert "user" in result.stdout
+    assert "admin" in result.stdout
+    assert "user_only" in result.stdout
+    assert "admin_only" in result.stdout
+    assert "exports/scan-reports/assessment-51.md" in result.stdout
+    assert "仅被动" in result.stdout
+
+
+def test_noninteractive_coverage_requires_both_profile_ids() -> None:
+    result = runner.invoke(
+        app,
+        ["coverage", "http://127.0.0.1:8080/", "--non-interactive"],
+    )
+
+    assert result.exit_code == 2
+    assert "--user-profile 和 --admin-profile" in result.stdout
+    assert "选择同源 Target" not in result.stdout
+
+
+def test_quick_scan_never_invokes_coverage_wizard(monkeypatch) -> None:
+    class ExplodingWizard:
+        def __init__(self, **kwargs):
+            raise AssertionError("quick scan must not create the coverage wizard")
+
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class Manager:
+        started_by_this_command = False
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            return Runtime()
+
+    class Api:
+        def __init__(self, base_url):
+            pass
+
+        def start_scan(self, url, options):
+            return ScanRunView(
+                id=77,
+                input_url=url,
+                normalized_url=url,
+                status="queued",
+                current_stage="queued",
+                progress=0,
+                retry_count=0,
+                created_at=datetime.now(timezone.utc),
+            )
+
+    monkeypatch.setattr(coverage_cli, "CoverageSetupWizard", ExplodingWizard)
+    monkeypatch.setattr(scan_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(scan_cli, "LocalScanApi", Api)
+
+    result = runner.invoke(
+        app,
+        ["scan", "http://127.0.0.1:8080/", "--detach"],
+    )
+
+    assert result.exit_code == 0
+    assert "已后台提交" in result.stdout
+
+
+def test_terminal_secret_prompt_uses_hidden_input(monkeypatch) -> None:
+    captured = {}
+
+    def prompt(label, **kwargs):
+        captured.update({"label": label, **kwargs})
+        return "hidden-value"
+
+    monkeypatch.setattr(coverage_cli.typer, "prompt", prompt)
+
+    value = coverage_cli.TyperCoveragePrompts().secret("user 密码（输入已隐藏）")
+
+    assert value == "hidden-value"
+    assert captured == {"label": "user 密码（输入已隐藏）", "hide_input": True}

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -102,6 +102,7 @@ def test_coverage_command_invokes_guided_wizard_and_renders_contexts(monkeypatch
     monkeypatch.setattr(coverage_cli, "WebRuntimeManager", Manager)
     monkeypatch.setattr(coverage_cli, "CoverageSetupWizard", Wizard)
     monkeypatch.setattr(coverage_cli, "LocalScanApi", Api)
+    monkeypatch.setattr(coverage_cli, "_is_interactive_terminal", lambda: True, raising=False)
 
     result = runner.invoke(app, ["coverage", "http://127.0.0.1:8080/"])
 
@@ -120,6 +121,22 @@ def test_coverage_command_invokes_guided_wizard_and_renders_contexts(monkeypatch
     assert "仅被动" in result.stdout
 
 
+def test_coverage_command_refuses_to_prompt_without_an_interactive_terminal(
+    monkeypatch,
+) -> None:
+    class ExplodingWizard:
+        def __init__(self, **kwargs):
+            raise AssertionError("non-TTY coverage must not prompt")
+
+    monkeypatch.setattr(coverage_cli, "CoverageSetupWizard", ExplodingWizard)
+    monkeypatch.setattr(coverage_cli, "_is_interactive_terminal", lambda: False, raising=False)
+
+    result = runner.invoke(app, ["coverage", "http://127.0.0.1:8080/"])
+
+    assert result.exit_code == 2
+    assert "--non-interactive" in result.stdout
+
+
 def test_noninteractive_coverage_requires_both_profile_ids() -> None:
     result = runner.invoke(
         app,
@@ -129,6 +146,77 @@ def test_noninteractive_coverage_requires_both_profile_ids() -> None:
     assert result.exit_code == 2
     assert "--user-profile 和 --admin-profile" in result.stdout
     assert "选择同源 Target" not in result.stdout
+
+
+def test_noninteractive_coverage_forwards_bounded_options_and_source_run(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    class Runtime:
+        base_url = "http://127.0.0.1:8000"
+
+    class Manager:
+        started_by_this_command = False
+
+        def __init__(self, **kwargs):
+            pass
+
+        def ensure(self, *, ui_port):
+            return Runtime()
+
+    class Api:
+        def __init__(self, base_url):
+            pass
+
+        def start_assessment(self, request):
+            captured["request"] = request
+            return _assessment_view()
+
+    monkeypatch.setattr(coverage_cli, "WebRuntimeManager", Manager)
+    monkeypatch.setattr(coverage_cli, "LocalScanApi", Api)
+
+    result = runner.invoke(
+        app,
+        [
+            "coverage",
+            "http://127.0.0.1:8080/",
+            "--non-interactive",
+            "--user-profile",
+            "12",
+            "--admin-profile",
+            "13",
+            "--source-run",
+            "7",
+            "--max-pages",
+            "9",
+            "--max-resources",
+            "17",
+            "--max-depth",
+            "3",
+            "--request-timeout",
+            "4",
+            "--overall-timeout",
+            "80",
+            "--retry-attempts",
+            "2",
+            "--detach",
+        ],
+    )
+
+    assert result.exit_code == 0
+    request = captured["request"]
+    assert request.source_run_id == 7
+    assert request.options.model_dump() == {
+        "max_pages": 9,
+        "max_resources": 17,
+        "max_depth": 3,
+        "request_timeout_seconds": 4.0,
+        "overall_timeout_seconds": 80.0,
+        "retry_attempts": 2,
+        "max_redirects": 5,
+        "user_agent": "Garden-Authorized-Asset-Scanner/0.2",
+    }
 
 
 def test_quick_scan_never_invokes_coverage_wizard(monkeypatch) -> None:

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+from click import unstyle
 from typer.testing import CliRunner
 
 import app.cli.coverage as coverage_cli
@@ -259,10 +260,11 @@ def test_noninteractive_coverage_forwards_bounded_options_and_source_run(
 
 def test_coverage_help_reuses_quick_retries_option_name() -> None:
     result = runner.invoke(app, ["coverage", "--help"])
+    help_text = unstyle(result.stdout)
 
     assert result.exit_code == 0
-    assert "--retries" in result.stdout
-    assert "--retry-attempts" not in result.stdout
+    assert "--retries" in help_text
+    assert "--retry-attempts" not in help_text
 
 
 def test_waiting_coverage_renders_context_health_changes(monkeypatch, capsys) -> None:

--- a/tests/test_coverage_comparison.py
+++ b/tests/test_coverage_comparison.py
@@ -1,0 +1,220 @@
+import pytest
+from sqlalchemy import func, select
+
+from app.db.bootstrap import get_session
+from app.models.coverage_difference import CoverageDifference
+from app.services.coverage_comparison import CoverageComparisonService
+from tests.helpers.assessment import add_asset, make_authenticated_run
+
+
+@pytest.fixture
+def db_session():
+    with get_session() as session:
+        yield session
+        session.rollback()
+
+
+def _complete_contexts(run) -> dict[str, object]:
+    contexts = {context.kind: context for context in run.contexts}
+    for context in contexts.values():
+        context.status = "completed"
+        context.collection_status = "completed"
+        context.completeness = "complete"
+    return contexts
+
+
+def test_complete_contexts_classify_admin_only(db_session) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    add_asset(
+        db_session,
+        run,
+        context_id=contexts["admin"].id,
+        identity_key="GET:/admin",
+        url="http://127.0.0.1:8000/admin",
+        status_code=200,
+        title="Admin",
+        attributes={
+            "content_type": "text/html",
+            "content_signature": "stable-admin-signature",
+        },
+    )
+
+    summary = CoverageComparisonService().compare(db_session, run)
+
+    assert summary.counts == {"admin_only": 1}
+    item = summary.differences[0]
+    assert item.identity_key == "GET:/admin"
+    assert item.classification == "admin_only"
+    assert (item.anonymous_state, item.user_state, item.admin_state) == (
+        "absent",
+        "absent",
+        "present",
+    )
+    assert (item.anonymous_present, item.user_present, item.admin_present) == (
+        False,
+        False,
+        True,
+    )
+
+
+def test_failed_user_context_is_unknown_not_absent(db_session) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    contexts["user"].status = "failed"
+    contexts["user"].collection_status = "failed"
+    contexts["user"].completeness = "incomplete"
+    add_asset(
+        db_session,
+        run,
+        context_id=contexts["admin"].id,
+        identity_key="GET:/admin",
+        url="http://127.0.0.1:8000/admin",
+    )
+
+    item = CoverageComparisonService().compare(db_session, run).differences[0]
+
+    assert item.user_state == "unknown"
+    assert item.user_present is None
+    assert item.classification == "unknown"
+    assert item.confidence == "low"
+
+
+@pytest.mark.parametrize(
+    ("present_kinds", "expected"),
+    [
+        (("anonymous", "user", "admin"), "shared"),
+        (("user", "admin"), "user_only"),
+        (("user",), "inconsistent"),
+        (("anonymous",), "unexpectedly_anonymous"),
+        (("anonymous", "user"), "unexpectedly_anonymous"),
+        (("anonymous", "admin"), "unexpectedly_anonymous"),
+    ],
+)
+def test_complete_context_presence_classification_table(
+    db_session,
+    present_kinds: tuple[str, ...],
+    expected: str,
+) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    for kind in present_kinds:
+        add_asset(
+            db_session,
+            run,
+            context_id=contexts[kind].id,
+            identity_key="GET:/matrix",
+            url="http://127.0.0.1:8000/matrix",
+            status_code=200,
+            title="Matrix",
+            attributes={
+                "content_type": "text/html",
+                "content_signature": "same-signature",
+            },
+        )
+
+    item = CoverageComparisonService().compare(db_session, run).differences[0]
+
+    assert item.classification == expected
+    assert item.confidence == "high"
+
+
+def test_incomplete_context_keeps_observed_presence_but_unknown_for_missing_assets(
+    db_session,
+) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    contexts["user"].status = "failed"
+    contexts["user"].collection_status = "failed"
+    contexts["user"].completeness = "incomplete"
+    for kind in ("user", "admin"):
+        add_asset(
+            db_session,
+            run,
+            context_id=contexts[kind].id,
+            identity_key="GET:/partially-seen",
+        )
+
+    item = CoverageComparisonService().compare(db_session, run).differences[0]
+
+    assert (item.anonymous_state, item.user_state, item.admin_state) == (
+        "absent",
+        "present",
+        "present",
+    )
+    assert item.classification == "user_only"
+
+
+def test_all_present_with_different_stable_response_is_medium_inconsistent(db_session) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    for kind, signature in (
+        ("anonymous", "public"),
+        ("user", "user"),
+        ("admin", "admin"),
+    ):
+        add_asset(
+            db_session,
+            run,
+            context_id=contexts[kind].id,
+            identity_key="GET:/profile",
+            url="http://127.0.0.1:8000/profile",
+            status_code=200,
+            title="Profile",
+            attributes={
+                "content_type": "application/json",
+                "content_signature": signature,
+            },
+        )
+
+    item = CoverageComparisonService().compare(db_session, run).differences[0]
+
+    assert item.classification == "inconsistent"
+    assert item.confidence == "medium"
+
+
+def test_compare_is_idempotent_and_context_summaries_are_allowlisted(db_session) -> None:
+    run = make_authenticated_run(db_session)
+    contexts = _complete_contexts(run)
+    forbidden_values = {
+        "authorization": "Bearer raw-secret",
+        "cookie": "session=raw-secret",
+        "response_text": "raw private response",
+        "protected_storage_ref": "vault://private/payload",
+    }
+    add_asset(
+        db_session,
+        run,
+        context_id=contexts["admin"].id,
+        identity_key="GET:/items?id&token",
+        url="http://127.0.0.1:8000/items?id=7&token=raw-query-secret#private",
+        status_code=200,
+        title="Items",
+        attributes={
+            "content_type": "application/json",
+            "content_signature": "safe-signature",
+            **forbidden_values,
+        },
+    )
+
+    first = CoverageComparisonService().compare(db_session, run)
+    second = CoverageComparisonService().compare(db_session, run)
+
+    row_count = db_session.scalar(
+        select(func.count(CoverageDifference.id)).where(CoverageDifference.scan_run_id == run.id)
+    )
+    assert row_count == 1
+    assert len(first.differences) == len(second.differences) == 1
+    summary = second.differences[0].context_summaries["admin"]
+    assert set(summary) == {
+        "asset_id",
+        "status_code",
+        "url",
+        "title",
+        "content_type",
+        "content_signature",
+    }
+    assert summary["url"] == ("http://127.0.0.1:8000/items?id=[REDACTED]&token=[REDACTED]")
+    rendered = str(summary)
+    assert "raw-query-secret" not in rendered
+    assert all(value not in rendered for value in forbidden_values.values())

--- a/tests/test_coverage_wizard.py
+++ b/tests/test_coverage_wizard.py
@@ -244,6 +244,27 @@ def test_wizard_rejects_a_selected_profile_with_invalid_login_config() -> None:
     assert prompts.hidden_values == []
 
 
+def test_wizard_rejects_cross_origin_urls_in_a_selected_login_config() -> None:
+    setup = _setup_records()
+    cross_origin_config = encode_inline_login_config(
+        {
+            "adapter": "playwright",
+            "login_url": "https://outside.example/login",
+            "validate_url": "/me",
+            "auto_detect_selectors": True,
+        }
+    )
+    with session_scope() as session:
+        session.get(CredentialProfile, setup.user_id).login_config_path = cross_origin_config
+        session.commit()
+    prompts = ScriptedPrompts([str(setup.target_id), str(setup.user_id)])
+
+    with pytest.raises(InputValidationError, match="同源"):
+        CoverageSetupWizard(prompts=prompts).run(setup.url)
+
+    assert prompts.hidden_values == []
+
+
 def test_wizard_creates_same_origin_target_and_missing_profiles_without_exposing_secrets(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_coverage_wizard.py
+++ b/tests/test_coverage_wizard.py
@@ -1,0 +1,277 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from app.cli.coverage_wizard import CoverageSetupWizard
+from app.core.errors import ConflictError, InputValidationError
+from app.db.bootstrap import session_scope
+from app.models.credential_profile import CredentialProfile
+from app.models.enums import AuthType, TargetType
+from app.models.target import Target
+from app.schemas.credential import CredentialProfileCreate
+from app.schemas.target import TargetCreate
+from app.services.credentials import CredentialProfileService
+from app.services.ephemeral_secret_store import EphemeralSecretStore
+from app.services.login_configs import LoginConfigService, encode_inline_login_config
+from app.services.targets import TargetService
+
+
+class ScriptedPrompts:
+    def __init__(self, answers: list[str]) -> None:
+        self.answers = list(answers)
+        self.hidden_values: list[str] = []
+        self.rendered_text = ""
+        self.offered: dict[str, tuple[str, ...]] = {}
+
+    def choose(self, label: str, choices) -> str:
+        values = tuple(choice.value for choice in choices)
+        self.offered[label] = values
+        answer = self.answers.pop(0)
+        assert answer in values
+        return answer
+
+    def confirm(self, label: str, *, default: bool = True) -> bool:
+        answer = self.answers.pop(0).lower()
+        return answer in {"yes", "y", "是"}
+
+    def text(self, label: str, *, default: str | None = None) -> str:
+        answer = self.answers.pop(0)
+        return answer or default or ""
+
+    def secret(self, label: str) -> str:
+        answer = self.answers.pop(0)
+        self.hidden_values.append(answer)
+        return answer
+
+    def write(self, text: str) -> None:
+        self.rendered_text += text
+
+
+@dataclass(frozen=True)
+class SetupRecords:
+    url: str
+    target_id: int
+    user_id: int
+    admin_id: int
+    wrong_role_id: int
+
+
+def _create_profile(session, target_id: int, *, name: str, role: str):
+    login_config = encode_inline_login_config(
+        {
+            "adapter": "http",
+            "login_request": {"method": "POST", "url": "/login"},
+            "validate_request": {"method": "GET", "url": "/me"},
+        }
+    )
+    return CredentialProfileService().create(
+        session,
+        CredentialProfileCreate(
+            target_id=target_id,
+            name=name,
+            role=role,
+            auth_type=AuthType.PASSWORD,
+            username=f"{name}@example.test",
+            secret_ref=f"env://{name.upper().replace('-', '_')}_SECRET",
+            login_config_path=login_config,
+        ),
+    )
+
+
+def _setup_records() -> SetupRecords:
+    with session_scope() as session:
+        target = TargetService().create(
+            session,
+            TargetCreate(
+                name="coverage-app",
+                base_url="http://127.0.0.1:8181/app",
+                type=TargetType.WEB,
+                owner="appsec",
+            ),
+        )
+        other = TargetService().create(
+            session,
+            TargetCreate(
+                name="other-app",
+                base_url="http://127.0.0.1:8282/app",
+                type=TargetType.WEB,
+                owner="appsec",
+            ),
+        )
+        user = _create_profile(session, target.id, name="coverage-user", role="user")
+        admin = _create_profile(session, target.id, name="coverage-admin", role="admin")
+        wrong_role = _create_profile(session, target.id, name="coverage-auditor", role="auditor")
+        _create_profile(session, other.id, name="other-user", role="user")
+        return SetupRecords(
+            url="http://127.0.0.1:8181/start",
+            target_id=target.id,
+            user_id=user.id,
+            admin_id=admin.id,
+            wrong_role_id=wrong_role.id,
+        )
+
+
+def test_wizard_selects_same_origin_target_and_exact_roles() -> None:
+    setup = _setup_records()
+    prompts = ScriptedPrompts(
+        [str(setup.target_id), str(setup.user_id), str(setup.admin_id), "yes"]
+    )
+
+    request = CoverageSetupWizard(prompts=prompts).run(setup.url)
+
+    assert request.target_id == setup.target_id
+    assert request.user_profile_id == setup.user_id
+    assert request.admin_profile_id == setup.admin_id
+    assert request.active_checks_enabled is False
+    assert prompts.hidden_values == []
+    assert prompts.offered["选择同源 Target"] == (str(setup.target_id),)
+    assert prompts.offered["选择 user 凭据档案"] == (str(setup.user_id),)
+    assert prompts.offered["选择 admin 凭据档案"] == (str(setup.admin_id),)
+
+
+def test_wizard_creates_same_origin_target_and_missing_profiles_without_exposing_secrets(
+    tmp_path: Path,
+) -> None:
+    user_secret = "user-entered-password"
+    admin_secret = "admin-entered-password"
+    prompts = ScriptedPrompts(
+        [
+            "yes",
+            "coverage-app",
+            "appsec",
+            "yes",
+            "coverage-user",
+            "/login",
+            "/account",
+            "reader@example.test",
+            user_secret,
+            "yes",
+            "coverage-admin",
+            "/login",
+            "/admin",
+            "admin@example.test",
+            admin_secret,
+            "yes",
+        ]
+    )
+    secret_store = EphemeralSecretStore(tmp_path / "secrets")
+
+    request = CoverageSetupWizard(
+        prompts=prompts,
+        secret_store=secret_store,
+    ).run("http://127.0.0.1:8181/start")
+
+    with session_scope() as session:
+        created_user = session.get(CredentialProfile, request.user_profile_id)
+        created_admin = session.get(CredentialProfile, request.admin_profile_id)
+        assert created_user is not None
+        assert created_admin is not None
+        assert created_user.target_id == request.target_id == created_admin.target_id
+        assert (created_user.role, created_admin.role) == ("user", "admin")
+        assert created_user.secret_ref.startswith("ephemeral-file://")
+        assert created_admin.secret_ref.startswith("ephemeral-file://")
+        user_login_config = LoginConfigService().load(created_user.login_config_path)
+        admin_login_config = LoginConfigService().load(created_admin.login_config_path)
+        serialized = json.dumps(
+            {"user": created_user.__dict__, "admin": created_admin.__dict__},
+            default=str,
+        )
+
+    assert prompts.hidden_values == [user_secret, admin_secret]
+    assert secret_store.read(created_user.secret_ref) == user_secret
+    assert secret_store.read(created_admin.secret_ref) == admin_secret
+    assert user_login_config.adapter == admin_login_config.adapter == "playwright"
+    assert user_login_config.auto_detect_selectors is True
+    assert admin_login_config.auto_detect_selectors is True
+    assert user_secret not in serialized
+    assert admin_secret not in serialized
+    assert user_secret not in prompts.rendered_text
+    assert admin_secret not in prompts.rendered_text
+
+
+def test_wizard_cancellation_rolls_back_draft_and_deletes_temporary_secrets(
+    tmp_path: Path,
+) -> None:
+    prompts = ScriptedPrompts(
+        [
+            "yes",
+            "cancelled-target",
+            "appsec",
+            "yes",
+            "cancelled-user",
+            "/login",
+            "/account",
+            "reader@example.test",
+            "temporary-user-secret",
+            "yes",
+            "cancelled-admin",
+            "/login",
+            "/admin",
+            "admin@example.test",
+            "temporary-admin-secret",
+            "no",
+        ]
+    )
+    secret_store = EphemeralSecretStore(tmp_path / "secrets")
+
+    with pytest.raises(InputValidationError, match="已取消"):
+        CoverageSetupWizard(prompts=prompts, secret_store=secret_store).run(
+            "http://127.0.0.1:8181/start"
+        )
+
+    assert list(secret_store.root.glob("*.secret")) == []
+    with session_scope() as session:
+        assert list(session.scalars(select(Target))) == []
+        assert list(session.scalars(select(CredentialProfile))) == []
+
+
+def test_wizard_profile_creation_failure_rolls_back_and_deletes_all_draft_secrets(
+    tmp_path: Path,
+) -> None:
+    with session_scope() as session:
+        target = TargetService().create(
+            session,
+            TargetCreate(
+                name="coverage-app",
+                base_url="http://127.0.0.1:8181",
+                type=TargetType.WEB,
+                owner="appsec",
+            ),
+        )
+        existing = _create_profile(session, target.id, name="collision", role="auditor")
+        target_id = target.id
+        existing_id = existing.id
+
+    prompts = ScriptedPrompts(
+        [
+            str(target_id),
+            "yes",
+            "draft-user",
+            "/login",
+            "/account",
+            "reader@example.test",
+            "temporary-user-secret",
+            "yes",
+            "collision",
+            "/login",
+            "/admin",
+            "admin@example.test",
+            "temporary-admin-secret",
+        ]
+    )
+    secret_store = EphemeralSecretStore(tmp_path / "secrets")
+
+    with pytest.raises(ConflictError, match="already exists"):
+        CoverageSetupWizard(prompts=prompts, secret_store=secret_store).run(
+            "http://127.0.0.1:8181/start"
+        )
+
+    assert list(secret_store.root.glob("*.secret")) == []
+    with session_scope() as session:
+        profiles = list(session.scalars(select(CredentialProfile)))
+        assert [(profile.id, profile.name, profile.role) for profile in profiles] == [
+            (existing_id, "collision", "auditor")
+        ]

--- a/tests/test_coverage_wizard.py
+++ b/tests/test_coverage_wizard.py
@@ -25,10 +25,12 @@ class ScriptedPrompts:
         self.hidden_values: list[str] = []
         self.rendered_text = ""
         self.offered: dict[str, tuple[str, ...]] = {}
+        self.offered_labels: dict[str, tuple[str, ...]] = {}
 
     def choose(self, label: str, choices) -> str:
         values = tuple(choice.value for choice in choices)
         self.offered[label] = values
+        self.offered_labels[label] = tuple(choice.label for choice in choices)
         answer = self.answers.pop(0)
         assert answer in values
         return answer
@@ -128,6 +130,7 @@ def test_wizard_selects_same_origin_target_and_exact_roles() -> None:
     assert request.active_checks_enabled is False
     assert prompts.hidden_values == []
     assert prompts.offered["选择同源 Target"] == (str(setup.target_id),)
+    assert "appsec" in prompts.offered_labels["选择同源 Target"][0]
     assert prompts.offered["选择 user 凭据档案"] == (str(setup.user_id), "__create__")
     assert prompts.offered["选择 admin 凭据档案"] == (str(setup.admin_id), "__create__")
 
@@ -193,6 +196,41 @@ def test_wizard_reprompts_for_an_expired_temporary_profile_secret(
         assert store.read(profile.secret_ref) == "replacement-user-secret"
 
 
+def test_wizard_reuses_a_valid_protected_session_before_reprompting_for_secret(
+    tmp_path: Path,
+) -> None:
+    setup = _setup_records()
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    consumed_reference = store.write("consumed-secret")
+    store.delete(consumed_reference)
+    with session_scope() as session:
+        session.get(CredentialProfile, setup.user_id).secret_ref = consumed_reference
+        session.commit()
+
+    class ReusableSessionService:
+        def __init__(self) -> None:
+            self.profile_ids: list[int] = []
+
+        def ensure_valid_for_profile(self, session, profile_id):
+            self.profile_ids.append(profile_id)
+            return object()
+
+    auth_service = ReusableSessionService()
+    prompts = ScriptedPrompts(
+        [str(setup.target_id), str(setup.user_id), str(setup.admin_id), "yes"]
+    )
+
+    request = CoverageSetupWizard(
+        prompts=prompts,
+        secret_store=store,
+        auth_session_service=auth_service,
+    ).run(setup.url)
+
+    assert request.user_profile_id == setup.user_id
+    assert auth_service.profile_ids == [setup.user_id]
+    assert prompts.hidden_values == []
+
+
 def test_wizard_rejects_a_selected_profile_with_invalid_login_config() -> None:
     setup = _setup_records()
     with session_scope() as session:
@@ -233,10 +271,11 @@ def test_wizard_creates_same_origin_target_and_missing_profiles_without_exposing
     )
     secret_store = EphemeralSecretStore(tmp_path / "secrets")
 
-    request = CoverageSetupWizard(
+    wizard = CoverageSetupWizard(
         prompts=prompts,
         secret_store=secret_store,
-    ).run("http://127.0.0.1:8181/start")
+    )
+    request = wizard.run("http://127.0.0.1:8181/start")
 
     with session_scope() as session:
         created_user = session.get(CredentialProfile, request.user_profile_id)
@@ -265,6 +304,10 @@ def test_wizard_creates_same_origin_target_and_missing_profiles_without_exposing
     assert user_secret not in prompts.rendered_text
     assert admin_secret not in prompts.rendered_text
 
+    wizard.cleanup_unsubmitted_secrets()
+
+    assert list(secret_store.root.glob("*.secret")) == []
+
 
 def test_wizard_cancellation_rolls_back_draft_and_deletes_temporary_secrets(
     tmp_path: Path,
@@ -292,6 +335,46 @@ def test_wizard_cancellation_rolls_back_draft_and_deletes_temporary_secrets(
     secret_store = EphemeralSecretStore(tmp_path / "secrets")
 
     with pytest.raises(InputValidationError, match="已取消"):
+        CoverageSetupWizard(prompts=prompts, secret_store=secret_store).run(
+            "http://127.0.0.1:8181/start"
+        )
+
+    assert list(secret_store.root.glob("*.secret")) == []
+    with session_scope() as session:
+        assert list(session.scalars(select(Target))) == []
+        assert list(session.scalars(select(CredentialProfile))) == []
+
+
+def test_wizard_keyboard_interrupt_rolls_back_and_deletes_draft_secrets(
+    tmp_path: Path,
+) -> None:
+    class InterruptingPrompts(ScriptedPrompts):
+        def secret(self, label: str) -> str:
+            if self.hidden_values:
+                raise KeyboardInterrupt
+            return super().secret(label)
+
+    prompts = InterruptingPrompts(
+        [
+            "yes",
+            "interrupted-target",
+            "appsec",
+            "yes",
+            "interrupted-user",
+            "/login",
+            "/account",
+            "reader@example.test",
+            "temporary-user-secret",
+            "yes",
+            "interrupted-admin",
+            "/login",
+            "/admin",
+            "admin@example.test",
+        ]
+    )
+    secret_store = EphemeralSecretStore(tmp_path / "secrets")
+
+    with pytest.raises(KeyboardInterrupt):
         CoverageSetupWizard(prompts=prompts, secret_store=secret_store).run(
             "http://127.0.0.1:8181/start"
         )

--- a/tests/test_coverage_wizard.py
+++ b/tests/test_coverage_wizard.py
@@ -128,8 +128,82 @@ def test_wizard_selects_same_origin_target_and_exact_roles() -> None:
     assert request.active_checks_enabled is False
     assert prompts.hidden_values == []
     assert prompts.offered["选择同源 Target"] == (str(setup.target_id),)
-    assert prompts.offered["选择 user 凭据档案"] == (str(setup.user_id),)
-    assert prompts.offered["选择 admin 凭据档案"] == (str(setup.admin_id),)
+    assert prompts.offered["选择 user 凭据档案"] == (str(setup.user_id), "__create__")
+    assert prompts.offered["选择 admin 凭据档案"] == (str(setup.admin_id), "__create__")
+
+
+def test_wizard_can_create_a_new_profile_when_existing_profiles_are_available(
+    tmp_path: Path,
+) -> None:
+    setup = _setup_records()
+    prompts = ScriptedPrompts(
+        [
+            str(setup.target_id),
+            "__create__",
+            "alternate-coverage-user",
+            "/login",
+            "/account",
+            "alternate@example.test",
+            "temporary-user-secret",
+            str(setup.admin_id),
+            "yes",
+        ]
+    )
+
+    request = CoverageSetupWizard(
+        prompts=prompts,
+        secret_store=EphemeralSecretStore(tmp_path / "secrets"),
+    ).run(setup.url)
+
+    assert request.user_profile_id != setup.user_id
+    assert request.admin_profile_id == setup.admin_id
+    assert prompts.offered["选择 user 凭据档案"] == (
+        str(setup.user_id),
+        "__create__",
+    )
+
+
+def test_wizard_reprompts_for_an_expired_temporary_profile_secret(
+    tmp_path: Path,
+) -> None:
+    setup = _setup_records()
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    expired_reference = store.write("expired-secret")
+    store.delete(expired_reference)
+    with session_scope() as session:
+        session.get(CredentialProfile, setup.user_id).secret_ref = expired_reference
+        session.commit()
+    prompts = ScriptedPrompts(
+        [
+            str(setup.target_id),
+            str(setup.user_id),
+            "replacement-user-secret",
+            str(setup.admin_id),
+            "yes",
+        ]
+    )
+
+    request = CoverageSetupWizard(prompts=prompts, secret_store=store).run(setup.url)
+
+    assert request.user_profile_id == setup.user_id
+    assert prompts.hidden_values == ["replacement-user-secret"]
+    with session_scope() as session:
+        profile = session.get(CredentialProfile, setup.user_id)
+        assert profile.secret_ref != expired_reference
+        assert store.read(profile.secret_ref) == "replacement-user-secret"
+
+
+def test_wizard_rejects_a_selected_profile_with_invalid_login_config() -> None:
+    setup = _setup_records()
+    with session_scope() as session:
+        session.get(CredentialProfile, setup.user_id).login_config_path = "inline://broken"
+        session.commit()
+    prompts = ScriptedPrompts([str(setup.target_id), str(setup.user_id)])
+
+    with pytest.raises(InputValidationError, match="Inline login config"):
+        CoverageSetupWizard(prompts=prompts).run(setup.url)
+
+    assert prompts.hidden_values == []
 
 
 def test_wizard_creates_same_origin_target_and_missing_profiles_without_exposing_secrets(

--- a/tests/test_ephemeral_secret_store.py
+++ b/tests/test_ephemeral_secret_store.py
@@ -1,0 +1,101 @@
+import os
+import stat
+
+import pytest
+
+from app.core.errors import InputValidationError
+from app.services.ephemeral_secret_store import EphemeralSecretStore
+from app.services.secret_resolver import SecretResolver
+
+
+def test_ephemeral_secret_is_private_atomic_and_not_in_reference(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    secret = "coverage-user-secret"
+
+    ref = store.write(secret)
+    path = store.path_for(ref)
+
+    assert ref.startswith("ephemeral-file://")
+    assert secret not in ref
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert store.read(ref) == secret
+    assert not list(path.parent.glob("*.tmp"))
+
+
+def test_delete_is_idempotent(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("temporary")
+    path = store.path_for(ref)
+
+    store.delete(ref)
+    store.delete(ref)
+
+    assert not path.exists()
+
+
+def test_purge_expired_deletes_old_secret_and_returns_reference(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("expired")
+    path = store.path_for(ref)
+    os.utime(path, (0, 0))
+
+    deleted = store.purge_expired(max_age_seconds=900)
+
+    assert deleted == (ref,)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("ref", ["ephemeral-file:///etc/passwd", "env://SECRET"])
+def test_store_rejects_outside_or_wrong_scheme(tmp_path, ref) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+
+    with pytest.raises(InputValidationError):
+        store.read(ref)
+
+
+def test_store_rejects_symlink_even_when_target_is_inside_root(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    real_ref = store.write("hidden")
+    real_path = store.path_for(real_ref)
+    link = real_path.parent / "link.secret"
+    link.symlink_to(real_path)
+
+    with pytest.raises(InputValidationError):
+        store.read(f"ephemeral-file://{link}")
+
+
+def test_store_rejects_symlinked_parent_inside_root(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    real_ref = store.write("hidden")
+    real_path = store.path_for(real_ref)
+    alias = real_path.parent / "alias"
+    alias.symlink_to(real_path.parent, target_is_directory=True)
+
+    with pytest.raises(InputValidationError):
+        store.read(f"ephemeral-file://{alias / real_path.name}")
+
+
+def test_store_rejects_group_or_world_readable_secret(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("hidden")
+    store.path_for(ref).chmod(0o644)
+
+    with pytest.raises(InputValidationError):
+        store.read(ref)
+
+
+def test_store_rejects_group_or_world_accessible_root(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("hidden")
+    store.root.chmod(0o755)
+
+    with pytest.raises(InputValidationError):
+        store.read(ref)
+
+
+def test_secret_resolver_reads_ephemeral_reference(tmp_path) -> None:
+    store = EphemeralSecretStore(tmp_path / "secrets")
+    ref = store.write("hidden-value")
+
+    assert SecretResolver(ephemeral_store=store).resolve(ref) == "hidden-value"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -63,7 +63,7 @@ if [ "${1:-}" = "-m" ] && [ "${2:-}" = "pip" ]; then
 fi
 if [ "${1:-}" = "-m" ] && [ "${2:-}" = "app.cli.main" ]; then
   if [ "${3:-}" = "version" ] || [ "${3:-}" = "--version" ]; then
-    echo "Garden 0.2.0"
+    echo "Garden 0.3.0"
   fi
   exit 0
 fi
@@ -73,7 +73,7 @@ if [ "${1:-}" = "-I" ] && [ "$(basename "${2:-}")" = "launcher.py" ]; then
     exit 44
   fi
   if [ "${3:-}" = "version" ] || [ "${3:-}" = "--version" ]; then
-    echo "Garden 0.2.0"
+    echo "Garden 0.3.0"
   fi
   exit 0
 fi
@@ -174,9 +174,9 @@ def test_installed_launchers_survive_runtime_move(tmp_path):
     )
 
     assert garden.returncode == 0, garden.stderr
-    assert garden.stdout.strip() == "Garden 0.2.0"
+    assert garden.stdout.strip() == "Garden 0.3.0"
     assert gardenctl.returncode == 0, gardenctl.stderr
-    assert gardenctl.stdout.strip() == "Garden 0.2.0"
+    assert gardenctl.stdout.strip() == "Garden 0.3.0"
 
 
 def test_installer_discovers_usable_versioned_python_after_old_python3(tmp_path):
@@ -426,7 +426,7 @@ def test_installed_launcher_does_not_use_module_mode_from_repository_cwd(tmp_pat
     )
 
     assert launched.returncode == 0, launched.stderr
-    assert launched.stdout.strip() == "Garden 0.2.0"
+    assert launched.stdout.strip() == "Garden 0.3.0"
     launcher = (bin_dir / "garden").read_text(encoding="utf-8")
     assert "-m app.cli.main" not in launcher
     assert "launcher.py" in launcher

--- a/tests/test_inventory_gateway.py
+++ b/tests/test_inventory_gateway.py
@@ -11,6 +11,24 @@ class _FakePage:
         return self._hrefs
 
 
+class _FakeResponse:
+    def __init__(self, *, content_length: str | None, text: str = "body") -> None:
+        self.content_length = content_length
+        self.body = text
+        self.text_calls = 0
+
+    def header_value(self, name: str) -> str | None:
+        if name == "content-type":
+            return "application/json"
+        if name == "content-length":
+            return self.content_length
+        return None
+
+    def text(self) -> str:
+        self.text_calls += 1
+        return self.body
+
+
 def test_extract_links_skips_download_targets() -> None:
     gateway = SyncPlaywrightInventoryGateway()
     page = _FakePage(
@@ -39,3 +57,30 @@ def test_download_navigation_errors_are_classified() -> None:
     assert gateway._is_download_navigation_error(Exception("page.goto: download is starting"))
     assert gateway._is_download_navigation_error(Exception("Download is starting"))
     assert not gateway._is_download_navigation_error(Exception("Navigation timeout"))
+
+
+def test_response_text_is_not_loaded_when_declared_body_exceeds_limit() -> None:
+    gateway = SyncPlaywrightInventoryGateway()
+    response = _FakeResponse(content_length=str(256 * 1024 + 1))
+
+    assert gateway._extract_navigation_response_text(response) is None
+    assert gateway._extract_response_text(response, "application/json") is None
+    assert response.text_calls == 0
+
+
+def test_response_text_is_not_loaded_when_size_is_unknown() -> None:
+    gateway = SyncPlaywrightInventoryGateway()
+    response = _FakeResponse(content_length=None)
+
+    assert gateway._extract_navigation_response_text(response) is None
+    assert gateway._extract_response_text(response, "application/json") is None
+    assert response.text_calls == 0
+
+
+def test_response_text_is_loaded_when_declared_body_is_within_limit() -> None:
+    gateway = SyncPlaywrightInventoryGateway()
+    response = _FakeResponse(content_length="4", text="body")
+
+    assert gateway._extract_navigation_response_text(response) == "body"
+    assert gateway._extract_response_text(response, "application/json") == "body"
+    assert response.text_calls == 2

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -59,6 +59,10 @@ def test_upgrade_database_creates_current_schema(tmp_path):
         "scan_jobs",
         "inventory_runs",
     } <= tables
+    context_columns = {
+        column["name"] for column in inspect(create_engine(url)).get_columns("scan_contexts")
+    }
+    assert "temporary_secret_ref" in context_columns
 
 
 def test_stamp_existing_database_preserves_rows(tmp_path):

--- a/tests/test_playwright_contract.py
+++ b/tests/test_playwright_contract.py
@@ -1,3 +1,6 @@
+import pytest
+
+from app.core.errors import OverallScanTimeout, ScanInterrupted
 from app.db.bootstrap import session_scope
 from app.integrations.auth.playwright_adapter import PlaywrightLoginAdapter
 from app.models.enums import AuthType, LoginFailureReason, TargetStatus, TargetType
@@ -29,6 +32,17 @@ class FailingPlaywrightGateway:
 
     def validate(self, config, target, storage_state):
         raise TimeoutError("selector not found")
+
+
+class InterruptedPlaywrightGateway:
+    def __init__(self, error: RuntimeError) -> None:
+        self.error = error
+
+    def login(self, config, target, username, password, *, before_request=None):
+        raise self.error
+
+    def validate(self, config, target, storage_state, *, before_request=None):
+        raise self.error
 
 
 def test_playwright_adapter_contract_success() -> None:
@@ -116,3 +130,30 @@ def test_playwright_adapter_contract_failure() -> None:
     login_result = adapter.login(target, credential, "demo-admin-password", config)
     assert login_result.success is False
     assert login_result.failure_reason == LoginFailureReason.FORM_NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OverallScanTimeout("deadline"), ScanInterrupted("cancelled")],
+)
+def test_playwright_adapter_propagates_pipeline_control_flow(error) -> None:
+    adapter = PlaywrightLoginAdapter(gateway=InterruptedPlaywrightGateway(error))
+    config = PlaywrightLoginConfig.model_validate(
+        {
+            "adapter": "playwright",
+            "login_url": "/login",
+            "validate_url": "/me",
+            "auto_detect_selectors": True,
+        }
+    )
+    target = type("TargetStub", (), {"name": "target", "base_url": "https://app.test"})()
+    credential = type(
+        "CredentialStub",
+        (),
+        {"name": "user", "role": "user", "username": "user"},
+    )()
+
+    with pytest.raises(type(error)):
+        adapter.login(target, credential, "secret", config)
+    with pytest.raises(type(error)):
+        adapter.validate(target, credential, config, {"storage_state": {}})

--- a/tests/test_v030_quick_compatibility.py
+++ b/tests/test_v030_quick_compatibility.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from app.cli.main import app as cli_app
+from app.db.bootstrap import session_scope
+from app.models.scan_run import ScanRun
+from app.schemas.scan import ScanRunView
+from app.services.scan_reporting import ScanReportService
+
+
+def _quick_view(url: str) -> ScanRunView:
+    return ScanRunView(
+        id=31,
+        input_url=url,
+        normalized_url=url,
+        status="queued",
+        current_stage="queued",
+        progress=0,
+        retry_count=0,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_v030_keeps_quick_scan_command_contract() -> None:
+    result = CliRunner().invoke(cli_app, ["scan", "--help"])
+
+    assert result.exit_code == 0
+    for token in (
+        "ENTRY_URL",
+        "--url",
+        "--max-pages",
+        "--max-resources",
+        "--max-depth",
+        "--request-timeout",
+        "--overall-timeout",
+        "--retries",
+        "--detach",
+        "--ui-port",
+    ):
+        assert token in result.stdout
+    assert "--user-profile" not in result.stdout
+    assert "--admin-profile" not in result.stdout
+
+
+def test_v030_keeps_quick_http_and_homepage_contract(app) -> None:
+    class RecordingService:
+        def __init__(self) -> None:
+            self.started: tuple[str, object] | None = None
+
+        def start_scan(self, url, options):
+            self.started = (url, options)
+            return _quick_view(url)
+
+    service = RecordingService()
+    with TestClient(app) as client:
+        original_service = app.state.scan_service
+        app.state.scan_service = service
+        try:
+            response = client.post(
+                "/api/scans",
+                json={"url": "https://quick.test/", "options": {"max_pages": 7}},
+            )
+            homepage = client.get("/")
+        finally:
+            app.state.scan_service = original_service
+
+    assert response.status_code == 202
+    assert response.json()["mode"] == "quick"
+    assert service.started is not None
+    assert service.started[0] == "https://quick.test/"
+    assert service.started[1].max_pages == 7
+    assert '<form action="/scans" method="post"' in homepage.text
+    assert 'name="url"' in homepage.text
+
+
+def test_v030_keeps_quick_report_heading_order(tmp_path) -> None:
+    with session_scope() as session:
+        run = ScanRun(
+            mode="quick",
+            input_url="https://quick.test/",
+            normalized_url="https://quick.test/",
+            status="completed",
+            current_stage="finished",
+            progress=100,
+            options={},
+        )
+        session.add(run)
+        session.flush()
+        report_path = ScanReportService(output_root=tmp_path).generate(session, run.id)
+
+    text = open(report_path, encoding="utf-8").read()
+    headings = [
+        "## 执行摘要",
+        "## 扫描范围",
+        "## 发现的资产",
+        "## 关键属性",
+        "## 证据",
+        "## 已观察到的安全控制",
+        "## 风险或关注项",
+        "## 扫描覆盖范围",
+        "## 失败或未覆盖部分",
+        "## 覆盖告警",
+        "## 请求失败",
+        "## 生成时间",
+    ]
+
+    assert text.startswith(f"# Garden 资产报告 #{run.id}\n")
+    assert [text.index(heading) for heading in headings] == sorted(
+        text.index(heading) for heading in headings
+    )

--- a/tests/test_v030_quick_compatibility.py
+++ b/tests/test_v030_quick_compatibility.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+from click import unstyle
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
@@ -25,6 +26,7 @@ def _quick_view(url: str) -> ScanRunView:
 
 def test_v030_keeps_quick_scan_command_contract() -> None:
     result = CliRunner().invoke(cli_app, ["scan", "--help"])
+    help_text = unstyle(result.stdout)
 
     assert result.exit_code == 0
     for token in (
@@ -39,9 +41,9 @@ def test_v030_keeps_quick_scan_command_contract() -> None:
         "--detach",
         "--ui-port",
     ):
-        assert token in result.stdout
-    assert "--user-profile" not in result.stdout
-    assert "--admin-profile" not in result.stdout
+        assert token in help_text
+    assert "--user-profile" not in help_text
+    assert "--admin-profile" not in help_text
 
 
 def test_v030_keeps_quick_http_and_homepage_contract(app) -> None:

--- a/tests/test_v030_release.py
+++ b/tests/test_v030_release.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from app.cli.main import app
+from app.core.settings import Settings
+from app.schemas.scan import ScanOptions
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_v030_release_metadata_and_cli_version_are_aligned() -> None:
+    pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'version = "0.3.0"' in pyproject
+    assert Settings().project_version == "0.3.0"
+    result = CliRunner().invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "Garden 0.3.0"
+
+
+def test_v030_preserves_the_quick_scan_network_identity() -> None:
+    assert ScanOptions().user_agent == "Garden-Authorized-Asset-Scanner/0.2"
+
+
+def test_v030_documents_guided_and_automated_passive_coverage() -> None:
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    deployment = (PROJECT_ROOT / "docs" / "deployment.md").read_text(encoding="utf-8")
+
+    for text in (readme, deployment):
+        assert "garden coverage URL" in text
+        assert "--non-interactive" in text
+        assert "ephemeral-file://" in text
+        assert "主动权限重放未执行" in text
+        assert "覆盖差异不是已确认漏洞" in text


### PR DESCRIPTION
## 目标

发布 Garden v0.3.0 的三上下文被动认证覆盖能力，同时保持现有 `garden quick` 默认交互与输出兼容。

## 主要变更

- 新增 `garden coverage <URL>` 引导式流程，复用或创建 Target、user/admin 凭据档案。
- 密码等敏感输入保持隐藏；临时凭据按租约消费、失败清理与启动清扫，不进入报告或日志。
- 在 anonymous、user、admin 三个上下文中执行同入口、同预算、同超时的只读 GET 采集。
- 每次请求和重定向均执行同源与地址策略校验；跨源、超时与取消保持可解释状态。
- 新增三态覆盖矩阵：present / absent / unknown；失败或不完整上下文不会被误判为 absent。
- 报告包含上下文状态、覆盖差异和经过脱敏的证据；响应签名使用受限完整正文而非展示预览。
- 版本更新至 0.3.0，并补充部署与使用文档。

## 兼容性

- `garden quick` 的命令入口、默认 TUI 流程和既有报告语义保持不变。
- v0.2 数据库和 CLI 兼容测试继续通过。
- 本版本不执行主动权限重放、写入、利用或破坏性操作。

## 验证

- 全量测试：323 项通过。
- Ruff：`ruff check .` 通过。
- 格式：`ruff format --check .` 通过。
- 发布专项：安装脚本、构建 wheel 后迁移资源、v0.2 兼容、v0.3 quick 兼容、发布元数据和凭据向导共 36 项通过。
- 真实浏览器三上下文端到端测试通过。

## 审查提示

重点关注认证网络边界、临时凭据所有权、超时/取消传播，以及不完整上下文的 unknown 语义。