### PR TITLE
feat: 统一关注项分类数与原始观察数展示

### DIFF
--- a/app/api/routes/scans.py
+++ b/app/api/routes/scans.py
@@ -9,6 +9,7 @@ from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, Red
 from fastapi.templating import Jinja2Templates
 
 from app.schemas.scan import ScanOptions, ScanRunView, ScanStartRequest
+from app.services.scan_result_presentation import format_finding_count
 
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parents[2] / "templates"))
 router = APIRouter(tags=["scans"])
@@ -87,5 +88,12 @@ def scan_detail_page(request: Request, scan_run_id: int) -> HTMLResponse:
     return templates.TemplateResponse(
         request=request,
         name="scan_detail.html",
-        context={"scan": scan, "report": report, "page_title": f"Scan {scan.id}"},
+        context={
+            "scan": scan,
+            "report": report,
+            "page_title": f"Scan {scan.id}",
+            "finding_count_text": format_finding_count(
+                scan.finding_count, scan.finding_group_count
+            ),
+        },
     )

--- a/app/cli/scan.py
+++ b/app/cli/scan.py
@@ -16,6 +16,7 @@ from app.core.settings import get_settings
 from app.models.scan_run import TERMINAL_SCAN_RUN_STATUSES
 from app.schemas.scan import ScanFailureView, ScanOptions, ScanRunView
 from app.services.scan_failure_classification import is_coverage_warning
+from app.services.scan_result_presentation import format_finding_count
 
 
 def scan(
@@ -105,7 +106,7 @@ def _print_result(result: ScanRunView) -> None:
             ("阶段", result.current_stage),
             ("资产", str(result.asset_count)),
             ("证据", str(result.evidence_count)),
-            ("关注项", str(result.finding_count)),
+            ("关注项", format_finding_count(result.finding_count, result.finding_group_count)),
             ("报告", result.report_path or "未生成"),
         ],
         title="Garden 扫描结果",

--- a/app/schemas/scan.py
+++ b/app/schemas/scan.py
@@ -123,6 +123,7 @@ class ScanRunView(BaseModel):
     asset_count: int = 0
     evidence_count: int = 0
     finding_count: int = 0
+    finding_group_count: int | None = Field(default=None, ge=0)
 
 
 class FetchResult(BaseModel):

--- a/app/services/scan_application.py
+++ b/app/services/scan_application.py
@@ -38,6 +38,7 @@ from app.schemas.scan import (
 )
 from app.services.scan_network import HttpScanGateway, TargetNetworkPolicy
 from app.services.scan_pipeline import STAGES, ScanPipeline
+from app.services.scan_report_quality import project_finding_groups
 
 
 def create_assessment_stages(session: Session, run: ScanRun) -> None:
@@ -459,6 +460,7 @@ class ScanApplicationService:
             "asset_count": len(run.assets),
             "evidence_count": len(run.evidence),
             "finding_count": len(run.findings),
+            "finding_group_count": len(project_finding_groups(run.findings)),
         }
 
     def _resolve_options(self, options: ScanOptions) -> ScanOptions:

--- a/app/services/scan_reporting.py
+++ b/app/services/scan_reporting.py
@@ -17,6 +17,7 @@ from app.models.scan_run import ScanRun
 from app.services.coverage_identity import redacted_observed_url
 from app.services.scan_failure_classification import is_coverage_warning
 from app.services.scan_report_quality import project_finding_groups, report_version_values
+from app.services.scan_result_presentation import format_finding_count
 
 
 class ScanReportService:
@@ -286,7 +287,7 @@ class ScanReportService:
             f"- 入口 URL：{entry_url}",
             f"- 发现资产：{len(assets)}",
             f"- 证据记录：{len(evidence)}",
-            f"- 风险或关注项：{len(finding_groups)} 类（{len(findings)} 条原始观察）",
+            f"- 风险或关注项：{format_finding_count(len(findings), len(finding_groups))}",
             f"- 覆盖告警：{len(coverage_warnings)}",
             f"- 请求或阶段失败：{len(request_failures)}",
             "",

--- a/app/services/scan_result_presentation.py
+++ b/app/services/scan_result_presentation.py
@@ -1,0 +1,7 @@
+"""Side-effect-free result wording shared by terminal, Web, and reports."""
+
+
+def format_finding_count(raw_count: int, group_count: int | None) -> str:
+    if group_count is None:
+        return f"{raw_count} 条原始观察（分类数未提供）"
+    return f"{group_count} 类（{raw_count} 条原始观察）"

--- a/app/templates/scan_detail.html
+++ b/app/templates/scan_detail.html
@@ -21,7 +21,7 @@
       <dl class="mt-5 grid gap-4 sm:grid-cols-3">
         <div><dt>Assets</dt><dd>{{ scan.asset_count }}</dd></div>
         <div><dt>Evidence</dt><dd>{{ scan.evidence_count }}</dd></div>
-        <div><dt>Findings</dt><dd>{{ scan.finding_count }}</dd></div>
+        <div><dt>Findings</dt><dd>{{ finding_count_text }}</dd></div>
       </dl>
     </div>
     <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/tests/test_formal_scan_cli.py
+++ b/tests/test_formal_scan_cli.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
+import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 import app.cli.scan as scan_cli
@@ -12,6 +15,40 @@ from app.cli.main import app
 from app.schemas.scan import ScanRunView
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def run_terminal_scan(monkeypatch):
+    runtime = SimpleNamespace(base_url="http://127.0.0.1:8000")
+    manager = SimpleNamespace(ensure=lambda **kwargs: runtime)
+    monkeypatch.setattr(scan_cli, "WebRuntimeManager", lambda **kwargs: manager)
+
+    def invoke(view):
+        api = SimpleNamespace(start_scan=lambda url, options: view)
+        monkeypatch.setattr(scan_cli, "LocalScanApi", lambda base_url: api)
+        return runner.invoke(app, ["scan", "http://127.0.0.1:3000/"])
+
+    return invoke
+
+
+@pytest.mark.parametrize(
+    ("raw", "groups", "text"),
+    [
+        (104, 2, "2 类（104 条原始观察）"),
+        (0, 0, "0 类（0 条原始观察）"),
+        (104, None, "104 条原始观察（分类数未提供）"),
+    ],
+)
+def test_terminal_scan_shows_grouped_count(run_terminal_scan, raw, groups, text):
+    payload = _view(status="completed", stage="finished", progress=100).model_dump()
+    payload["finding_count"] = raw
+    if groups is None:
+        payload.pop("finding_group_count")
+    else:
+        payload["finding_group_count"] = groups
+    result = run_terminal_scan(ScanRunView.model_validate(payload))
+    assert result.exit_code == 0
+    assert text in unstyle(result.stdout)
 
 
 def _view(*, status="queued", stage="queued", progress=0):

--- a/tests/test_scan_result_presentation.py
+++ b/tests/test_scan_result_presentation.py
@@ -1,0 +1,13 @@
+from app.services.scan_result_presentation import format_finding_count
+
+
+def test_finding_count_text():
+    assert format_finding_count(104, 2) == "2 类（104 条原始观察）"
+
+
+def test_empty_finding_count():
+    assert format_finding_count(0, 0) == "0 类（0 条原始观察）"
+
+
+def test_legacy_finding_count():
+    assert format_finding_count(104, None) == "104 条原始观察（分类数未提供）"

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -748,6 +748,7 @@ def test_api_group_count_keeps_different_remediation_separate(tmp_path) -> None:
                     remediation=remediation,
                     asset_ids=[],
                     evidence_ids=[],
+                    created_at=scan.created_at,
                 )
             )
     saved = service.get_scan(scan.id)

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -670,6 +670,9 @@ def test_njau_style_report_keeps_104_raw_findings_and_trusted_versions(tmp_path,
     with TestClient(app) as client:
         app.state.scan_service = service
         response = client.get(f"/api/scans/{scan.id}")
+        detail = client.get(f"/scans/{scan.id}")
+    assert detail.status_code == 200
+    assert "<dd>2 类（104 条原始观察）</dd>" in detail.text
     assert response.status_code == 200
     assert response.json()["finding_count"] == 104
     assert response.json()["finding_group_count"] == 2

--- a/tests/test_url_scan_pipeline.py
+++ b/tests/test_url_scan_pipeline.py
@@ -12,8 +12,8 @@ import app.main as main_app
 from app.core.errors import InputValidationError, TargetPolicyError
 from app.core.settings import get_settings
 from app.db.bootstrap import session_scope
-from app.models.scan_run import ScanAsset, ScanEvidence, ScanRun
-from app.schemas.scan import ScanOptions
+from app.models.scan_run import ScanAsset, ScanEvidence, ScanFinding, ScanRun
+from app.schemas.scan import ScanOptions, ScanRunView
 from app.services.scan_application import InlineScanDispatcher, ScanApplicationService
 from app.services.scan_failure_classification import is_coverage_warning
 from app.services.scan_network import MAX_RESPONSE_BYTES, HttpScanGateway, TargetNetworkPolicy
@@ -609,7 +609,7 @@ def test_version_hints_require_context_and_include_version_query(tmp_path) -> No
     ]
 
 
-def test_njau_style_report_keeps_104_raw_findings_and_trusted_versions(tmp_path) -> None:
+def test_njau_style_report_keeps_104_raw_findings_and_trusted_versions(tmp_path, app) -> None:
     # 根页面加前 51 个子页面会形成 52 个已采集 HTML 资产；最后一个候选留在预算外。
     page_links = "".join(f'<a href="/page-{index}">Page</a>' for index in range(52))
 
@@ -662,6 +662,23 @@ def test_njau_style_report_keeps_104_raw_findings_and_trusted_versions(tmp_path)
     report = service.read_report(scan.id)
 
     assert scan.finding_count == 104
+    assert scan.finding_group_count == 2
+    saved = service.get_scan(scan.id)
+    assert saved.finding_count == 104
+    assert saved.finding_group_count == 2
+    assert (saved.asset_count, saved.evidence_count) == (55, 55)
+    with TestClient(app) as client:
+        app.state.scan_service = service
+        response = client.get(f"/api/scans/{scan.id}")
+    assert response.status_code == 200
+    assert response.json()["finding_count"] == 104
+    assert response.json()["finding_group_count"] == 2
+    assert response.json()["evidence_count"] == 55
+    legacy_payload = response.json()
+    legacy_payload.pop("finding_group_count")
+    legacy = ScanRunView.model_validate(legacy_payload)
+    assert legacy.finding_count == 104
+    assert legacy.finding_group_count is None
     assert scan.status == "completed_with_warnings"
     assert "2 类（104 条原始观察）" in report
     assert "- 覆盖告警：1" in report
@@ -691,6 +708,50 @@ def test_njau_style_report_keeps_104_raw_findings_and_trusted_versions(tmp_path)
     request_failures = report.split("## 请求失败", 1)[1]
     assert "coverage_limit_reached" in coverage
     assert "coverage_limit_reached" not in request_failures
+
+
+def test_scan_with_no_findings_returns_zero_groups(tmp_path) -> None:
+    service = _service(
+        tmp_path,
+        lambda request: httpx.Response(
+            200,
+            headers={
+                "content-type": "text/html",
+                "content-security-policy": "default-src 'self'",
+                "x-content-type-options": "nosniff",
+            },
+            text="<html>Healthy</html>",
+        ),
+    )
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions())
+    assert (scan.finding_count, scan.finding_group_count) == (0, 0)
+    saved = service.get_scan(scan.id)
+    assert (saved.finding_count, saved.finding_group_count) == (0, 0)
+
+
+def test_api_group_count_keeps_different_remediation_separate(tmp_path) -> None:
+    service = _service(
+        tmp_path, lambda request: httpx.Response(200, headers={"content-type": "text/plain"})
+    )
+    scan = service.start_scan("http://127.0.0.1/", ScanOptions())
+    with session_scope() as session:
+        for index, remediation in enumerate(("应用层配置", "边缘层配置")):
+            session.add(
+                ScanFinding(
+                    scan_run_id=scan.id,
+                    dedup_key=f"fixture-{index}",
+                    title="缺少安全头",
+                    category="security-headers",
+                    severity="low",
+                    confidence="high",
+                    summary="未观察到安全头。",
+                    remediation=remediation,
+                    asset_ids=[],
+                    evidence_ids=[],
+                )
+            )
+    saved = service.get_scan(scan.id)
+    assert (saved.finding_count, saved.finding_group_count) == (2, 2)
 
 
 def test_regenerated_legacy_report_omits_unverifiable_body_versions(tmp_path) -> None:

--- a/tests/test_v020_compatibility.py
+++ b/tests/test_v020_compatibility.py
@@ -42,7 +42,7 @@ def test_cli_scan_flags_and_defaults_are_unchanged() -> None:
     }
 
 
-def test_scan_api_schema_fields_are_unchanged() -> None:
+def test_scan_api_schema_preserves_old_fields_and_adds_optional_group_count() -> None:
     assert set(ScanStartRequest.model_fields) == {"url", "options"}
     assert set(ScanRunView.model_fields) == {
         "id",
@@ -68,7 +68,10 @@ def test_scan_api_schema_fields_are_unchanged() -> None:
         "asset_count",
         "evidence_count",
         "finding_count",
+        "finding_group_count",
     }
+    assert not ScanRunView.model_fields["finding_group_count"].is_required()
+    assert ScanRunView.model_fields["finding_group_count"].default is None
 
 
 def test_scan_status_semantics_are_unchanged() -> None:


### PR DESCRIPTION
## 内容

- API 新增可选 finding_group_count，finding_count 仍为原始记录数。
- CLI、Web 详情及新报告统一显示「2 类（104 条原始观察）」；旧响应缺字段时明确显示分类数未提供。
- 复用现有六字段分组，保留全部原始发现及证据。
- 默认 quick/scan 的启动交互、参数、进度、退出语义不变；仅最终计数文案改变。

## 依赖与合并顺序

依赖 #20，当前基线为 feat/v0-3-passive-auth-coverage。请先合并 #20，再将本 PR 改为面向 main 并运行 CI；本次不自动合并。后续诊断建议另一个 PR 依赖本 PR。

## TDD 与验证

- 服务104/2、CLI/Web、旧响应退化文案均观察到红灯后转绿；不同 remediation 分组和0/0回归通过。
- 本分支计数/兼容/CLI/API/流水线定向58项通过；Ruff lint、format和diff检查通过。
- 包含后续诊断的整合版本全量350项通过（2条已有websockets弃用警告），涵盖打包、迁移及本地浏览器E2E。
- 独立审阅无发现；兼容字段契约补丁另行复核通过。
- 仓库 CI 当前只对 base=main 的 PR 触发；本依赖分支未产生远端CI时，不代表CI已通过。

未改动版本、依赖、数据库、原始安全判断或目标网络行为。
